### PR TITLE
Image training on Node.js

### DIFF
--- a/mobile-browser-based-version/src/components/building_frames/containers/TrainingFrame.vue
+++ b/mobile-browser-based-version/src/components/building_frames/containers/TrainingFrame.vue
@@ -17,7 +17,7 @@
 
       <!-- Train Button -->
       <div class="flex items-center justify-center p-4">
-        <div v-if="!trainingManager.isTraining">
+        <div v-if="!disco.isTraining">
           <custom-button
             :center="true"
             @click="startTraining(false)"
@@ -35,7 +35,7 @@
           <custom-button
             :center="true"
             color="bg-red-500"
-            @click="trainingManager.stopTraining()"
+            @click="disco.stopTraining()"
           >
             Stop <span v-if="distributedTraining">Distributed</span><span v-else>Local</span> Training
           </custom-button>
@@ -44,8 +44,8 @@
       <!-- Training Board -->
       <div>
         <training-information-frame
-          v-if="trainingManager.trainingInformant"
-          :training-informant="trainingManager.trainingInformant"
+          v-if="disco.trainingInformant"
+          :training-informant="disco.trainingInformant"
         />
       </div>
 
@@ -115,7 +115,7 @@ import Download from '../../../assets/svg/Download.vue'
 
 import { mapState } from 'vuex'
 import * as memory from '../../../core/memory/memory'
-import { TrainingManager } from '../../../core/training/training_manager'
+import { Disco } from '../../../core/training/disco'
 import { DatasetBuilder } from '../../../core/dataset/dataset_builder'
 import { DataLoader } from '../../../core/dataset/data_loader/data_loader'
 import { Task } from '../../../core/task/task'
@@ -149,11 +149,11 @@ export default {
   },
   watch: {
     useIndexedDB (newValue) {
-      this.trainingManager.setIndexedDB(!!newValue)
+      this.disco.setIndexedDB(!!newValue)
     }
   },
   created () {
-    this.trainingManager = new TrainingManager(
+    this.disco = new Disco(
       this.task,
       this.$store.getters.platform,
       this.$toast,
@@ -169,7 +169,7 @@ export default {
             .build()
             .batch(this.task.trainingInformation.batchSize)
         }
-        this.trainingManager.startTraining(this.dataset, distributedTraining)
+        this.disco.startTraining(this.dataset, distributedTraining)
       } catch {
         this.$toast.error('Invalid files were given!')
         setTimeout(this.$toast.clear, 30000)

--- a/mobile-browser-based-version/src/core/dataset/data_loader/data_loader.ts
+++ b/mobile-browser-based-version/src/core/dataset/data_loader/data_loader.ts
@@ -1,4 +1,4 @@
-import { Dataset, LabelledDataset } from '../dataset_builder'
+import { Dataset } from '../dataset_builder'
 
 export type Source = string | File
 export type DataConfig = { features?: string[], labels?: string[] }
@@ -7,13 +7,4 @@ export abstract class DataLoader {
   abstract load (source: Source, config: DataConfig): Dataset
 
   abstract loadAll (sources: Source[], config: DataConfig): Dataset
-
-  static flattenDataset (dataset: LabelledDataset): LabelledDataset {
-    return dataset.map(({ xs, ys }) => {
-      return {
-        xs: Object.values(xs),
-        ys: Object.values(ys)
-      }
-    })
-  }
 }

--- a/mobile-browser-based-version/src/core/dataset/data_loader/image_loader.ts
+++ b/mobile-browser-based-version/src/core/dataset/data_loader/image_loader.ts
@@ -39,12 +39,12 @@ export class ImageLoader extends DataLoader {
             }
             index++
             return {
-              value: withLabels ? { xs: sample, ys: label } : sample,
+              value: withLabels ? { xs: [sample], ys: label } : sample,
               done: false
             }
           }
           return {
-            value: withLabels ? { xs: sample, ys: label } : sample,
+            value: withLabels ? { xs: [sample], ys: label } : sample,
             done: true
           }
         }
@@ -57,10 +57,13 @@ export class ImageLoader extends DataLoader {
     if (typeof source === 'string') {
       // Node environment
       const tfNode = require('@tensorflow/tfjs-node')
-      return tfNode.node.decodeImage(fs.readFileSync(source))
+      const image = tfNode.node.decodeImage(fs.readFileSync(source))
+      return image
     } else if (source instanceof File) {
-      // TODO: Browser environment
-      return tf.tensor([1]) // tf.browser.fromPixels(image)
+      // Browser environment
+      // TODO: synchronous loading of image sample
+      // return tf.browser.fromPixels(await createImageBitmap(source))
+      return tf.tensor([1])
     } else {
       throw new Error('not implemented')
     }

--- a/mobile-browser-based-version/src/core/dataset/data_loader/image_loader.ts
+++ b/mobile-browser-based-version/src/core/dataset/data_loader/image_loader.ts
@@ -39,12 +39,12 @@ export class ImageLoader extends DataLoader {
             }
             index++
             return {
-              value: withLabels ? { xs: [sample], ys: label } : sample,
+              value: withLabels ? { xs: [sample], ys: [label] } : sample,
               done: false
             }
           }
           return {
-            value: withLabels ? { xs: [sample], ys: label } : sample,
+            value: withLabels ? { xs: [sample], ys: [label] } : sample,
             done: true
           }
         }

