### PR TITLE
Fix for issue 219: NAN in the training graph after stoping.

### DIFF
--- a/mobile-browser-based-version/src/components/building_frames/TrainingInformationFrame.vue
+++ b/mobile-browser-based-version/src/components/building_frames/TrainingInformationFrame.vue
@@ -1,129 +1,128 @@
 <template>
-<div>
+  <div>
+    <div
+      x-transition:enter="transition duration-300 ease-in-out"
+      x-transition:enter-start="opacity-0"
+      x-transition:enter-end="opacity-100"
+      x-ref="trainingBoard"
+      x-show="isTraining"
+    >
+      <!-- Validation Accuracy users chart -->
+      <div class="grid grid-cols-2 p-4 space-x-4 lg:gap-2">
+        <div class="col-span-1 bg-white rounded-md dark:bg-darker">
+          <!-- Card header -->
+          <div class="p-4 border-b dark:border-primary">
+            <h4 class="text-lg font-semibold text-gray-500 dark:text-light">
+              Validation Accuracy of the Model
+            </h4>
+          </div>
+          <p class="p-4">
+            <span class="text-2xl font-medium text-gray-500 dark:text-light">{{
+              currentValidationAccuracy
+            }}</span>
+            <span class="text-sm font-medium text-gray-500 dark:text-primary"
+              >% of validation accuracy</span
+            >
+          </p>
+          <!-- Chart -->
+          <div class="relative p-4 w-100% h-100%">
+            <apexchart
+              width="100%"
+              height="200"
+              type="area"
+              :options="areaChartOptions"
+              :series="validationAccuracyData"
+            ></apexchart>
+          </div>
+        </div>
 
-  <div
-    x-transition:enter="transition duration-300 ease-in-out"
-    x-transition:enter-start="opacity-0"
-    x-transition:enter-end="opacity-100"
-    x-ref="trainingBoard"
-    x-show="isTraining"
-  >
-    <!-- Validation Accuracy users chart -->
-    <div class="grid grid-cols-2 p-4 space-x-4 lg:gap-2">
-      <div class="col-span-1 bg-white rounded-md dark:bg-darker">
-        <!-- Card header -->
-        <div class="p-4 border-b dark:border-primary">
-          <h4 class="text-lg font-semibold text-gray-500 dark:text-light">
-            Validation Accuracy of the Model
-          </h4>
-        </div>
-        <p class="p-4">
-          <span class="text-2xl font-medium text-gray-500 dark:text-light">{{
-            currentValidationAccuracy
-          }}</span>
-          <span class="text-sm font-medium text-gray-500 dark:text-primary"
-            >% of validation accuracy</span
-          >
-        </p>
-        <!-- Chart -->
-        <div class="relative p-4 w-100% h-100%">
-          <apexchart
-            width="100%"
-            height="200"
-            type="area"
-            :options="areaChartOptions"
-            :series="validationAccuracyData"
-          ></apexchart>
-        </div>
-      </div>
-
-      <div class="col-span-1 bg-white rounded-md dark:bg-darker">
-        <!-- Card header -->
-        <div class="p-4 border-b dark:border-primary">
-          <h4 class="text-lg font-semibold text-gray-500 dark:text-light">
-            Training Accuracy of the Model
-          </h4>
-        </div>
-        <p class="p-4">
-          <span class="text-2xl font-medium text-gray-500 dark:text-light">{{
-            currentTrainingAccuracy
-          }}</span>
-          <span class="text-sm font-medium text-gray-500 dark:text-primary"
-            >% of training accuracy</span
-          >
-        </p>
-        <!-- Chart -->
-        <div class="relative p-4 w-100% h-100%">
-          <apexchart
-            width="100%"
-            height="200"
-            type="area"
-            :options="areaChartOptions"
-            :series="trainingAccuracyData"
-          ></apexchart>
+        <div class="col-span-1 bg-white rounded-md dark:bg-darker">
+          <!-- Card header -->
+          <div class="p-4 border-b dark:border-primary">
+            <h4 class="text-lg font-semibold text-gray-500 dark:text-light">
+              Training Accuracy of the Model
+            </h4>
+          </div>
+          <p class="p-4">
+            <span class="text-2xl font-medium text-gray-500 dark:text-light">{{
+              currentTrainingAccuracy
+            }}</span>
+            <span class="text-sm font-medium text-gray-500 dark:text-primary"
+              >% of training accuracy</span
+            >
+          </p>
+          <!-- Chart -->
+          <div class="relative p-4 w-100% h-100%">
+            <apexchart
+              width="100%"
+              height="200"
+              type="area"
+              :options="areaChartOptions"
+              :series="trainingAccuracyData"
+            ></apexchart>
+          </div>
         </div>
       </div>
     </div>
