### PR TITLE
Run tests without docker

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -98,4 +98,4 @@ jobs:
           cache: npm
           cache-dependency-path: ${{ env.client_dir }}/package-lock.json
       - run: npm ci
-      - run: npm run test
+      - run: ./with_server npm run test

--- a/mobile-browser-based-version/README.md
+++ b/mobile-browser-based-version/README.md
@@ -87,7 +87,13 @@ To choose between **decentralized** and **federated** learning go to the setting
 
 ### Testing the server locally
 
-To run unit testing run `npm run test`. Make sure you are running a server at the same time. We use [mocha](https://mochajs.org/) and [chai](https://www.chaijs.com/) for testing; respectively they are libraries: unit tests and assertions.
+To run unit testing use `npm run test`.
+Make sure you are running a server at the same time.
+
+- You can `( cd server && npm run dev ) &` to start one in the background.
+- Or if you have docker, `./with_server` starts one for you and run the command given as arguments. So you can directly run `./with_server npm run test`.
+
+We use [mocha](https://mochajs.org/) and [chai](https://www.chaijs.com/) for testing; respectively they are libraries: unit tests and assertions.
 
 Note that tests for the server are found under `server/tests/`.
 

--- a/mobile-browser-based-version/package.json
+++ b/mobile-browser-based-version/package.json
@@ -7,7 +7,7 @@
     "prod": "vue-cli-service serve --mode production",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test": "./with_server env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --exit -r ts-node/register --file tests/setup.ts 'tests/**/*.ts'",
+    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha --exit -r ts-node/register --file tests/setup.ts 'tests/**/*.ts'",
     "build17": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
     "lint17": "export NODE_OPTIONS=--openssl-legacy-provider  && vue-cli-service lint",
     "serve17": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve"


### PR DESCRIPTION
* `npm run test` needs docker to run, which is not that user friendly. Avoid using it by default.
* add some explaination on how to run a server for the tests