--- a/mobile-browser-based-version/src/core/dataset/data_loader/tabular_loader.ts
+++ b/mobile-browser-based-version/src/core/dataset/data_loader/tabular_loader.ts
@@ -47,7 +47,12 @@ export class TabularLoader extends DataLoader {
       delimiter: this.delimiter
     }
     const dataset = TabularLoader.loadTabularDatasetFrom(source, csvConfig)
-    return DataLoader.flattenDataset(dataset as any)
+    return (dataset as any).map(({ xs, ys }) => {
+      return {
+        xs: Object.values(xs),
+        ys: Object.values(ys)
+      }
+    })
   }
 
   /**

--- a/mobile-browser-based-version/src/core/dataset/dataset_builder.ts
+++ b/mobile-browser-based-version/src/core/dataset/dataset_builder.ts
@@ -3,7 +3,6 @@ import * as tf from '@tensorflow/tfjs'
 import { Task } from '../task/task'
 
 export type Dataset = tf.data.Dataset<tf.TensorContainer>
-export type LabelledDataset = tf.data.Dataset<{ xs: tf.TensorContainer[], ys: tf.TensorContainer[] }>
 
 export class DatasetBuilder {
   private task: Task

--- a/mobile-browser-based-version/src/core/training/disco.ts
+++ b/mobile-browser-based-version/src/core/training/disco.ts
@@ -11,7 +11,7 @@ import * as tf from '@tensorflow/tfjs'
 /**
  * Handles the training loop, server communication & provides the user with feedback.
  */