+
+    <!-- Communication Console -->
+    <icon-card header="Peer Training Console">
+      <template v-slot:icon><contact /></template>
+      <template v-slot:extra>
+        <div id="mapHeader">
+          <ul class="grid grid-cols-1 p-4">
+            <li
+              class="border-gray-400"
+              v-for="(message, index) in trainingInformant.messages"
+              :key="index"
+            >
+              <div class="relative overflow-x-hidden">
+                <span
+                  style="white-space: pre-line"
+                  class="text-sm text-gray-500 dark:text-light"
+                  >{{ message }}</span
+                >
+              </div>
+            </li>
+          </ul>
+        </div>
+      </template>
+    </icon-card>
+
+    <!-- Distributed Training Information -->
+    <div class="grid grid-cols-1 gap-8 p-4 lg:grid-cols-2 xl:grid-cols-4">
+      <!-- Number of time model updated with someone else's model card -->
+      <icon-card-small
+        header="# of Averaging"
+        :description="String(trainingInformant.nbrUpdatesWithOthers)"
+      >
+        <performances />
+      </icon-card-small>
+
+      <!-- How much time I've been waiting for weights to arrive -->
+      <icon-card-small
+        header="Waiting Time"
+        :description="`${trainingInformant.waitingTime} sec`"
+        ><timer
+      /></icon-card-small>
+
+      <!-- Nbr. of Weight Requests -->
+      <icon-card-small
+        header="# Weight Requests"
+        :description="String(trainingInformant.nbrWeightRequests)"
+      >
+        <forward />
+      </icon-card-small>
+
+      <!-- Nbr. of people helped -->
+      <icon-card-small
+        header="# of People Helped"
+        :description="String(trainingInformant.whoReceivedMyModel.size)"
+      >
+        <people />
+      </icon-card-small>
+    </div>
   </div>
-
-  <!-- Communication Console -->
-  <icon-card header="Peer Training Console">
-    <template v-slot:icon><contact /></template>
-    <template v-slot:extra>
-      <div id="mapHeader">
-        <ul class="grid grid-cols-1 p-4">
-          <li
-            class="border-gray-400"
-            v-for="(message, index) in trainingInformant.messages"
-            :key="index"
-          >
-            <div class="relative overflow-x-hidden">
-              <span
-                style="white-space: pre-line"
-                class="text-sm text-gray-500 dark:text-light"
-                >{{ message }}</span
-              >
-            </div>
-          </li>
-        </ul>
-      </div>
-    </template>
-  </icon-card>
-
-  <!-- Distributed Training Information -->
-  <div class="grid grid-cols-1 gap-8 p-4 lg:grid-cols-2 xl:grid-cols-4">
-    <!-- Number of time model updated with someone else's model card -->
-    <icon-card-small
-      header="# of Averaging"
-      :description="String(trainingInformant.nbrUpdatesWithOthers)"
-    >
-      <performances />
-    </icon-card-small>
-
-    <!-- How much time I've been waiting for weights to arrive -->
-    <icon-card-small
-      header="Waiting Time"
-      :description="`${trainingInformant.waitingTime} sec`"
-      ><timer
-    /></icon-card-small>
-
-    <!-- Nbr. of Weight Requests -->
-    <icon-card-small
-      header="# Weight Requests"
-      :description="String(trainingInformant.nbrWeightRequests)"
-    >
-      <forward />
-    </icon-card-small>
-
-    <!-- Nbr. of people helped -->
-    <icon-card-small
-      header="# of People Helped"
-      :description="String(trainingInformant.whoReceivedMyModel.size)"
-    >
-      <people />
-    </icon-card-small>
-  </div>
-</div>
 </template>
 
 <script>
