### PR TITLE
call next middleware in express server

### DIFF
--- a/mobile-browser-based-version/server/run_server.js
+++ b/mobile-browser-based-version/server/run_server.js
@@ -49,6 +49,8 @@ function eventsHandler(request, response, next) {
       console.log(`${peerId} Connection closed`);
       peers = peers.filter(peer => peer.id !== peerId);
     });
+    // call next middleware
+    next()
   }
 
   function sendNewNeighbours(affectedPeers) {


### PR DESCRIPTION
Found a bug in `run_server.js`: the function `eventsHandler` should call the next middleware via `next()` at the end of its code.