### PR TITLE
281 batches nacho

### DIFF
--- a/browser/src/training/disco.ts
+++ b/browser/src/training/disco.ts
@@ -123,7 +123,7 @@ export class Disco {
 
     // TODO: dataset.size = null, since we build it with an iterator (issues occurs with ImageLoader) see issue 279
     await this.initTrainer()
-    await this.trainer.trainModel(data.dataset, data.size)
+    await this.trainer.trainModel(data.dataset)
   }
 
   /**

--- a/browser/src/training/trainer/round_tracker.ts
+++ b/browser/src/training/trainer/round_tracker.ts
@@ -3,25 +3,20 @@
  *
  * @remark
  * In distributed training, the client trains locally for a certain amount of epochs before sharing his weights to the server/neighbor, this
- * is what we call a round. A round is measured in epochs (1 round == 1 epoch), a round can be any number > 0, if roundDuration = 0.5, then
- * every half epoch we share our weights with the server.
+ * is what we call a round.
  *
  * The role of the RoundTracker is to keep track of when a roundHasEnded using the current batch number. The batch in the RoundTracker is cumulative whereas
  * in the onBatchEnd it is not (it resets to 0 after each epoch).
+ *
+ * The roundDuration is the length of a round (in batches).
  */
 export class RoundTracker {
     round: number = 0;
     batch: number = 0;
     roundDuration: number;
-    numberOfBatchesInAnEpoch: number
-    batchesPerRound: number
 
-    constructor (roundDuration: number, trainSize: number, batchSize: number) {
+    constructor (roundDuration: number) {
       this.roundDuration = roundDuration
-      this.numberOfBatchesInAnEpoch = RoundTracker.numberOfBatchesInAnEpoch(trainSize, batchSize)
-      this.batchesPerRound = Math.floor(this.numberOfBatchesInAnEpoch * this.roundDuration)
-
-      console.log(`RoundTracker: roundDuration: ${roundDuration}, nb batches in an epoch ${this.numberOfBatchesInAnEpoch}`)
     }
 
     /**
@@ -37,29 +32,13 @@ export class RoundTracker {
    *
    * @remark
    * Returns true if (batch) mod (batches per round) == 0, false otherwise
-   *
-   * E.g if there are 1000 samples in total, and roundDuration is
-   * 2.5, withBatchSize 100, then if batch is a multiple of 25, the local round has ended.
-   *
    */
     roundHasEnded (): boolean {
       if (this.batch === 0) {
         return false
       }
 
-      const roundHasEnded = this.batch % this.batchesPerRound === 0
-      if (roundHasEnded) {
-        this.round += 1
-        console.log('Round has ended.')
-      }
+      const roundHasEnded = this.batch % this.roundDuration === 0
       return roundHasEnded
-    }
-
-    /**
-   * Return the number of batches in an epoch given train size batch size
-   */
-    static numberOfBatchesInAnEpoch (trainSize: number, batchSize: number) {
-      const carryOver = trainSize % batchSize === 0 ? 0 : 1
-      return Math.floor(trainSize / batchSize) + carryOver
     }
 }

--- a/browser/src/training/trainer/trainer.ts
+++ b/browser/src/training/trainer/trainer.ts
@@ -79,19 +79,18 @@ export abstract class Trainer {
    * @param trainSize number of samples in the training set
    * @returns
    */
-  private initRoundTracker (trainSize: number) {
-    const batchSize = this.task.trainingInformation.batchSize
+  private initRoundTracker () {
     const roundDuration = this.task.trainingInformation.roundDuration
-    this.roundTracker = new RoundTracker(roundDuration, trainSize, batchSize)
+    this.roundTracker = new RoundTracker(roundDuration)
   }
 
   /**
    * Start training the model with the given dataset
    * @param dataset
    */
-  async trainModel (dataset: tf.data.Dataset<tf.TensorContainer>, trainSize: number) {
+  async trainModel (dataset: tf.data.Dataset<tf.TensorContainer>) {
     // Init round tracker - requires size info
-    this.initRoundTracker(trainSize)
+    this.initRoundTracker()
 
     // Reset stopTraining setting
     this.resetStopTrainerState()

--- a/browser/tests/communication/round_tracker.test.ts
+++ b/browser/tests/communication/round_tracker.test.ts
@@ -2,80 +2,23 @@ import { expect } from 'chai'
 
 import { RoundTracker } from '../../src/training/trainer/round_tracker'
 
-const roundDurationIsOne = [
-  // batch, batchSize, trainSize, roundDuration, epoch
-  { values: [2, 5, 10, 1, 0], output: true },
-  { values: [2, 5, 10, 1, 1], output: true },
-  { values: [0, 5, 10, 1, 0], output: false },
-  { values: [1, 5, 10, 1, 0], output: false }
-]
+const roundDuration = 2
 
-const roundDurationLessThanOne = [
-  // batch, batchSize, trainSize, roundDuration, epoch
-  { values: [5, 1, 10, 0.5, 0], output: true },
-  { values: [10, 1, 10, 0.5, 0], output: true },
-  { values: [5, 1, 10, 0.55, 0], output: true },
-  { values: [12, 1, 10, 0.6, 0], output: true },
-  { values: [2, 1, 10, 0.3, 1], output: true },
-  { values: [2, 1, 10, 0.3, 1], output: true },
-  { values: [3, 1, 10, 0.3, 0], output: true }
-]
-
-const roundDurationGreaterThanOne = [
-  // batch, batchSize, trainSize, roundDuration, epoch
-  { values: [5, 1, 10, 1.5, 1], output: true },
-  { values: [5, 1, 10, 1.5, 4], output: true },
-  { values: [4, 1, 10, 1.5, 1], output: false },
-  { values: [5, 1, 10, 1.5, 0], output: false }
-]
-
-describe('RoundTracker test: _numberOfBatchesInAnEpoch', () => {
-  it('Simple test', () => {
-    let batchSize = 5
-    let trainSize = 10
-    expect(RoundTracker.numberOfBatchesInAnEpoch(trainSize, batchSize)).equal(2)
-    // Titanic example
-    batchSize = 4
-    trainSize = 10
-    expect(RoundTracker.numberOfBatchesInAnEpoch(trainSize, batchSize)).equal(3)
+describe('RoundTracker test:', () => {
+  it('at init false', () => {
+    const roundTracker = new RoundTracker(roundDuration)
+    expect(roundTracker.roundHasEnded()).equal(false)
   })
-})
+  it('before round ended false', () => {
+    const roundTracker = new RoundTracker(roundDuration)
+    roundTracker.updateBatch()
+    expect(roundTracker.roundHasEnded()).equal(false)
+  })
 
-describe('RoundTracker test: _localRoundHasEnded', () => {
-  it('Case: roundDuration == 1', () => {
-    roundDurationIsOne.forEach((example) => {
-      const batch = example.values[0]
-      const batchSize = example.values[1]
-      const trainSize = example.values[2]
-      const roundDuration = example.values[3]
-      const epoch = example.values[4]
-      const roundTracker = new RoundTracker(roundDuration, trainSize, batchSize)
-      roundTracker.batch = batch + epoch * roundTracker.numberOfBatchesInAnEpoch
-      expect(roundTracker.roundHasEnded()).equal(example.output)
-    })
-  })
-  it('Case: roundDuration < 1', () => {
-    roundDurationLessThanOne.forEach((example) => {
-      const batch = example.values[0]
-      const batchSize = example.values[1]
-      const trainSize = example.values[2]
-      const roundDuration = example.values[3]
-      const epoch = example.values[4]
-      const roundTracker = new RoundTracker(roundDuration, trainSize, batchSize)
-      roundTracker.batch = batch + epoch * roundTracker.numberOfBatchesInAnEpoch
-      expect(roundTracker.roundHasEnded()).equal(example.output)
-    })
-  })
-  it('Case: roundDuration > 1', () => {
-    roundDurationGreaterThanOne.forEach((example) => {
-      const batch = example.values[0]
-      const batchSize = example.values[1]
-      const trainSize = example.values[2]
-      const roundDuration = example.values[3]
-      const epoch = example.values[4]
-      const roundTracker = new RoundTracker(roundDuration, trainSize, batchSize)
-      roundTracker.batch = batch + epoch * roundTracker.numberOfBatchesInAnEpoch
-      expect(roundTracker.roundHasEnded()).equal(example.output)
-    })
+  it('round ended true when ended', () => {
+    const roundTracker = new RoundTracker(roundDuration)
+    roundTracker.updateBatch()
+    roundTracker.updateBatch()
+    expect(roundTracker.roundHasEnded()).equal(true)
   })
 })

--- a/browser/tests/dataset/data_loader/image_loader.test.ts
+++ b/browser/tests/dataset/data_loader/image_loader.test.ts
@@ -69,11 +69,7 @@ describe('image loader test', () => {
     const labels = _.map(_.range(24), (label) => (label % 10).toString())
 
     const cifar10 = (await loadTasks())[3]
-    const loaded = await new NodeImageLoader(cifar10).loadAll(files, { labels: labels })
-
-    const logger = new ConsoleLogger()
-    const disco = new Disco(cifar10, logger, false)
-
-    await disco.startTraining(loaded, TrainingSchemes.FEDERATED)
+    await new NodeImageLoader(cifar10).loadAll(files, { labels: labels })
+    // TODO: implement test?
   }).timeout(5 * 60 * 1000)
 })

--- a/browser/tests/dataset/data_loader/image_loader.test.ts
+++ b/browser/tests/dataset/data_loader/image_loader.test.ts
@@ -3,9 +3,7 @@ import * as tfNode from '@tensorflow/tfjs-node'
 import fs from 'fs'
 import _ from 'lodash'
 
-import { ConsoleLogger, dataset, TrainingSchemes } from 'discojs'
-
-import { Disco } from '../../../src/training/disco'
+import { dataset } from 'discojs'
 import { loadTasks } from '../../../src/tasks'
 
 export class NodeImageLoader extends dataset.ImageLoader<string> {

--- a/server/tasks/tasks.json
+++ b/server/tasks/tasks.json
@@ -41,7 +41,7 @@
     "trainingInformation": {
       "modelID": "titanic-model",
       "epochs": 20,
-      "roundDuration": 1,
+      "roundDuration": 10,
       "validationSplit": 0.2,
       "batchSize": 30,
       "preprocessFunctions": [],
@@ -81,7 +81,7 @@
     "trainingInformation": {
       "modelID": "mnist-model",
       "epochs": 10,
-      "roundDuration": 5,
+      "roundDuration": 10,
       "validationSplit": 0.2,
       "batchSize": 30,
       "modelCompileData": {
@@ -115,7 +115,7 @@
     "trainingInformation": {
       "modelID": "lus-covid-model",
       "epochs": 15,
-      "roundDuration": 5,
+      "roundDuration": 10,
       "validationSplit": 0.2,
       "batchSize": 2,
       "modelCompileData": {
@@ -150,7 +150,7 @@
     "trainingInformation": {
       "modelID": "cifar10-model",
       "epochs": 10,
-      "roundDuration": 5,
+      "roundDuration": 10,
       "validationSplit": 0.2,
       "batchSize": 10,
       "modelCompileData": {
@@ -197,7 +197,7 @@
     "trainingInformation": {
       "modelID": "simple_face-model",
       "epochs": 50,
-      "roundDuration": 2,
+      "roundDuration": 10,
       "validationSplit": 0.2,
       "batchSize": 10,
       "modelCompileData": {


### PR DESCRIPTION
Simplify the roundTracker, now rounds are in batches, no longer depend on size of data to compute epoch length. 

fixes #281