@@ -151,13 +150,9 @@ export default {
   },
   data () {
     return {
-      // Test Apexcharts
       areaChartOptions: this.trainingInformant.getAreaChartOptions(),
       trainingAccuracyData: this.trainingInformant.getTrainingAccuracyData(),
-      validationAccuracyData:
-        this.trainingInformant.getValidationAccuracyData(),
-      interoperabilityHeatmpaOptions:
-        this.trainingInformant.getHeatmapOptions()
+      validationAccuracyData: this.trainingInformant.getValidationAccuracyData()
     }
   },
 

--- a/mobile-browser-based-version/src/core/training/trainer/trainer.ts
+++ b/mobile-browser-based-version/src/core/training/trainer/trainer.ts
@@ -110,8 +110,8 @@ export abstract class Trainer {
   /**
    * Format accuracy
    */
-  private formatAccuracy (accuracy: number) {
-    return +(accuracy * 100).toFixed(2)
+  private roundDecimals (accuracy: number, decimalsToRound: number = 2): number {
+    return +(accuracy * 100).toFixed(decimalsToRound)
   }
 
   /**
@@ -120,8 +120,8 @@ export abstract class Trainer {
   private onEpochEnd (trainingAccuracy: number, validationAccuracy: number) {
     this.trainerLogger.onEpochEnd(trainingAccuracy, validationAccuracy)
     if (!isNaN(trainingAccuracy) && !isNaN(validationAccuracy)) {
-      this.trainingInformant.updateValidationAccuracyGraph(this.formatAccuracy(validationAccuracy))
-      this.trainingInformant.updateTrainingAccuracyGraph(this.formatAccuracy(trainingAccuracy))
+      this.trainingInformant.updateValidationAccuracyGraph(this.roundDecimals(validationAccuracy))
+      this.trainingInformant.updateTrainingAccuracyGraph(this.roundDecimals(trainingAccuracy))
     }
   }
 

--- a/mobile-browser-based-version/src/core/training/trainer/trainer.ts
+++ b/mobile-browser-based-version/src/core/training/trainer/trainer.ts
@@ -108,12 +108,21 @@ export abstract class Trainer {
   }
 
   /**
+   * Format accuracy
+   */
+  private formatAccuracy (accuracy: number) {
+    return +(accuracy * 100).toFixed(2)
+  }
+
+  /**
    * We update the training graph, this needs to be done on epoch end as there is no validation accuracy onBatchEnd.
    */
-  private onEpochEnd (accuracy: number, validationAccuracy: number) {
-    this.trainerLogger.onEpochEnd(accuracy, validationAccuracy)
-    // updateGraph does not work in onBatchEnd since we do not get validation accuracy.
-    this.trainingInformant.updateGraph(TrainerLogger.formatAccuracy(accuracy), TrainerLogger.formatAccuracy(validationAccuracy))
+  private onEpochEnd (trainingAccuracy: number, validationAccuracy: number) {
+    this.trainerLogger.onEpochEnd(trainingAccuracy, validationAccuracy)
+    if (!isNaN(trainingAccuracy) && !isNaN(validationAccuracy)) {
+      this.trainingInformant.updateValidationAccuracyGraph(this.formatAccuracy(validationAccuracy))
+      this.trainingInformant.updateTrainingAccuracyGraph(this.formatAccuracy(trainingAccuracy))
+    }
   }
 
   /** onBatchEnd callback, when a round ends, we call onRoundEnd (to be implemented for local and distributed instances)

--- a/mobile-browser-based-version/src/core/training/trainer/trainer_logger.ts
+++ b/mobile-browser-based-version/src/core/training/trainer/trainer_logger.ts
@@ -24,13 +24,6 @@ export class TrainerLogger extends Logger {
     console.log(chalk.red(message))
   }
 
-  /**
-   * Format accuracy
-   */
-  static formatAccuracy (accuracy: number) {
-    return (accuracy * 100).toFixed(2)
-  }
-
   onBatchEnd (batch: number, accuracy: number) {
     this.success(`On batch end:${batch}`)
     this.success(`Train Accuracy: ${accuracy}`)

--- a/mobile-browser-based-version/src/core/training/training_informant.ts
+++ b/mobile-browser-based-version/src/core/training/training_informant.ts
@@ -28,7 +28,7 @@ export class TrainingInformant {
    * @param {Number} length the number of messages to be kept to inform the users about status of communication with other peers.
    * @param {String} taskID the task's name.
    */
-  constructor (length, taskID) {
+  constructor (length: number, taskID: string) {
     this.taskID = taskID
     // number of people with whom I've shared my model
     this.whoReceivedMyModel = new Set()
@@ -46,7 +46,7 @@ export class TrainingInformant {
     this.nbrMessagesToShow = length
     this.messages = []
 
-    // validation accurarcy chart
+    // validation accuracy chart
     this.validationAccuracyChart = null // new TrainingChart("validationAccuracy_".concat(taskID), "Validation Accuracy")
     this.validationAccuracy = 0
 
@@ -69,7 +69,7 @@ export class TrainingInformant {
    * Updates the set of peers who received my model.
    * @param {String} peerName the peer's name to whom I recently shared my model to.
    */
-  updateWhoReceivedMyModel (peerName) {
+  updateWhoReceivedMyModel (peerName: string) {
     this.whoReceivedMyModel.add(peerName)
   }
 
@@ -77,7 +77,7 @@ export class TrainingInformant {
    * Updates the number of updates I did with other peers.
    * @param {Number} nbrUpdates the number of updates I did thanks to other peers contribution since the last update of the parameter.
    */
-  updateNbrUpdatesWithOthers (nbrUpdates) {
+  updateNbrUpdatesWithOthers (nbrUpdates: number) {
     this.nbrUpdatesWithOthers += nbrUpdates
   }
 
@@ -85,7 +85,7 @@ export class TrainingInformant {
    * Updates the time I waited to receive weights.
    * @param {Number} time
    */
-  updateWaitingTime (time) {
+  updateWaitingTime (time: number) {
     this.waitingTime += time
   }
 
@@ -93,7 +93,7 @@ export class TrainingInformant {
    * Updates the number of weights request I received.
    * @param {Number} nbrRequests the number of weight requests I received since the last update of the parameter.
    */
-  updateNbrWeightsRequests (nbrRequests) {
+  updateNbrWeightsRequests (nbrRequests: number) {
     this.nbrWeightRequests += nbrRequests
   }
 
@@ -101,14 +101,14 @@ export class TrainingInformant {
    * Add a new message to the message list.
    * @param {String} msg a message.
    */
-  addMessage (msg) {
+  addMessage (msg: string) {
     if (this.messages.length >= this.nbrMessagesToShow) {
       this.messages.shift()
     }
     this.messages.push(msg)
   }
 
-  cssColors = (color) => {
+  cssColors = (color: string) => {
     return getComputedStyle(document.documentElement)
       .getPropertyValue(color)
       .trim()
@@ -131,61 +131,6 @@ export class TrainingInformant {
       primaryLighter: this.cssColors(`--color-${this.getColor()}-lighter`),
       primaryDark: this.cssColors(`--color-${this.getColor()}-dark`),
       primaryDarker: this.cssColors(`--color-${this.getColor()}-darker`)
-    }
-  }
-
-  /**
-   * Update the Heatmap for Interoperability.
-   */
-  updateHeatmapData (weightsIn, biasesIn, weightsOut, biasesOut) {
-    this.displayHeatmap = true
-    this.weightsIn = weightsIn
-    this.biasesIn = biasesIn
-    this.weightsOut = weightsOut
-    this.biasesOut = biasesOut
-  }
-
-  /**
-   * Give the defined options for the Interoperability Heatmap.
-   * TODO: Make the fetching of categories dynamic.
-   * @returns An object containing the options to style the heatmap.
-   */
-  getHeatmapOptions () {
-    return {
-      colors: [this.getColorPalette().primaryLight],
-      dataLabels: {
-        enabled: true,
-        style: {
-          colors: ['#FFF']
-        },
-        offsetX: 30
-      },
-      chart: {
-        id: 'vuechart-example'
-      },
-      plotOptions: {
-        heatmap: {
-          colorScale: {
-            min: 0.8,
-            max: 1.2
-          }
-        }
-      },
-      xaxis: {
-        categories: ['Id', 'Age', 'SibSp', 'Parch', 'Fare', 'Pclass'],
-        labels: {
-          style: {
-            colors: '#FFF'
-          }
-        }
-      },
-      yaxis: {
-        labels: {
-          style: {
-            colors: '#FFF'
-          }
-        }
-      }
     }
   }
 
@@ -290,20 +235,10 @@ export class TrainingInformant {
   }
 
   /**
-   * Update the accuracy graphs data
-   * @param {Number} validationAccuracy the current validation accuracy of the model
-   * @param {Number} trainingAccuracy the current training accuracy of the model
-   */
-  updateGraph (validationAccuracy, trainingAccuracy) {
-    this._updateValidationAccuracyGraph(validationAccuracy)
-    this._updateTrainingAccuracyGraph(trainingAccuracy)
-  }
-
-  /**
    *  Updates the data to be displayed on the validation accuracy graph.
    * @param {Number} validationAccuracy the current validation accuracy of the model
    */
-  _updateValidationAccuracyGraph (validationAccuracy) {
+  updateValidationAccuracyGraph (validationAccuracy: number) {
     this.validationAccuracyDataSerie.push(validationAccuracy)
     this.validationAccuracyDataSerie.splice(0, 1)
     this.currentValidationAccuracy = validationAccuracy
@@ -313,7 +248,7 @@ export class TrainingInformant {
    *  Updates the data to be displayed on the training accuracy graph.
    * @param {Number} trainingAccuracy the current training accuracy of the model
    */
-  _updateTrainingAccuracyGraph (trainingAccuracy) {
+  updateTrainingAccuracyGraph (trainingAccuracy: number) {
     this.trainingAccuracyDataSerie.push(trainingAccuracy)
     this.trainingAccuracyDataSerie.splice(0, 1)
     this.currentTrainingAccuracy = trainingAccuracy

--- a/mobile-browser-based-version/src/core/training/training_informant.ts
+++ b/mobile-browser-based-version/src/core/training/training_informant.ts
@@ -1,6 +1,10 @@
 /**
  * Class that collects information about the status of the training-loop of the model.
  */
+
+type DataSerie = {
+  data: number[];
+};
 export class TrainingInformant {
   taskID: string;
   whoReceivedMyModel: Set<unknown>;
@@ -214,7 +218,7 @@ export class TrainingInformant {
    * Returns the Validation Accuracy over the last 10 epochs.
    * @returns the validation accuracy data
    */
-  getValidationAccuracyData () {
+  getValidationAccuracyData (): DataSerie[] {
     return [
       {
         data: this.validationAccuracyDataSerie
@@ -226,7 +230,7 @@ export class TrainingInformant {
    * Returns the Training Accuracy over the last 10 epochs.
    * @returns the training accuracy data
    */
-  getTrainingAccuracyData () {
+  getTrainingAccuracyData (): DataSerie[] {
     return [
       {
         data: this.trainingAccuracyDataSerie

--- a/mobile-browser-based-version/src/core/training/training_informant.ts
+++ b/mobile-browser-based-version/src/core/training/training_informant.ts
@@ -1,10 +1,11 @@
-/**
- * Class that collects information about the status of the training-loop of the model.
- */
 
 type DataSerie = {
   data: number[];
 };
+
+/**
+ * Class that collects information about the status of the training-loop of the model.
+ */
 export class TrainingInformant {
   taskID: string;
   whoReceivedMyModel: Set<unknown>;


### PR DESCRIPTION
Fix for issue 219: NAN in the training graph after stoping.

Basically mid training we are able to stop training, however at this point onEpochEnd might be reached, and because of this the train accuracy is NAN, to fix the graph displaying NAN values and doing funny things I only update the graph if the values are not NAN. (seems like an easy reasonable fix).

I removed an intermediary `updateGraph` function, since the parameters were inverted in the function call, in the UI, validation accuracy was actually train accuracy and vice-versa. Since the function was redundant (and being used wrongly) to begin with I removed it and made explicit calls to updateTrainGraph, and updateValid...

I removed redundant code from the old interoperability feature.


Fixes 219