### PR TITLE
Add lint, build and test jobs to CI

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -6,16 +6,12 @@ on:
     types: [completed]
 
 env:
-  server_dir: mobile-browser-based-version/server
   server_url: https://deai-313515.ew.r.appspot.com/
 
 jobs:
   deploy:
     name: deploy-gae
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ env.server_dir }}
 
     steps:
       - name: checkout
@@ -24,6 +20,7 @@ jobs:
       - name: deploy
         uses: google-github-actions/deploy-appengine@v0.2.0
         with:
+          working_directory: mobile-browser-based-version/server
           deliverables: app.yaml
           version: prod
           project_id: ${{ secrets.GCP_PROJECT }}

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -10,21 +10,25 @@ env:
 
 jobs:
   deploy:
-    name: deploy-gae
+    name: deploy
     runs-on: ubuntu-latest
 
     steps:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: deploy
-        uses: google-github-actions/deploy-appengine@v0.2.0
+      - name: authenticate-to-google-cloud
+        uses: "google-github-actions/auth@v0"
+        with:
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+
+      - name: deploy-to-google-cloud
+        uses: google-github-actions/deploy-appengine@v0.8.0
         with:
           working_directory: mobile-browser-based-version/server
           deliverables: app.yaml
           version: prod
           project_id: ${{ secrets.GCP_PROJECT }}
-          credentials: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: test
         run: curl "${{ env.server_url }}"

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,0 +1,33 @@
+name: Deploy to GAE
+on:
+  workflow_run:
+    workflows: ["Lint, test and build"]
+    branches: [production]
+    types: [completed]
+
+env:
+  server_dir: mobile-browser-based-version/server
+  server_url: https://deai-313515.ew.r.appspot.com/
+
+jobs:
+  deploy:
+    name: Deploying to Google Cloud
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.server_dir }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Deploy to App Engine
+        uses: google-github-actions/deploy-appengine@v0.2.0
+        with:
+          deliverables: app.yaml
+          version: prod
+          project_id: ${{ secrets.GCP_PROJECT }}
+          credentials: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Test
+        run: curl "${{ env.server_url }}"

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,7 +1,7 @@
-name: Deploy to GAE
+name: deploy-server
 on:
   workflow_run:
-    workflows: ["Lint, test and build"]
+    workflows: ["lint-test-build"]
     branches: [production]
     types: [completed]
 
@@ -11,17 +11,17 @@ env:
 
 jobs:
   deploy:
-    name: Deploying to Google Cloud
+    name: deploy-gae
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ env.server_dir }}
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v2
 
-      - name: Deploy to App Engine
+      - name: deploy
         uses: google-github-actions/deploy-appengine@v0.2.0
         with:
           deliverables: app.yaml
@@ -29,5 +29,5 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT }}
           credentials: ${{ secrets.GCP_CREDENTIALS }}
 
-      - name: Test
+      - name: test
         run: curl "${{ env.server_url }}"

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,7 +1,7 @@
-name: Build and Deploy
+name: github-pages
 on:
   workflow_run:
-    workflows: ["Lint, test and build"]
+    workflows: ["lint-test-build"]
     branches: [production]
     types: [completed]
 
@@ -9,18 +9,18 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
+      - name: checkout
         uses: actions/checkout@v2
         with:
           ref: "production"
 
-      - name: Install and Build 🔧
+      - name: install-and-build
         run: |
           npm install
           npm run build
         working-directory: mobile-browser-based-version
 
-      - name: Deploy 🚀
+      - name: deploy
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,8 +1,10 @@
 name: Build and Deploy
 on:
-  push:
-    branches:
-      - production
+  workflow_run:
+    workflows: ["Lint, test and build"]
+    branches: [production]
+    types: [completed]
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -10,9 +12,9 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
         with:
-         ref: 'production'
+          ref: "production"
 
-      - name: Install and Build 🔧 
+      - name: Install and Build 🔧
         run: |
           npm install
           npm run build
@@ -21,6 +23,5 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          branch: gh-pages 
-          folder: mobile-browser-based-version/dist 
-
+          branch: gh-pages
+          folder: mobile-browser-based-version/dist

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -1,4 +1,4 @@
-name: Lint, test and build
+name: lint-test-build
 on:
   push:
     branch: production
@@ -41,6 +41,7 @@ jobs:
           cache-dependency-path: ${{ env.server_dir }}/package-lock.json
       - run: npm ci
       - run: npm run build
+
   build-server-docker:
     needs: build-server
     runs-on: ubuntu-latest
@@ -50,6 +51,7 @@ jobs:
         with:
           install: true
       - run: docker build ${{ env.server_dir }}
+
   build-client:
     needs: lint-client-and-server
     runs-on: ubuntu-latest
@@ -81,6 +83,7 @@ jobs:
           cache-dependency-path: ${{ env.server_dir }}/package-lock.json
       - run: npm ci
       - run: npm run test
