### PR TITLE
UI: Add About Us page

### DIFF
--- a/mobile-browser-based-version/public/index.html
+++ b/mobile-browser-based-version/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.0/css/all.min.css"/>
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/mobile-browser-based-version/src/components/AboutUs.vue
+++ b/mobile-browser-based-version/src/components/AboutUs.vue
@@ -1,0 +1,80 @@
+<template>
+  <base-layout :withSection="true" customClass="pt-4">
+    <div class="box-border h-32 w-32 p-4 border-4 border-gray-200 bg-blue-100 rounded">
+      <h2>Developed in the Machine Learning and Optimization Laboratory at EPFL, Disco enables collaborative and privacy-preserving
+        training of machine learning models. Disco offers both decentralized and federated learning.<br /><br />
+        We follow an open development process - you're more than welcome to join the conversation on our Slack space,
+        as well as on the issues pages on Github.</h2>
+     </div>
+    <!-- Links -->
+    <div class="grid md:grid-cols-3 gap-8 m-8">
+    <!-- LAB -->
+      <div class="box-border h-32 w-32 p-4 bg-blue-200">
+        <a href="https://www.epfl.ch/labs/mlo/" target="_blank" class="float space-x-4">
+          <i class="fa-solid fa-diagram-project"></i>
+          <span class="text font-bold">Visit ML&O</span>
+        </a>
+      </div>
+      <!-- Github -->
+      <div class="box-border h-32 w-32 p-4 bg-blue-200">
+        <a href="https://github.com/epfml/disco" target="_blank" class="float space-x-4">
+          <i class="fa-brands fa-github"></i>
+          <span class="text font-bold">Follow on Github</span>
+        </a>
+      </div>
+      <!-- Slack -->
+      <div class="box-border h-32 w-32 p-4 bg-blue-200">
+        <a href="https://join.slack.com/t/disco-decentralized/shared_invite/zt-fpsb7c9h-1M9hnbaSonZ7lAgJRTyNsw" target="_blank" class="float space-x-4">
+          <i class="fa-brands fa-slack"></i>
+          <span class="text font-bold">Join on Slack</span>
+        </a>
+      </div>
+    </div>
+    <!-- Team Members-->
+    <section class="mb-32 text-gray-800 text-center"><br />
+      <h2 class="text-3xl font-bold mb-12">Our Team</h2><br /><br />
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-x-6 lg:gap-xl-12">
+        <div class="mb-12 lg:mb-0">
+          <img class="rounded-lg shadow-lg mb-6 mx-auto" src="https://people.epfl.ch/private/common/photos/links/276449.jpg?ts=1647931251" style="height: 150px"/>
+          <h5 class="text-lg font-bold">Martin Jaggi</h5>
+          <h4>Tenure Track Assistant Professor</h4>
+          <p>✉️ martin.jaggi<span class="spamprotection">CHARSEQUENCE</span>@epfl.ch</p>
+        </div>
+        <div class="mb-12 lg:mb-0">
+          <img class="rounded-lg shadow-lg mb-6 mx-auto" src="https://people.epfl.ch/private/common/photos/links/204167.jpg?ts=1647931281" style="height: 150px"/>
+          <h5 class="text-lg font-bold">Mary-Anne Hartley</h5>
+          <h4>Postdoctoral Researcher</h4>
+          <p>✉️ mary-anne.hartley<span class="spamprotection">CHARSEQUENCE</span>@epfl.ch</p>
+        </div>
+        <div class="mb-12 md:mb-0">
+          <img class="rounded-lg shadow-lg mb-6 mx-auto" src="https://avatars.githubusercontent.com/u/17376073?v=4" style="height: 150px" />
+          <h5 class="text-lg font-bold">Ignacio S. Aleman </h5>
+          <h4>Research Software Engineer</h4>
+          <p>✉️ ignaciosaleman<span class="spamprotection">CHARSEQUENCE</span>@gmail.com</p>
+        </div>
+      </div>
+    </section>
+  </base-layout>
+</template>
+
+<!-- Prevent email crawling -->
+<style type="text/css">
+  span.spamprotection {display:none;}
+</style>
+
+<script lang="ts">
+import BaseLayout from './containers/BaseLayout.vue'
+import { useI18n } from 'vue-i18n'
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'about-page',
+  setup () {
+    const { t, locale } = useI18n()
+    return { t, locale }
+  },
+  components: {
+    BaseLayout
+  }
+})
+</script>

--- a/mobile-browser-based-version/src/components/sidebar/Sidebar.vue
+++ b/mobile-browser-based-version/src/components/sidebar/Sidebar.vue
@@ -72,6 +72,13 @@
       >
         <settings-icon />
       </SidebarButton>
+      <!-- Go to About Us page -->
+      <SidebarButton
+        @click="goToAboutUs"
+        :activePage="activePage"
+      >
+        About Us
+      </SidebarButton>
     </div>
   </nav>
 
@@ -211,6 +218,10 @@ export default defineComponent({
     goToInformation () {
       this.setActivePage('info')
       this.$router.push({ name: 'information' })
+    },
+    goToAboutUs () {
+      this.setActivePage('aboutus')
+      this.$router.push({ name: 'aboutus' })
     }
   },
   async mounted () {

--- a/mobile-browser-based-version/src/router/index.ts
+++ b/mobile-browser-based-version/src/router/index.ts
@@ -6,6 +6,7 @@ import TaskList from '../components/TaskList.vue'
 import Information from '../components/Information.vue'
 import NewTaskCreationForm from '../components/NewTaskCreationForm.vue'
 import NotFound from '../components/NotFound.vue'
+import AboutUs from '../components/AboutUs.vue'
 
 const routes = [
   {
@@ -27,6 +28,11 @@ const routes = [
     path: '/information',
     name: 'information',
     component: Information
+  },
+  {
+    path: '/about-us',
+    name: 'aboutus',
+    component: AboutUs
   },
   {
     path: '/:pathMatch(.*)*',

--- a/mobile-browser-based-version/tailwind.config.js
+++ b/mobile-browser-based-version/tailwind.config.js
@@ -18,6 +18,8 @@ module.exports = {
         light: 'var(--light)',
         dark: 'var(--dark)',
         darker: 'var(--darker)',
+        blue: colors.sky,
+        yellow: colors.amber,
         primary: {
           DEFAULT: 'var(--color-primary)',
           50: 'var(--color-primary-50)',


### PR DESCRIPTION
A new page called "About Us" is added to display the lab info, external links of Disco and team information. 

Some notes about contact addresses
- Email addresses are protected from spam by using invisible components. JS functions were not used since some users may not have it enabled which causes the email addresses to be hidden. "mailto" was not used since users might not have a default mail client set up.

![resim](https://user-images.githubusercontent.com/63195023/160199864-3373c037-6e9f-4ad1-92d5-38f7e8f3c6e6.png)
