### PR TITLE
add DEV_TOOLS option in env.dev

### DIFF
--- a/mobile-browser-based-version/.env.development
+++ b/mobile-browser-based-version/.env.development
@@ -1,2 +1,3 @@
 VUE_APP_DEAI_SERVER=http://localhost:8080/deai/
 VUE_APP_FEAI_SERVER=http://localhost:8080/feai/
+DEV_TOOLS=disabled

--- a/mobile-browser-based-version/src/main.js
+++ b/mobile-browser-based-version/src/main.js
@@ -1,4 +1,4 @@
-import devtools from '@vue/devtools'
+import devtools from '@vue/devtools';
 import { createApp } from 'vue';
 import App from './components/App.vue';
 import router from './router';
@@ -9,8 +9,11 @@ import { store } from './store/store';
 import { createCustomI18n } from './platforms/i18n.js';
 import VueApexCharts from 'vue3-apexcharts';
 
-if (process.env.NODE_ENV === 'development') {
-    devtools.connect('http://localhost', 8081);
+if (
+  process.env.NODE_ENV === 'development' &&
+  process.env.DEV_TOOLS === 'enabled'
+) {
+  devtools.connect('http://localhost', 8081);
 }
 // create vue app
 const app = createApp(App);


### PR DESCRIPTION
By changing the line 
```
DEV_TOOLS=disabled
```
in the `.env.development` file, you can enable the Vue dev tools.

This PR aims at removing the `404` error in the console due to the dev tools that were loaded by default previously.