+
   test-client:
     needs: [build-client, build-server-docker, test-server]
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -1,0 +1,98 @@
+name: Lint, test and build
+on:
+  push:
+    branch: production
+  pull_request:
+
+env:
+  node_version: 15
+  client_dir: mobile-browser-based-version
+  server_dir: mobile-browser-based-version/server
+
+jobs:
+  lint-client-and-server:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.client_dir }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ env.client_dir }}/package-lock.json
+      - run: npm ci
+      - run: npx eslint --max-warnings 0 .
+      - run: npm run lint
+
+  build-server:
+    needs: lint-client-and-server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.server_dir }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ env.server_dir }}/package-lock.json
+      - run: npm ci
+      - run: npm run build
+  build-server-docker:
+    needs: build-server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - run: docker build ${{ env.server_dir }}
+  build-client:
+    needs: lint-client-and-server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.client_dir }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ env.client_dir }}/package-lock.json
+      - run: npm ci
+      - run: npm run build
+
+  test-server:
+    needs: build-server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.server_dir }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ env.server_dir }}/package-lock.json
+      - run: npm ci
+      - run: npm run test
+  test-client:
+    needs: [build-client, build-server-docker, test-server]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.client_dir }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ env.client_dir }}/package-lock.json
+      - run: npm ci
+      - run: npm run test

--- a/mobile-browser-based-version/package.json
+++ b/mobile-browser-based-version/package.json
@@ -7,7 +7,6 @@
     "prod": "vue-cli-service serve --mode production",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "blam": "false; true",
     "test": "./with_server env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --exit -r ts-node/register --file tests/setup.ts 'tests/**/*.ts'",
     "build17": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
     "lint17": "export NODE_OPTIONS=--openssl-legacy-provider  && vue-cli-service lint",

--- a/mobile-browser-based-version/package.json
+++ b/mobile-browser-based-version/package.json
@@ -7,7 +7,8 @@
     "prod": "vue-cli-service serve --mode production",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha --exit -r ts-node/register --file tests/setup.ts 'tests/**/*.ts'",
+    "blam": "false; true",
+    "test": "./with_server env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --exit -r ts-node/register --file tests/setup.ts 'tests/**/*.ts'",
     "build17": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
     "lint17": "export NODE_OPTIONS=--openssl-legacy-provider  && vue-cli-service lint",
     "serve17": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve"

--- a/mobile-browser-based-version/server/src/topologies/topologies.ts
+++ b/mobile-browser-based-version/server/src/topologies/topologies.ts
@@ -1,8 +1,8 @@
 class TreeNode {
-  id: any
-  leftChild: any
-  rightChild: any
-  parent: any
+  id: any;
+  leftChild: any;
+  rightChild: any;
+  parent: any;
 
   constructor (id) {
     this.id = id
@@ -21,8 +21,8 @@ class TreeNode {
 }
 
 class BinaryTree {
-  root: any
-  index: any
+  root: any;
+  index: any;
   constructor () {
     this.root = null
     this.index = {}
@@ -78,16 +78,16 @@ class BinaryTree {
       this.root = null
       return
     }
-    const removeLeft = deepestNode.parent.leftChild == deepestNode
+    const removeLeft = deepestNode.parent.leftChild === deepestNode
 
     let childId = deepestNode.id
     const deepestParent = deepestNode.parent
 
     let current = deepestParent
     const affectedPeers = new Set()
-    while (current != node.parent) {
+    while (current !== node.parent) {
       const currentNeighbours = this.getNeighbours(current.id)
-      currentNeighbours.forEach(neighbour => affectedPeers.add(neighbour))
+      currentNeighbours.forEach((neighbour) => affectedPeers.add(neighbour))
       const tmp = current.id
       current.id = childId
       this.index[current.id] = current

--- a/mobile-browser-based-version/with_server
+++ b/mobile-browser-based-version/with_server
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+set -o pipefail
+
+readonly PORT=8080
+
+container=$(
+	docker build --quiet server |
+		xargs docker run --rm --detach --publish $PORT:$PORT
+)
+cleanup() {
+	docker stop $container >/dev/null
+}
+trap cleanup EXIT
+
+while ! curl --silent http://localhost:$PORT >/dev/null
+do
+	sleep 0.1
+done
+
+$@


### PR DESCRIPTION
Mine first PR to disco, tell me if I missed anything :grin: 

Takes care of #225

It triggers upon merging from `develop` -> `production` and on PR creation.
 
> * Run server tests
> * Build server docker
> * Run client tests

Done and
* add some caching while at it
* change the client's `npm run test` to also start the server


> * Run server docker

Hum, I'm using the one build from sources for the test, is it better to start the docker one?

> * Build and update to github pages

The deploy workflow already takes care of that. I changed the trigger to do it iff the `lint-build-test` passes.

> * Update google app engine (server)

I don't know what are the credentials for GAE.
One can use [Google's GitHub Action](https://github.com/google-github-actions/deploy-appengine)  for that, feel free to push to this PR if you have theses.

> Allow only a PR to be pushed for review if it passes auto tests (PR-draft would still work without tests)

Enforcing this need an admin change to the setting of the repo. It would be best to enforce it after merging this PR.