### PR TITLE
added contribution readme and refactored readme into smaller files

### DIFF
--- a/mobile-browser-based-version/README.md
+++ b/mobile-browser-based-version/README.md
@@ -2,9 +2,9 @@
 
 Welcome to the disco developer guide, the guide is broken down into small chapters. To get up and running you can find the information here as well as in the [SERVER](server/README.md) chapter.
 
-If you run into any sort of trouble then hopefully you can find an answer in our [FAQ](information/FAQ.md). Otherwise please create a new issue.
+If you run into any sort of trouble then hopefully you can find an answer in our [FAQ](information/FAQ.md); otherwise please create a new issue.
 
-To learn how about the contribution process or our architecture you can go to the respective chapters.
+To learn more about the development (contributing) process or our architecture you can go to the respective chapters.
 
 #### Chapters
 

--- a/mobile-browser-based-version/README.md
+++ b/mobile-browser-based-version/README.md
@@ -22,13 +22,13 @@ All commands are ran from the folder ./mobile-browser-based-version.
 
 ### Development Environment
 
-We recommand the [VS code](https://code.visualstudio.com/) IDE with the following extensions :
+We recommend the [VS code](https://code.visualstudio.com/) IDE with the following extensions :
 
 1. Vue.js Extension Pack
 2. Git Extension Pack
 3. JavaScript (ES6) code snippets
 
-To benenfit from all offered functionalities, open `VS code` using
+To benefit from all offered functionalities, open `VS code` using
 
 ```
 code .
@@ -53,7 +53,7 @@ npm install
 This command will install the necessary libraries required to run the application (defined in the `package.json` and `package-lock.json`). The latter command is only required when one is using the app for the first time.
 
 > **⚠ WARNING: Apple Silicon.**  
-> `TensorFlow.js` in version `3.13.0` currently suportes for M1 mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
+> `TensorFlow.js` in version `3.13.0` currently supports for M1 mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
 
 ```
 node -p "process.arch"
@@ -77,7 +77,7 @@ This will start the application locally with two visualization options:
 > **⚠ WARNING: Connection issues**  
 > If federated learning works, but not decentralised learning, then it might be that webRTC is not enabled, this is needed for peer2peer communication.
 
-To **Manually test decentralized learning** between two peers, run the aformentioned command twice (on different terminal pages). This will create another link that can be used to represent a second user. Open the two links on two different page windows.
+To **Manually test decentralized learning** between two peers, run the aforementioned command twice (on different terminal pages). This will create another link that can be used to represent a second user. Open the two links on two different page windows.
 
 To choose between **decentralized** and **federated** learning go to the settings found in menu.
 

--- a/mobile-browser-based-version/README.md
+++ b/mobile-browser-based-version/README.md
@@ -1,24 +1,20 @@
 # Disco - Developer Guide
 
-## Code Organisation
+Welcome to the disco developer guide, the guide is broken down into small chapters. To get up and running you can find the information here as well as in the [SERVER](server/README.md) chapter.
 
-    .
-    ├── assets       # contains the resources of the app
-    │ ├── css        # css files
-    │ ├── svg        # svg image / icons
-    ├── components   # vue file folder
-    │ ├── XXX.vue    # vue example file
-    ├── helpers      # typescript helpers folder
-    │ ├── XXX.ts     # js example file
-    ├── platforms    # i18n related folder
-    │ ├── ...
-    ├── router       # vue-router related folder
-    │ ├── index.ts
-    ├── store        # vuex related folder
-    │ ├── store.ts
-    ├── main.ts      # root file of the app
-    ├── .env.XXX     # environment specific variables
-    └── ...          # rest of the files
+If you run into any sort of trouble then hopefully you can find an answer in our [FAQ](information/FAQ.md). Otherwise please create a new issue.
+
+To learn how about the contribution process or our architecture you can go to the respective chapters.
+
+#### Chapters
+
+- README _(you are here)_
+- [SERVER](server/README.md)
+- [FAQ](information/FAQ.md)
+- [CONTRIBUTING](information/CONTRIBUTING.md)
+- [ARCHITECTURE](information/ARCHITECTURE.md)
+
+## Headers
 
 ## How to run the app
 
@@ -123,151 +119,3 @@ For creating a customized task from scratch, please follow the following steps:
 4. Change the information in the javascript file to suit the requirements of the created task. There are three main objects to change. The first one is called display_informations. It contains all the textual task-related information. The second one is called training_information and holds all the information about the model (i.e model's name, architecture ...). The third one is the data_preprocessing function. This function takes the user's uploaded files and returns the processed data as a tensor.
 5. In each vue file, look for the script part of the code (after <script>) and replace the first import with the javascript associated with your task. For instance, replace import {...} from "titanic_script" with import {...} from "[your_task_name]\_script".
 6. Add your task to the vue routing file in ./src/router/index.js. More instructions soon to come.
-
-## Explanation of the current architecture of the app
-
-### Overview of the architecture
-
-Tasks are organized around the following files:
-
-- vue files are used to render the task-related user interface. Users should not modify the core code of these files.
-- a typescript file contains all the task-related information and methods. For instance, in this file, one can find the specific data-processing function or the textual description of the task.
-
-### Use of TypeScript (a dialect of JavaScript)
-
-In order to facilitate development with javascript (js) we use [typescript](https://www.typescriptlang.org/) (ts); this adds an additional layer on top of javascript that allows for a deeper integration with your editor which enables you to catch errors faster.
-
-If you know js then you basically already know ts, since js is a subset of ts, anything you can do on js, you can also do on ts. What's new is that ts has a stricter policy (these can be silenced, and so we can indeed run ts files as if they were js), here are some examples:
-
-#### Function overloading
-
-This would run perfectly on js
-
-```js
-function addNumbers(a, b) {
-  return a + b;
-}
-var sum = addNumbers(15, 25, 30);
-```
-
-However in ts we get the following compile error: `Expected 2 arguments, but got 3. `.
-
-#### Equality checks
-
-```js
-const isEqual = 20 == "20";
-console.log(isEqual);
-```
-
-In js these two are equal since it tries to cast types and see if they are equal, while convenient in a small project, this can lead to hard to find bugs in larger ones. In ts this would yield the following compile error:
-
-```
-This condition will always return 'false' since the types 'number' and 'string' have no overlap.
-```
-
-#### Type annotations
-
-Typescript allows us to annotate the input and output of functions, this greatly simplifies using functions where types might be ambiguous, the previous function we saw could be annotate as follows in ts:
-
-```ts
-function addNumbers(a: number, b: number): number {
-  return a + b;
-}
-var sum = addNumbers(15, 25);
-```
-
-Since we know the output type is of type number, we can safely call `sum.toPrecision(2)`, if we wanted to get the sum with 2 significant digits. If sum was not of type number (that dit not have a function called toPrecision or was of type any), then we would get a compile error: `TypeError: k.toPrecision is not a function` .
-
-This brings us to our next comment, if we cast sum as type any, then we would get no compiler error:
-
-```ts
-var sum = "hello DeAI" as any;
-sum.toPrecision(2);
-```
-
-any is a special ts type that you can use when you don't want type checking errors, this is however not desirable since this would defeat the whole purpose of using ts in the first place.
-
-Note that all these compile errors will also appear in your editor, this will allow you to easily find these bugs without having to first compile!
-
-In vue files you simply need to add ts in the script tag to enable ts:
-
-```vue
-<script lang="ts"></script>
-```
-
-There are of course more details, but if you know js, now you should be ready for ts! If you want to learn more this [official (5min) guide](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html) is an excellent place to start.
-
-#### Our policy
-
-We follow the standard ts policy (which is by default flexible and not very strict) since the original code base was in js; as a consequence some files might not yet be annotated.
-
-If you are on boarding, we strongly recommend that you annotate your functions and classes! However this is not strictly enforced, your code will run if you don't annotate it. Perhaps for a quick mock up of your code you may opt not to annotate, however when you are ready to pull request to develop we expect your functions and classes to be annotated.
-
-In a nutshell the following will give compile errors:
-
-- Equality checks on objects that are not of the same type.
-- Overloading a function.
-- If a variable is annotated or type inferred, using a non existing type function on it.
-
-### Use of Vue.js
-
-The main front-end framework used by the application is Vue.js, a widely used framework to build single-page UI (See [Reference](https://router.vuejs.org/guide/)).  
-The application is built around Vue.js components. Essentially, components are defined around two parts:
-
-1. An HTML template that states how the component should be rendered
-2. A script that defines the behaviors of the components
-
-### Component architecture of the project
-
-Components can be organized in a parent/child relation. Meaning that one can have a parent component that holds many other child components.  
-`routers` are used to define which components are displayed to the user depending on the user's inputs.
-
-The application runs the following architecture:
-
-- **The global component** of the app is called `App.vue`. This component implements a mini-side bar that is always displayed to the user. This mini-sidebar allows the user to directly access the available list of tasks available, and change some parameters of the page (color and night mode).
-- **Information Display Components** are components that are displayed on the right side of the mini-side bar. Depending on the user's path choice, a component is displayed. The following components can be displayed:
-  - **The task list component** is called `TaskList.vue`. It's the default component used to fill this space. It shows which ML tasks are open for collaborative training.
-  - **Task-related Components** are components used to display the interface associated with a particular task. The UI components for an ML task come in a parent-child relation: one global component (called `[taskName]_model.vue`) is used to implement a sidebar that allows the user to navigate through the different components associated with a task. On the right side of this global component, the following components are used to create a task (and note that all of them need to be created for each task):
-    - **Description of the task** under the name `[taskName]\_description.vue. It gives an overview of the task.
-    - **Training of the task** under the name `[taskName]_training.vue`. Allows the users to train a model, either collaboratively using p2p communication, or alone by local training. As a side note, components are created only when they are called by the user. Meaning that until the user reaches the training page of the task, the `[taskName]_training.vue`is not created. When a user reaches for the first time the training components, the component is created, and only then the NN model is created and stored in the browser's indexdb database. The training is done in a seperated script. To start training, the function named `join_training`is called. This function preprocess the data using the task specific data pre-processing function and then train the model using the shared `train`function.
-
-All these are served by the typescript file associated to the task.
-
-### Training Loop
-
-A shared function `training` is called by all components that are training a model. This function is located in the file ./helpers/training.js.  
-The idea is that the training part for all tasks relies on the same ML backend, while the pre-processing of the training data is done in a custom version (at the component level) by each task.  
-The training process works as follows:
-
-1. When a user has stated that he wishes to join the training of a task, a TF.js model is initialized (for now with a standard initialization) and stored into the browser's local storage. (call to `create_model`, a function embedded into the task's training component)
-2. Once the user connects their dataset, a pre-processing function is called. The pre-processing function is specifically tailored for each task and so is embedded in the task's training component under the name `data_preprocessing`. This can be either one-off preprocessing of the entire dataset, or a batch-wise pre-processing function which will then be repeatedly called during training, for each new minibatch of training data.
-3. The `training` function function loads the model from the browser's local storage and updates the model by training it on the given dataset (and communicating with peers or a federated learning server). As mentioned earlier, the training function is shared by all training components.
-
-## Communication between peers
-
-Explanations on communication between peers will be added soon.
-
-The decentralized training version relies on p2p communication via [peer2js](https://peerjs.com/). The federated trainind does not need `peer2js` but direclty communicates with the server.
-
-## Some further integrations notes
-
-### Using on mobile devices
-
-Depending on the user's screen width, the left hand sidebar associated to task's components can disapear and be opened using the button located on the top left corner of the user's screen.
-For now a template that shows how to create tasks can be found.
-
-### Main packages used
-
-| Name                                                  |     Keyword     | Description                                                               |
-| ----------------------------------------------------- | :-------------: | :------------------------------------------------------------------------ |
-| [vuex](https://vuex.vuejs.org/)                       |     `Store`     | It serves as a centralized store for all the components in an application |
-| [vee-validate](https://vee-validate.logaretm.com/v4/) |     `Form`      | Form Validation for Vue.js                                                |
-| [vue-toaster](https://github.com/MeForma/vue-toaster) | `Notifications` | Toast notification plugin for Vue.js                                      |
-| [tippy](https://atomiks.github.io/tippyjs/)           |     `Menu`      | Pluging to build menu / side bars                                         |
-| [vue-i18n](https://vue-i18n.intlify.dev/)             | `Internation.`  | Internationalization plugin for Vue.js                                    |
-| [vue-router](https://router.vuejs.org/)               |    `Routing`    | Official router plugin for Vue.js                                         |
-| [tfjs](https://www.tensorflow.org/js)                 |  `ML backend`   | Library for machine learning in JavaScript                                |
-| [axios](https://axios-http.com/)                      | `HTTP requests` | Axios is a promise-based HTTP Client for node.js and the browser.         |
-| [lodash](https://lodash.com/)                         |  `JS Helpers`   | Functional library for higher order function on list and js objects       |
-| [yup](https://github.com/jquense/yup)                 |     `Form`      | Schema builder for runtime value parsing and validation (forms).          |
-| [peerjs](https://peerjs.com/)                         | `Communication` | P2P communication libary for DeAI                                         |

--- a/mobile-browser-based-version/README.md
+++ b/mobile-browser-based-version/README.md
@@ -1,6 +1,6 @@
 # Disco - Developer Guide
 
-Welcome to the disco developer guide, the guide is broken down into small chapters. To get up and running you can find the information here as well as in the [SERVER](server/README.md) chapter.
+Welcome to the Disco developer guide, the guide is broken down into small chapters. To get up and running you can find the information here as well as in the [SERVER](server/README.md) chapter.
 
 If you run into any sort of trouble then hopefully you can find an answer in our [FAQ](information/FAQ.md); otherwise please create a new issue.
 

--- a/mobile-browser-based-version/README.md
+++ b/mobile-browser-based-version/README.md
@@ -9,10 +9,10 @@ To learn more about the development (contributing) process or our architecture y
 #### Chapters
 
 - README _(you are here)_
-- [SERVER](server/README.md)
 - [FAQ](information/FAQ.md)
 - [CONTRIBUTING](information/CONTRIBUTING.md)
 - [ARCHITECTURE](information/ARCHITECTURE.md)
+- [SERVER](server/README.md)
 
 ## Headers
 

--- a/mobile-browser-based-version/information/ARCHITECTURE.md
+++ b/mobile-browser-based-version/information/ARCHITECTURE.md
@@ -8,10 +8,8 @@
     │ ├── svg        # svg image / icons
     ├── components   # vue file folder
     │ ├── XXX.vue    # vue example file
-    ├── helpers      # typescript helpers folder
-    │ ├── XXX.ts     # js example file
-    ├── platforms    # i18n related folder
-    │ ├── ...
+    ├── core         # core code of the client (training, communication, ...)
+    │ ├── XXX.ts     # ts example file
     ├── router       # vue-router related folder
     │ ├── index.ts
     ├── store        # vuex related folder

--- a/mobile-browser-based-version/information/ARCHITECTURE.md
+++ b/mobile-browser-based-version/information/ARCHITECTURE.md
@@ -22,7 +22,7 @@
 
 ### Use of TypeScript (a dialect of JavaScript)
 
-In order to facilitate development with javascript (js) we use [typescript](https://www.typescriptlang.org/) (ts); this adds an additional layer on top of javascript that allows for a deeper integration with your editor which enables you to catch errors faster.
+In order to facilitate development with JavaScript (js) we use [TypeScript](https://www.typescriptlang.org/) (ts); this adds an additional layer on top of JavaScript that allows for a deeper integration with your editor which enables you to catch errors faster.
 
 If you know js then you basically already know ts, since js is a subset of ts, anything you can do on js, you can also do on ts. What's new is that ts has a stricter policy (these can be silenced, and so we can indeed run ts files as if they were js), here are some examples:
 
@@ -54,7 +54,7 @@ This condition will always return 'false' since the types 'number' and 'string' 
 
 #### Type annotations
 
-Typescript allows us to annotate the input and output of functions, this greatly simplifies using functions where types might be ambiguous, the previous function we saw could be annotate as follows in ts:
+TypeScript allows us to annotate the input and output of functions, this greatly simplifies using functions where types might be ambiguous, the previous function we saw could be annotate as follows in ts:
 
 ```ts
 function addNumbers(a: number, b: number): number {
@@ -118,7 +118,7 @@ The application runs the following architecture:
     - **Description of the task** under the name `[taskName]\_description.vue. It gives an overview of the task.
     - **Training of the task** under the name `[taskName]_training.vue`. Allows the users to train a model, either collaboratively using p2p communication, or alone by local training. As a side note, components are created only when they are called by the user. Meaning that until the user reaches the training page of the task, the `[taskName]_training.vue`is not created. When a user reaches for the first time the training components, the component is created, and only then the NN model is created and stored in the browser's indexdb database. The training is done in a separated script. To start training, the function named `join_training`is called. This function preprocess the data using the task specific data pre-processing function and then train the model using the shared `train`function.
 
-All these are served by the typescript file associated to the task.
+All these are served by the TypeScript file associated to the task.
 
 ### Training Loop
 

--- a/mobile-browser-based-version/information/ARCHITECTURE.md
+++ b/mobile-browser-based-version/information/ARCHITECTURE.md
@@ -1,0 +1,160 @@
+# Disco - Architecture
+
+## Code Organisation
+
+    .
+    ├── assets       # contains the resources of the app
+    │ ├── css        # css files
+    │ ├── svg        # svg image / icons
+    ├── components   # vue file folder
+    │ ├── XXX.vue    # vue example file
+    ├── helpers      # typescript helpers folder
+    │ ├── XXX.ts     # js example file
+    ├── platforms    # i18n related folder
+    │ ├── ...
+    ├── router       # vue-router related folder
+    │ ├── index.ts
+    ├── store        # vuex related folder
+    │ ├── store.ts
+    ├── main.ts      # root file of the app
+    ├── .env.XXX     # environment specific variables
+    └── ...          # rest of the files
+
+### Use of TypeScript (a dialect of JavaScript)
+
+In order to facilitate development with javascript (js) we use [typescript](https://www.typescriptlang.org/) (ts); this adds an additional layer on top of javascript that allows for a deeper integration with your editor which enables you to catch errors faster.
+
+If you know js then you basically already know ts, since js is a subset of ts, anything you can do on js, you can also do on ts. What's new is that ts has a stricter policy (these can be silenced, and so we can indeed run ts files as if they were js), here are some examples:
+
+#### Function overloading
+
+This would run perfectly on js
+
+```js
+function addNumbers(a, b) {
+  return a + b;
+}
+var sum = addNumbers(15, 25, 30);
+```
+
+However in ts we get the following compile error: `Expected 2 arguments, but got 3. `.
+
+#### Equality checks
+
+```js
+const isEqual = 20 == "20";
+console.log(isEqual);
+```
+
+In js these two are equal since it tries to cast types and see if they are equal, while convenient in a small project, this can lead to hard to find bugs in larger ones. In ts this would yield the following compile error:
+
+```
+This condition will always return 'false' since the types 'number' and 'string' have no overlap.
+```
+
+#### Type annotations
+
+Typescript allows us to annotate the input and output of functions, this greatly simplifies using functions where types might be ambiguous, the previous function we saw could be annotate as follows in ts:
+
+```ts
+function addNumbers(a: number, b: number): number {
+  return a + b;
+}
+var sum = addNumbers(15, 25);
+```
+
+Since we know the output type is of type number, we can safely call `sum.toPrecision(2)`, if we wanted to get the sum with 2 significant digits. If sum was not of type number (that dit not have a function called toPrecision or was of type any), then we would get a compile error: `TypeError: k.toPrecision is not a function` .
+
+This brings us to our next comment, if we cast sum as type any, then we would get no compiler error:
+
+```ts
+var sum = "hello DeAI" as any;
+sum.toPrecision(2);
+```
+
+any is a special ts type that you can use when you don't want type checking errors, this is however not desirable since this would defeat the whole purpose of using ts in the first place.
+
+Note that all these compile errors will also appear in your editor, this will allow you to easily find these bugs without having to first compile!
+
+In vue files you simply need to add ts in the script tag to enable ts:
+
+```vue
+<script lang="ts"></script>
+```
+
+There are of course more details, but if you know js, now you should be ready for ts! If you want to learn more this [official (5min) guide](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html) is an excellent place to start.
+
+#### Our policy
+
+We follow the standard ts policy (which is by default flexible and not very strict) since the original code base was in js; as a consequence some files might not yet be annotated.
+
+If you are on boarding, we strongly recommend that you annotate your functions and classes! However this is not strictly enforced, your code will run if you don't annotate it. Perhaps for a quick mock up of your code you may opt not to annotate, however when you are ready to pull request to develop we expect your functions and classes to be annotated.
+
+In a nutshell the following will give compile errors:
+
+- Equality checks on objects that are not of the same type.
+- Overloading a function.
+- If a variable is annotated or type inferred, using a non existing type function on it.
+
+### Use of Vue.js
+
+The main front-end framework used by the application is Vue.js, a widely used framework to build single-page UI (See [Reference](https://router.vuejs.org/guide/)).  
+The application is built around Vue.js components. Essentially, components are defined around two parts:
+
+1. An HTML template that states how the component should be rendered
+2. A script that defines the behaviors of the components
+
+### Component architecture of the project
+
+Components can be organized in a parent/child relation. Meaning that one can have a parent component that holds many other child components.  
+`routers` are used to define which components are displayed to the user depending on the user's inputs.
+
+The application runs the following architecture:
+
+- **The global component** of the app is called `App.vue`. This component implements a mini-side bar that is always displayed to the user. This mini-sidebar allows the user to directly access the available list of tasks available, and change some parameters of the page (color and night mode).
+- **Information Display Components** are components that are displayed on the right side of the mini-side bar. Depending on the user's path choice, a component is displayed. The following components can be displayed:
+  - **The task list component** is called `TaskList.vue`. It's the default component used to fill this space. It shows which ML tasks are open for collaborative training.
+  - **Task-related Components** are components used to display the interface associated with a particular task. The UI components for an ML task come in a parent-child relation: one global component (called `[taskName]_model.vue`) is used to implement a sidebar that allows the user to navigate through the different components associated with a task. On the right side of this global component, the following components are used to create a task (and note that all of them need to be created for each task):
+    - **Description of the task** under the name `[taskName]\_description.vue. It gives an overview of the task.
+    - **Training of the task** under the name `[taskName]_training.vue`. Allows the users to train a model, either collaboratively using p2p communication, or alone by local training. As a side note, components are created only when they are called by the user. Meaning that until the user reaches the training page of the task, the `[taskName]_training.vue`is not created. When a user reaches for the first time the training components, the component is created, and only then the NN model is created and stored in the browser's indexdb database. The training is done in a seperated script. To start training, the function named `join_training`is called. This function preprocess the data using the task specific data pre-processing function and then train the model using the shared `train`function.
+
+All these are served by the typescript file associated to the task.
+
+### Training Loop
+
+A shared function `training` is called by all components that are training a model. This function is located in the file ./helpers/training.js.  
+The idea is that the training part for all tasks relies on the same ML backend, while the pre-processing of the training data is done in a custom version (at the component level) by each task.  
+The training process works as follows:
+
+1. When a user has stated that he wishes to join the training of a task, a TF.js model is initialized (for now with a standard initialization) and stored into the browser's local storage. (call to `create_model`, a function embedded into the task's training component)
+2. Once the user connects their dataset, a pre-processing function is called. The pre-processing function is specifically tailored for each task and so is embedded in the task's training component under the name `data_preprocessing`. This can be either one-off preprocessing of the entire dataset, or a batch-wise pre-processing function which will then be repeatedly called during training, for each new minibatch of training data.
+3. The `training` function function loads the model from the browser's local storage and updates the model by training it on the given dataset (and communicating with peers or a federated learning server). As mentioned earlier, the training function is shared by all training components.
+
+## Communication between peers
+
+Explanations on communication between peers will be added soon.
+
+The decentralized training version relies on p2p communication via [peer2js](https://peerjs.com/). The federated trainind does not need `peer2js` but direclty communicates with the server.
+
+## Some further integrations notes
+
+### Using on mobile devices
+
+Depending on the user's screen width, the left hand sidebar associated to task's components can disapear and be opened using the button located on the top left corner of the user's screen.
+For now a template that shows how to create tasks can be found.
+
+### Main packages used
+
+| Name                                                  |     Keyword     | Description                                                               |
+| ----------------------------------------------------- | :-------------: | :------------------------------------------------------------------------ |
+| [vuex](https://vuex.vuejs.org/)                       |     `Store`     | It serves as a centralized store for all the components in an application |
+| [vee-validate](https://vee-validate.logaretm.com/v4/) |     `Form`      | Form Validation for Vue.js                                                |
+| [vue-toaster](https://github.com/MeForma/vue-toaster) | `Notifications` | Toast notification plugin for Vue.js                                      |
+| [tippy](https://atomiks.github.io/tippyjs/)           |     `Menu`      | Pluging to build menu / side bars                                         |
+| [vue-i18n](https://vue-i18n.intlify.dev/)             | `Internation.`  | Internationalization plugin for Vue.js                                    |
+| [vue-router](https://router.vuejs.org/)               |    `Routing`    | Official router plugin for Vue.js                                         |
+| [tfjs](https://www.tensorflow.org/js)                 |  `ML backend`   | Library for machine learning in JavaScript                                |
+| [axios](https://axios-http.com/)                      | `HTTP requests` | Axios is a promise-based HTTP Client for node.js and the browser.         |
+| [lodash](https://lodash.com/)                         |  `JS Helpers`   | Functional library for higher order function on list and js objects       |
+| [yup](https://github.com/jquense/yup)                 |     `Form`      | Schema builder for runtime value parsing and validation (forms).          |
+| [peerjs](https://peerjs.com/)                         | `Communication` | P2P communication libary for DeAI                                         |

--- a/mobile-browser-based-version/information/ARCHITECTURE.md
+++ b/mobile-browser-based-version/information/ARCHITECTURE.md
@@ -116,7 +116,7 @@ The application runs the following architecture:
   - **The task list component** is called `TaskList.vue`. It's the default component used to fill this space. It shows which ML tasks are open for collaborative training.
   - **Task-related Components** are components used to display the interface associated with a particular task. The UI components for an ML task come in a parent-child relation: one global component (called `[taskName]_model.vue`) is used to implement a sidebar that allows the user to navigate through the different components associated with a task. On the right side of this global component, the following components are used to create a task (and note that all of them need to be created for each task):
     - **Description of the task** under the name `[taskName]\_description.vue. It gives an overview of the task.
-    - **Training of the task** under the name `[taskName]_training.vue`. Allows the users to train a model, either collaboratively using p2p communication, or alone by local training. As a side note, components are created only when they are called by the user. Meaning that until the user reaches the training page of the task, the `[taskName]_training.vue`is not created. When a user reaches for the first time the training components, the component is created, and only then the NN model is created and stored in the browser's indexdb database. The training is done in a seperated script. To start training, the function named `join_training`is called. This function preprocess the data using the task specific data pre-processing function and then train the model using the shared `train`function.
+    - **Training of the task** under the name `[taskName]_training.vue`. Allows the users to train a model, either collaboratively using p2p communication, or alone by local training. As a side note, components are created only when they are called by the user. Meaning that until the user reaches the training page of the task, the `[taskName]_training.vue`is not created. When a user reaches for the first time the training components, the component is created, and only then the NN model is created and stored in the browser's indexdb database. The training is done in a separated script. To start training, the function named `join_training`is called. This function preprocess the data using the task specific data pre-processing function and then train the model using the shared `train`function.
 
 All these are served by the typescript file associated to the task.
 
@@ -127,20 +127,20 @@ The idea is that the training part for all tasks relies on the same ML backend, 
 The training process works as follows:
 
 1. When a user has stated that he wishes to join the training of a task, a TF.js model is initialized (for now with a standard initialization) and stored into the browser's local storage. (call to `create_model`, a function embedded into the task's training component)
-2. Once the user connects their dataset, a pre-processing function is called. The pre-processing function is specifically tailored for each task and so is embedded in the task's training component under the name `data_preprocessing`. This can be either one-off preprocessing of the entire dataset, or a batch-wise pre-processing function which will then be repeatedly called during training, for each new minibatch of training data.
+2. Once the user connects their dataset, a pre-processing function is called. The pre-processing function is specifically tailored for each task and so is embedded in the task's training component under the name `data_preprocessing`. This can be either one-off preprocessing of the entire dataset, or a batch-wise pre-processing function which will then be repeatedly called during training, for each new mini batch of training data.
 3. The `training` function function loads the model from the browser's local storage and updates the model by training it on the given dataset (and communicating with peers or a federated learning server). As mentioned earlier, the training function is shared by all training components.
 
 ## Communication between peers
 
 Explanations on communication between peers will be added soon.
 
-The decentralized training version relies on p2p communication via [peer2js](https://peerjs.com/). The federated trainind does not need `peer2js` but direclty communicates with the server.
+The decentralized training version relies on p2p communication via [peer2js](https://peerjs.com/). The federated training does not need `peer2js` but directly communicates with the server.
 
 ## Some further integrations notes
 
 ### Using on mobile devices
 
-Depending on the user's screen width, the left hand sidebar associated to task's components can disapear and be opened using the button located on the top left corner of the user's screen.
+Depending on the user's screen width, the left hand sidebar associated to task's components can disappear and be opened using the button located on the top left corner of the user's screen.
 For now a template that shows how to create tasks can be found.
 
 ### Main packages used
@@ -157,4 +157,4 @@ For now a template that shows how to create tasks can be found.
 | [axios](https://axios-http.com/)                      | `HTTP requests` | Axios is a promise-based HTTP Client for node.js and the browser.         |
 | [lodash](https://lodash.com/)                         |  `JS Helpers`   | Functional library for higher order function on list and js objects       |
 | [yup](https://github.com/jquense/yup)                 |     `Form`      | Schema builder for runtime value parsing and validation (forms).          |
-| [peerjs](https://peerjs.com/)                         | `Communication` | P2P communication libary for DeAI                                         |
+| [peerjs](https://peerjs.com/)                         | `Communication` | P2P communication library for DeAI                                        |

--- a/mobile-browser-based-version/information/CONTRIBUTING.md
+++ b/mobile-browser-based-version/information/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 ## TODO list
 
-To get an overview of who is working on what we use the [project](https://github.com/epfml/disco/projects/7) feature of GitHub as described earlier, this gives us a table with the currents todo’s, what is currently being worked on, and what has been finished.
+To get an overview of who is working on what we use the [project](https://github.com/epfml/disco/projects/7) feature of GitHub as described earlier, this gives us a table with the current TODOs, what is currently being worked on, and what has been finished.
 
-Each note in the the project can be linked to an issue by tagging it, e.g. add #202 in the note content. You cannot assign yourself a note, but you can assign yourself an issue, which is how we can keep track of who his working on what feature.
+Each note in the the project can be linked to an issue by tagging it, e.g. add #202 in the note content. You cannot assign yourself a note, but you can assign yourself an issue, which is how we can keep track of who is working on what feature.
 
 > **Tip** : When creating a new issue, on the right hand side, under the assignees menu, you can also add a project, if you add the `TODO` project, this will directly create a note in our project with the issue
 

--- a/mobile-browser-based-version/information/CONTRIBUTING.md
+++ b/mobile-browser-based-version/information/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Disco - How to contribute
+
+## TODO list
+
+To get an overview of who is working on what we use the [project](https://github.com/epfml/disco/projects/7) feature of GitHub as described earlier, this gives us a table with the currents todo’s, what is currently being worked on, and what has been finished.
+
+Each note in the the project can be linked to an issue by tagging it, e.g. add #202 in the note content. You cannot assign yourself a note, but you can assign yourself an issue, which is how we can keep track of who his working on what feature.
+
+> **Tip** : When creating a new issue, on the right hand side, under the assignees menu, you can also add a project, if you add the `TODO` project, this will directly create a note in our project with the issue
+
+The project link can be found [here](https://github.com/epfml/disco/projects/7)
+
+## Contributing code: PR
+
+Once you start working on a feature, create a new branch from the `develop` branch, and use the following convention:
+
+`IssueNumber-Key-Word-YourName`
+
+So for example, if I am working on issue 202, which is related to fixing a train bug I would call this branch:
+
+`202-train-bug-nacho`
+
+Once you have added a minimum number of content to your branch (e.g. you can see a bit where you are going), you can create a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+It is important to give a good description to your PR as this makes it easier for other people to go through it. [This](https://github.com/epfml/disco/pull/176) is good example of a PR is the following:
+
+> **Tip** : [Here](https://github.com/epfml/disco/pull/176) is a good example of a PR.
+
+Once you have finished your work on your draft PR, make sure to do the following before turning it into review PR.
+
+1. Run both the server and main test suites (descriptions about how to run tests can be found in the README files in GitHub).
+
+2. Make sure you remove debugging comments / console outputs.
+
+## FAQ
+
+If you have a question, always go to the [FAQ](FAQ.md) first. If you do not find an answer, and eventually find a solution, then if you think this might be useful to others please add your question and answer to the FAQ.

--- a/mobile-browser-based-version/information/FAQ.md
+++ b/mobile-browser-based-version/information/FAQ.md
@@ -2,7 +2,7 @@
 
 ### Issue using the apple silicon chips:
 
-`TensorFlow.js` in version `3.13.0` currently suportes for M1 mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
+`TensorFlow.js` in version `3.13.0` currently supports for M1 mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
 
 ```
 node -p "process.arch"

--- a/mobile-browser-based-version/information/FAQ.md
+++ b/mobile-browser-based-version/information/FAQ.md
@@ -1,9 +1,26 @@
 # Disco - FAQ
 
-### Issue using the apple silicon chips:
+### Problem:  Using TensorFlow.js on Mac laptops with M1 chips
 
-`TensorFlow.js` in version `3.13.0` currently supports for M1 mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
+### Solution:
+
+`TensorFlow.js` in version `3.13.0` currently supports for M1 Mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
 
 ```
 node -p "process.arch"
 ```
+### Problem:  `npm run serve` version error on Windows 11 with correct npm and Node versions
+
+### Solution:
+
+1. Remove npm and Node completely from your computer.
+2. Install the latest version of npm and Node, then execute `npm run serve` again.
+3. If you receive an error, downgrade the Node version to the appropriate version. Check [here](https://github.com/epfml/disco/blob/b133bd598a6f65e5bb6a56e21106bf6a7abdda90/mobile-browser-based-version/README.md?plain=1#L47-L51 "here") for the versions we currently use. 
+
+	Then run the following commands by using nvm.
+```
+nvm install 15.12.0 
+nvm use 15.12.0 
+```
+If you do not have nvm installed, it can be downloaded from [here](https://github.com/coreybutler/nvm-windows "here").
+4. Execute `npm run serve` and you are done!

--- a/mobile-browser-based-version/information/FAQ.md
+++ b/mobile-browser-based-version/information/FAQ.md
@@ -1,0 +1,9 @@
+# Disco - FAQ
+
+### Issue using the apple silicon chips:
+
+`TensorFlow.js` in version `3.13.0` currently suportes for M1 mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
+
+```
+node -p "process.arch"
+```

--- a/mobile-browser-based-version/information/FAQ.md
+++ b/mobile-browser-based-version/information/FAQ.md
@@ -1,26 +1,30 @@
 # Disco - FAQ
 
-### Problem:  Using TensorFlow.js on Mac laptops with M1 chips
+### Problem: Using TensorFlow.js on Mac laptops with M1 chips
 
 ### Solution:
 
-`TensorFlow.js` in version `3.13.0` currently supports for M1 Mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
+`TensorFlow.js` in version `3.13.0` (or later) currently supports for M1 Mac laptops. However, make sure you have an `arm` node executable installed (not `x86`). It can be checked using:
 
 ```
 node -p "process.arch"
 ```
-### Problem:  `npm run serve` version error on Windows 11 with correct npm and Node versions
+
+### Problem: `npm run serve` version error on Windows 11 with correct npm and Node versions
 
 ### Solution:
 
 1. Remove npm and Node completely from your computer.
 2. Install the latest version of npm and Node, then execute `npm run serve` again.
-3. If you receive an error, downgrade the Node version to the appropriate version. Check [here](https://github.com/epfml/disco/blob/b133bd598a6f65e5bb6a56e21106bf6a7abdda90/mobile-browser-based-version/README.md?plain=1#L47-L51) for the versions we currently use. 
+3. If you receive an error, downgrade the Node version to the appropriate version. Check [here](https://github.com/epfml/disco/blob/b133bd598a6f65e5bb6a56e21106bf6a7abdda90/mobile-browser-based-version/README.md?plain=1#L47-L51) for the versions we currently use.
 
-	Then run the following commands by using nvm.
-	```
-	nvm install 15.12.0 
-	nvm use 15.12.0 
-	```
-	If you do not have nvm installed, it can be downloaded from [here](https://github.com/coreybutler/nvm-windows).
+   Then run the following commands by using nvm.
+
+   ```
+   nvm install 15.12.0
+   nvm use 15.12.0
+   ```
+
+   If you do not have nvm installed, it can be downloaded from [here](https://github.com/coreybutler/nvm-windows).
+
 4. Execute `npm run serve` and you are done!

--- a/mobile-browser-based-version/information/FAQ.md
+++ b/mobile-browser-based-version/information/FAQ.md
@@ -15,12 +15,12 @@ node -p "process.arch"
 
 1. Remove npm and Node completely from your computer.
 2. Install the latest version of npm and Node, then execute `npm run serve` again.
-3. If you receive an error, downgrade the Node version to the appropriate version. Check [here](https://github.com/epfml/disco/blob/b133bd598a6f65e5bb6a56e21106bf6a7abdda90/mobile-browser-based-version/README.md?plain=1#L47-L51 "here") for the versions we currently use. 
+3. If you receive an error, downgrade the Node version to the appropriate version. Check [here](https://github.com/epfml/disco/blob/b133bd598a6f65e5bb6a56e21106bf6a7abdda90/mobile-browser-based-version/README.md?plain=1#L47-L51) for the versions we currently use. 
 
 	Then run the following commands by using nvm.
-```
-nvm install 15.12.0 
-nvm use 15.12.0 
-```
-If you do not have nvm installed, it can be downloaded from [here](https://github.com/coreybutler/nvm-windows "here").
+	```
+	nvm install 15.12.0 
+	nvm use 15.12.0 
+	```
+	If you do not have nvm installed, it can be downloaded from [here](https://github.com/coreybutler/nvm-windows).
 4. Execute `npm run serve` and you are done!


### PR DESCRIPTION
The README is looking good but it's a bit overwhelming, and it's also missing a "how to contribute section".

In this brief PR we add the following:

- Add a CONTRIBUTING.md to the source folder explaining our workflow

We refactor the following:

- Break up the big README.md, we keep a minimal README.md with instructions of how to build, run and general info, and add another ARCHITECTURE.md and FAQ.md explaining details.

Will close #147 