-export class TrainingManager {
+export class Disco {
   platform: Platform
   task: Task
   client: Client
@@ -40,7 +40,7 @@ export class TrainingManager {
   }
 
   /**
-   * Connects the TrainingManager to the server
+   * Connects the Disco instance to the server
    */
   async connect (): Promise<void> {
     try {

--- a/mobile-browser-based-version/src/core/training/trainer/trainer.ts
+++ b/mobile-browser-based-version/src/core/training/trainer/trainer.ts
@@ -69,7 +69,7 @@ export abstract class Trainer {
   }
 
   /**
-   * Request stop training to be used from the training_manager or any class that is taking care of the trainer.
+   * Request stop training to be used from the Disco instance or any class that is taking care of the trainer.
    */
   stopTraining () {
     this.stopTrainingRequested = true

--- a/mobile-browser-based-version/tests/core/dataset/data_loader/image_loader.test.ts
+++ b/mobile-browser-based-version/tests/core/dataset/data_loader/image_loader.test.ts
@@ -26,7 +26,7 @@ describe('image loader test', () => {
     const imageContent = tfNode.node.decodeImage(fs.readFileSync(path))
     const datasetContent = await new ImageLoader().load(path, { labels: ['example'] }).toArray()
     expect((datasetContent[0] as any).xs[0].shape).eql(imageContent.shape)
-    expect((datasetContent[0] as any).ys).eql(['example'])
+    expect((datasetContent[0] as any).ys[0]).eql('example')
   })
 
   it('load multiple cifar10 samples with labels', async () => {
@@ -41,7 +41,7 @@ describe('image loader test', () => {
     _.forEach(
       _.zip(datasetContent, imagesContent, labels), ([actual, sample, label]) => {
         expect((actual as any).xs[0].shape).eql(sample.shape)
-        expect((actual as any).ys).eql(label)
+        expect((actual as any).ys[0]).eql(label)
       }
     )
   })

--- a/mobile-browser-based-version/tests/core/dataset/data_loader/image_loader.test.ts
+++ b/mobile-browser-based-version/tests/core/dataset/data_loader/image_loader.test.ts
@@ -1,6 +1,6 @@
 import { expect, assert } from 'chai'
 import { ImageLoader } from '../../../../src/core/dataset/data_loader/image_loader'
-import { TrainingManager } from '../../../../src/core/training/training_manager'
+import { Disco } from '../../../../src/core/training/disco'
 import { loadTasks } from '../../../../src/core/task/utils'
 import { Platform } from '../../../../src/platforms/platform'
 import { logger } from '../../../../src/core/logging/console_logger'
@@ -59,9 +59,9 @@ describe('image loader test', () => {
 
     const dataset = new ImageLoader().loadAll(files, { labels: labels })
     const cifar10 = (await loadTasks())[3]
-    const trainingManager = new TrainingManager(cifar10, Platform.federated, logger, false)
-    trainingManager.startTraining(dataset, false)
+    const disco = new Disco(cifar10, Platform.federated, logger, false)
+    disco.startTraining(dataset, false)
     await timer(500) // TODO: ugly
-    assert(trainingManager.isTraining)
+    assert(disco.isTraining)
   })
 })

--- a/mobile-browser-based-version/tests/core/dataset/data_loader/image_loader.test.ts
+++ b/mobile-browser-based-version/tests/core/dataset/data_loader/image_loader.test.ts
@@ -62,6 +62,6 @@ describe('image loader test', () => {
     const trainingManager = new TrainingManager(cifar10, Platform.federated, logger, false)
     trainingManager.startTraining(dataset, false)
     await timer(500) // TODO: ugly
-    assert(trainingManager.trainer)
+    assert(trainingManager.isTraining)
   })
 })

--- a/mobile-browser-based-version/tests/training_manager.test.ts
+++ b/mobile-browser-based-version/tests/training_manager.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { loadTasks } from '../src/core/task/utils'
 import { TabularLoader } from '../src/core/dataset/data_loader/tabular_loader'
-import { TrainingManager } from '../src/core/training/training_manager'
+import { Disco } from '../src/core/training/disco'
 import { logger } from '../src/core/logging/console_logger'
 import { Platform } from '../src/platforms/platform'
 
@@ -19,7 +19,7 @@ describe('train test', () => {
         labels: titanic.trainingInformation.outputColumns
       }
     )
-    const trainer = new TrainingManager(titanic, platform, logger, false)
+    const trainer = new Disco(titanic, platform, logger, false)
 
     await trainer.connect()
     expect(trainer.isConnected).true


### PR DESCRIPTION
This PR enables training from an image dataset on Node.js. This is ensured by two new tests:
1. loading a small subset of CIFAR10
2. training from this small dataset

@Nacho114 wdyt of test 2 (`tests/core/image_loader.test.ts`)? You might want to reproduce the same code for the benchmarks, I'm afraid chai might not be reporting any error thrown during the training loop, despite the timer I set.