### PR TITLE
Fix testing redirection & model library

### DIFF
--- a/browser/src/components/Finished.vue
+++ b/browser/src/components/Finished.vue
@@ -52,25 +52,22 @@ export default {
       default: undefined
     }
   },
-  data (): { memory: Memory } {
-    return {
-      memory: undefined
-    }
-  },
   computed: {
-    ...mapState(['useIndexedDB'])
-  },
-  watch: {
-    useIndexedDB (newValue: boolean) {
-      this.memory = newValue ? new IndexedDB() : new EmptyMemory()
+    ...mapState(['useIndexedDB', 'models']),
+    memory (): Memory {
+      return this.usedIndexedDB ? new IndexedDB() : new EmptyMemory()
     }
   },
   methods: {
     ...mapMutations(['setTestingModel']),
     testModel () {
-      const path = pathFor(ModelType.WORKING, this.task.taskID, this.task.trainingInformation.modelID)
-      this.setTestingModel(path)
-      this.$router.push({ path: '/testing' })
+      if (this.memory.contains(ModelType.WORKING, this.task.taskID, this.task.trainingInformation.modelID)) {
+        this.setTestingModel(pathFor(ModelType.WORKING, this.task.taskID, this.task.trainingInformation.modelID))
+        this.$router.push({ path: '/testing' })
+      } else {
+        this.$toast.error('Model was not trained!')
+        setTimeout(this.$toast.clear, 30000)
+      }
     },
     async saveModel () {
       if (!(this.memory instanceof EmptyMemory)) {

--- a/browser/src/components/containers/IconCard.vue
+++ b/browser/src/components/containers/IconCard.vue
@@ -53,9 +53,9 @@
   </div>
 </template>
 
-<script type="ts">
-import DownArrow from '../../assets/svg/DownArrow.vue'
-import UpArrow from '../../assets/svg/UpArrow.vue'
+<script lang="ts">
+import DownArrow from '@/assets/svg/DownArrow.vue'
+import UpArrow from '@/assets/svg/UpArrow.vue'
 export default {
   name: 'IconCard',
   components: {

--- a/browser/src/components/pages/Features.vue
+++ b/browser/src/components/pages/Features.vue
@@ -1,8 +1,5 @@
 <template>
-  <base-layout
-    :with-section="true"
-    custom-class="pt-4"
-  >
+  <div>
     <!-- Progress Bar -->
     <div class="w-full py-6">
       <div class="flex">
@@ -209,11 +206,10 @@
         </div>
       </card>
     </div>
-  </base-layout>
+  </div>
 </template>
 
 <script>
-import BaseLayout from '../containers/BaseLayout.vue'
 import Card from '../containers/Card.vue'
 import { useI18n } from 'vue-i18n'
 import { defineComponent } from 'vue'
@@ -221,7 +217,6 @@ import { defineComponent } from 'vue'
 export default defineComponent({
   name: 'Features',
   components: {
-    BaseLayout,
     Card
   },
   setup () {

--- a/browser/src/components/pages/Further.vue
+++ b/browser/src/components/pages/Further.vue
@@ -1,8 +1,5 @@
 <template>
-  <base-layout
-    :with-section="true"
-    custom-class="pt-4"
-  >
+  <div>
     <!-- Progress Bar -->
     <div class="w-full py-6">
       <div class="flex">
@@ -261,11 +258,10 @@
         </div>
       </card>
     </div>
-  </base-layout>
+  </div>
 </template>
 
 <script>
-import BaseLayout from '../containers/BaseLayout.vue'
 import Card from '../containers/Card.vue'
 import { useI18n } from 'vue-i18n'
 import { defineComponent } from 'vue'
@@ -273,7 +269,6 @@ import { defineComponent } from 'vue'
 export default defineComponent({
   name: 'Further',
   components: {
-    BaseLayout,
     Card
   },
   setup () {

--- a/browser/src/components/pages/Home.vue
+++ b/browser/src/components/pages/Home.vue
@@ -1,10 +1,7 @@
 <template>
   <div>
     <!-- Disco logo -->
-    <img
-      :src="discoWelcome"
-      class="mx-auto"
-    >
+    <Disco class="mx-auto mb-[5%]" />
 
     <!-- Main cards -->
     <div class="grid grid-cols-3 gap-8 items-stretch">
@@ -55,12 +52,15 @@
 </template>
 
 <script lang="ts">
+import Disco from '@/assets/svg/Disco.vue'
 import ButtonCard from '@/components/containers/ButtonCard.vue'
+import { defineComponent } from 'vue'
 
-export default {
+export default defineComponent({
   name: 'Home',
   components: {
-    ButtonCard
+    ButtonCard,
+    Disco
   },
   data () {
     return {
@@ -78,5 +78,5 @@ export default {
       this.$router.push({ path: '/testing' })
     }
   }
-}
+})
 </script>

--- a/browser/src/components/pages/Tutorial.vue
+++ b/browser/src/components/pages/Tutorial.vue
@@ -1,8 +1,5 @@
 <template>
-  <base-layout
-    :with-section="true"
-    custom-class="pt-4"
-  >
+  <div>
     <!-- Progress Bar -->
     <div class="w-full py-6">
       <div class="flex">
@@ -232,20 +229,18 @@
         </div>
       </card>
     </div>
-  </base-layout>
+  </div>
 </template>
 
 <script>
-import BaseLayout from '../containers/BaseLayout.vue'
-import Card from '../containers/Card.vue'
-import CustomButton from '../simple/CustomButton.vue'
+import Card from '@/components/containers/Card.vue'
+import CustomButton from '@/components/simple/CustomButton.vue'
 import { useI18n } from 'vue-i18n'
 import { defineComponent } from 'vue'
 
 export default defineComponent({
   name: 'Tutorial',
   components: {
-    BaseLayout,
     Card,
     CustomButton
   },

--- a/browser/src/components/sidebar/ModelLibrary.vue
+++ b/browser/src/components/sidebar/ModelLibrary.vue
@@ -57,7 +57,7 @@
             <div class="w-1/9">
               <button
                 :class="buttonClass(isDark)"
-                @click="deleteModel(path)"
+                @click="deleteModel(path, metadata)"
               >
                 <span><Bin2Icon /></span>
               </button>
@@ -115,7 +115,7 @@ export default {
       return this.useIndexedDB ? new IndexedDB() : new EmptyMemory()
     }
   },
-  async mounted () {
+  async mounted (): Promise<void> {
     await this.$store.dispatch('initModels')
   },
   methods: {
@@ -131,10 +131,9 @@ export default {
       this.$emit('switch-panel')
     },
 
-    deleteModel (path: string): void {
-      const metadata = this.models.get(path)
+    deleteModel (path: string, metadata): void {
       this.$store.commit('deleteModel', path)
-      this.memory.deleteSavedModel(metadata.taskID, metadata.modelName)
+      this.memory.deleteModel(metadata.modelType, metadata.taskID, metadata.name)
     },
 
     openTesting (metadata) {

--- a/browser/src/components/sidebar/ModelLibrary.vue
+++ b/browser/src/components/sidebar/ModelLibrary.vue
@@ -44,7 +44,7 @@
           >
             <div
               class="cursor-pointer w-2/3"
-              @click="openTesting(metadata)"
+              @click="openTesting(path)"
             >
               <span>
                 {{ metadata.name.substring(0, 16) }} <br>
@@ -85,7 +85,7 @@
   </TippyContainer>
 </template>
 <script lang="ts">
-import { mapState } from 'vuex'
+import { mapMutations, mapState } from 'vuex'
 
 import { Memory, EmptyMemory } from 'discojs'
 
@@ -119,6 +119,8 @@ export default {
     await this.$store.dispatch('initModels')
   },
   methods: {
+    ...mapMutations(['setTestingModel']),
+
     buttonClass: function (state: boolean) {
       return `flex items-center grid-cols-3 justify-between px-4 py-2 space-x-4 transition-colors border rounded-md hover:text-gray-900 hover:border-gray-900 dark:border-primary dark:hover:text-primary-100 dark:hover:border-primary-light focus:outline-none focus:ring focus:ring-primary-lighter focus:ring-offset-2 dark:focus:ring-offset-dark dark:focus:ring-primary-dark ${
         state
@@ -136,8 +138,9 @@ export default {
       this.memory.deleteModel(metadata.modelType, metadata.taskID, metadata.name)
     },
 
-    openTesting (metadata) {
-      this.$router.push({ name: metadata.taskID.concat('.testing') })
+    openTesting (path: string) {
+      this.setTestingModel(path)
+      this.$router.push({ path: '/testing' })
     },
 
     downloadModel (metadata) {

--- a/browser/src/components/testing/NewTesting.vue
+++ b/browser/src/components/testing/NewTesting.vue
@@ -79,12 +79,15 @@
       <div v-else>
         <IconCard>
           <template #title>
-            No registerd model
+            No registered model
           </template>
           <template #content>
-            Please go to the <RouterLink to="/list">
-              training page
-            </RouterLink>.
+            Please go to the <RouterLink
+              class="underline font-bold"
+              to="/list"
+            >
+              training page.
+            </RouterLink>
           </template>
         </IconCard>
       </div>
@@ -109,7 +112,7 @@ import TestingBar from '@/components/testing/TestingBar.vue'
 import DatasetInput from '@/components/dataset_input/DatasetInput.vue'
 // import Testing from '@/components/testing/Testing.vue'
 import ButtonCard from '@/components/containers/ButtonCard.vue'
-import IconCard from '@/components/containers/Card.vue'
+import IconCard from '@/components/containers/IconCard.vue'
 import { IndexedDB } from '@/memory'
 import { WebTabularLoader, WebImageLoader } from '@/data_loader'
 
@@ -162,11 +165,23 @@ export default {
   },
   watch: {
     testingModel (path: string) {
-      this.step = 0
-      this.selectModel(path, this.models.get(path))
+      const metadata = this.models.get(path)
+      if (metadata !== undefined) {
+        this.selectModel(path, metadata)
+      }
     }
   },
   async mounted (): Promise<void> {
+    await this.$store.dispatch('initModels')
+    // can't watch before mount
+    if (this.testingModel !== undefined) {
+      const metadata = this.models.get(this.testingModel)
+      if (metadata !== undefined) {
+        this.selectModel(this.testingModel, metadata)
+      }
+    }
+  },
+  async activated (): Promise<void> {
     await this.$store.dispatch('initModels')
   },
   methods: {
@@ -178,7 +193,7 @@ export default {
       } else {
         throw new Error('model\'s task does not exist locally')
       }
-      this.step += 1
+      this.step = 1
     },
     prevStep (): void {
       this.step -= 1

--- a/browser/src/memory.ts
+++ b/browser/src/memory.ts
@@ -23,6 +23,10 @@ export class IndexedDB extends Memory {
     return models[key]
   }
 
+  async contains (type: ModelType, taskID: string, modelName: string): Promise<boolean> {
+    return await this.getModelMetadata(type, taskID, modelName) !== undefined
+  }
+
   async getModel (type: ModelType, taskID: string, modelName: string): Promise<tf.LayersModel> {
     return await tf.loadLayersModel(pathFor(type, taskID, modelName))
   }

--- a/browser/src/store/index.ts
+++ b/browser/src/store/index.ts
@@ -1,6 +1,6 @@
 import { loadTasks } from '@/tasks'
 
-import { Task } from 'discojs'
+import { ModelType, Task } from 'discojs'
 import { ActionContext, createStore } from 'vuex'
 import * as tf from '@tensorflow/tfjs'
 
@@ -39,7 +39,7 @@ export const store = createStore({
       for (const path in models) {
         // eslint-disable-next-line no-unused-vars
         const [location, _, directory, task, name] = path.split('/')
-        if (!(location === 'indexeddb:' && directory === 'saved')) {
+        if (location !== 'indexeddb:') {
           continue
         }
 
@@ -67,7 +67,7 @@ export const store = createStore({
             metadata: {
               name: name,
               taskID: task,
-              modelType: directory,
+              modelType: directory === 'working' ? ModelType.WORKING : ModelType.SAVED,
               date: dateSaved,
               hours: hourSaved,
               fileSize: Math.round(size / 1024)

--- a/discojs/src/client/federated.ts
+++ b/discojs/src/client/federated.ts
@@ -13,7 +13,7 @@ import { Base } from './base'
 export class Federated extends Base {
   private readonly clientID = randomUUID()
   private readonly peer: any
-  private round = -1 // The server starts at round 0, in the beginning we are behind
+  private round = 0
 
   private urlTo (category: string): string {
     const url = new URL('', this.url)

--- a/discojs/src/memory/base.ts
+++ b/discojs/src/memory/base.ts
@@ -5,52 +5,58 @@ import { ModelType } from './model_type'
 
 export abstract class Memory {
   /**
-  * Fetches metadata of the model.
-  * @param taskID the working model's corresponding task
-  * @param modelName the working model's file name
-  */
+   * Fetches metadata of the model.
+   * @param taskID the working model's corresponding task
+   * @param modelName the working model's file name
+   */
   abstract getModelMetadata (type: ModelType, taskID: TaskID, modelName: string): Promise<tf.io.ModelArtifactsInfo | undefined>
 
   /**
-  * Loads the current working model and returns it as a fresh TFJS object.
-  * @param taskID the working model's corresponding task
-  * @param modelName the working model's file name
-  */
+   * Loads the current working model and returns it as a fresh TFJS object.
+   * @param taskID the working model's corresponding task
+   * @param modelName the working model's file name
+   */
   abstract getModel (type: ModelType, taskID: TaskID, modelName: string): Promise<tf.LayersModel>
 
   /**
- * Loads a model from the model library into the current working model.
- * @param taskID the saved model's corresponding task
- * @param modelName the saved model's file name
- */
+   * Loads a model from the model library into the current working model.
+   * @param taskID the saved model's corresponding task
+   * @param modelName the saved model's file name
+   */
   abstract loadSavedModel (taskID: TaskID, modelName: string): Promise<void>
 
   /**
- * Loads a fresh TFJS model object into the current working model.
- * @param taskID the working model's corresponding task
- * @param modelName the working model's file name
- * @param model the fresh model
- */
+   * Loads a fresh TFJS model object into the current working model.
+   * @param taskID the working model's corresponding task
+   * @param modelName the working model's file name
+   * @param model the fresh model
+   */
   abstract updateWorkingModel (taskID: TaskID, modelName: string, model: tf.LayersModel): Promise<void>
 
   /**
- * Adds the current working model to the model library.
- * @param taskID the working model's corresponding task
- * @param modelName the working model's file name
- */
+   * Adds the current working model to the model library.
+   * @param taskID the working model's corresponding task
+   * @param modelName the working model's file name
+   */
   abstract saveWorkingModel (taskID: TaskID, modelName: string): Promise<void>
 
   /**
- * Removes the model from the library.
- * @param taskID the model's corresponding task
- * @param modelName the model's file name
- */
+   * Removes the model from the library.
+   * @param taskID the model's corresponding task
+   * @param modelName the model's file name
+   */
   abstract deleteModel (type: ModelType, taskID: TaskID, modelName: string): Promise<void>
 
   /**
- * Downloads a previously saved model.
- * @param String} taskID the saved model's corresponding task
- * @param String} modelName the saved model's file name
- */
+   * Downloads a previously saved model.
+   * @param {taskID} taskID the saved model's corresponding task
+   * @param {string} modelName the saved model's file name
+   */
   abstract downloadSavedModel (taskID: TaskID, modelName: string): Promise<void>
+
+  /**
+   * @param {taskID} taskID
+   * @param {string} modelName
+   */
+  abstract contains (modelType: ModelType, taskID: TaskID, modelName: string): Promise<boolean>
 }

--- a/discojs/src/memory/empty.ts
+++ b/discojs/src/memory/empty.ts
@@ -7,6 +7,10 @@ export class Empty extends Memory {
     return undefined
   }
 
+  async contains (): Promise<boolean> {
+    return false
+  }
+
   async getModel (): Promise<tf.LayersModel> {
     throw new Error('empty')
   }


### PR DESCRIPTION
There were some remaining bugs related to IndexedDB and the Vue store. The changes are:
- finished step
  - redirects to the correct model in the "model testing" page
  - correctly initializes its memory
  - handles untrained tasks
- model library
  - displays both working and saved models (closes #315)
  - correctly deletes models
  - is consistent w.r.t. IndexedDB content
 
Additionally:
- the UI for information pages uses a single `BaseLayout` to avoid duplicate footers
- the testing page is displayed correctly when no model is available
- federated client starts at round 0 instead of -1 to avoid stalling in the beginning and thus losing a round