### PR TITLE
github/lint-test-build: fix push trigger

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -1,7 +1,7 @@
 name: lint-test-build
 on:
   push:
-    branch: production
+    branches: production
   pull_request:
 
 env:


### PR DESCRIPTION
When pushing to a branch, the CI triggers, but that's not supposed to do so. It should only do it when pushing to the `production` branch or opening a PR.

It seems that the push trigger spec was wrong (but not flagged as so by GitHub!)