### PR TITLE
Validation split

### DIFF
--- a/browser/src/components/training/Training.vue
+++ b/browser/src/components/training/Training.vue
@@ -33,7 +33,10 @@
 
     <!-- Training Board -->
     <div>
-      <TrainingInformation :training-informant="trainingInformant" />
+      <TrainingInformation
+        :training-informant="trainingInformant"
+        :has-validation-data="hasValidationData"
+      />
     </div>
   </div>
 </template>
@@ -106,6 +109,9 @@ export default defineComponent({
       }
       // default scheme
       return TrainingSchemes.LOCAL
+    },
+    hasValidationData (): boolean {
+      return this.task?.trainingInformation?.validationSplit > 0
     }
   },
   watch: {

--- a/browser/src/components/training/TrainingInformation.vue
+++ b/browser/src/components/training/TrainingInformation.vue
@@ -7,9 +7,15 @@
       x-ref="trainingBoard"
       x-show="isTraining"
     >
-      <div class="grid grid-cols-2 p-4 gap-8">
+      <div
+        class="grid p-4 gap-8"
+        :class="hasValidationData ? 'grid-cols-2' : 'grid-cols-1'"
+      >
         <!-- Validation Accuracy users chart -->
-        <div class="bg-white rounded-md">
+        <div
+          v-if="hasValidationData"
+          class="bg-white rounded-md basis-0"
+        >
           <!-- Card header -->
           <div class="p-4 border-b">
             <h4 class="text-lg font-semibold text-slate-500">
@@ -41,7 +47,7 @@
         </div>
 
         <!-- Training Accuracy users chart -->
-        <div class="bg-white rounded-md">
+        <div class="bg-white rounded-md basis-0">
           <!-- Card header -->
           <div class="p-4 border-b">
             <h4 class="text-lg font-semibold text-slate-500">
@@ -195,6 +201,10 @@ export default defineComponent({
     trainingInformant: {
       type: TrainingInformant,
       default: undefined
+    },
+    hasValidationData: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {

--- a/discojs/src/dataset/data_loader/data_loader.ts
+++ b/discojs/src/dataset/data_loader/data_loader.ts
@@ -1,10 +1,15 @@
 import { Dataset } from '../dataset_builder'
 import { Task } from '../../task'
 
-export interface DataConfig { features?: string[], labels?: string[], shuffle?: boolean }
+export interface DataConfig {features?: string[], labels?: string[], shuffle?: boolean, validationSplit?: number}
 export interface Data {
   dataset: Dataset
   size: number
+}
+
+export interface DataTuple {
+  train: Data
+  validation?: Data
 }
 
 export abstract class DataLoader<Source> {
@@ -16,5 +21,5 @@ export abstract class DataLoader<Source> {
 
   abstract load (source: Source, config: DataConfig): Promise<Dataset>
 
-  abstract loadAll (sources: Source[], config: DataConfig): Promise<Data>
+  abstract loadAll (sources: Source[], config: DataConfig): Promise<DataTuple>
 }

--- a/discojs/src/dataset/data_loader/image_loader.spec.ts
+++ b/discojs/src/dataset/data_loader/image_loader.spec.ts
@@ -1,6 +1,5 @@
 import { assert, expect } from 'chai'
-import * as tf from '@tensorflow/tfjs'
-import * as tfNode from '@tensorflow/tfjs-node'
+import * as tf from '@tensorflow/tfjs-node'
 import fs from 'fs'
 import _ from 'lodash'
 
@@ -8,8 +7,8 @@ import { dataset, tasks } from '../..'
 import { List, Map, Range } from 'immutable'
 
 export class NodeImageLoader extends dataset.ImageLoader<string> {
-  async readImageFrom (source: string): Promise<tfNode.Tensor3D> {
-    return tfNode.node.decodeImage(fs.readFileSync(source)) as tfNode.Tensor3D
+  async readImageFrom (source: string): Promise<tf.Tensor3D> {
+    return tf.node.decodeImage(fs.readFileSync(source)) as tf.Tensor3D
   }
 }
 
@@ -24,24 +23,24 @@ describe('image loader', () => {
   it('loads single sample without label', async () => {
     const file = './example_training_data/9-mnist-example.png'
     const singletonDataset = await new NodeImageLoader(tasks.mnist.task).load(file)
-    const imageContent = tfNode.node.decodeImage(fs.readFileSync(file))
+    const imageContent = tf.node.decodeImage(fs.readFileSync(file))
     await Promise.all((await singletonDataset.toArrayForTest()).map(async (entry) => {
       expect(await imageContent.bytes()).eql(await (entry as tf.Tensor).bytes())
     }))
   })
 
   it('loads multiple samples without labels', async () => {
-    const imagesContent = FILES.CIFAR10.map((file) => tfNode.node.decodeImage(fs.readFileSync(file)))
+    const imagesContent = FILES.CIFAR10.map((file) => tf.node.decodeImage(fs.readFileSync(file)))
     const datasetContent = await (await new NodeImageLoader(tasks.cifar10.task)
       .loadAll(FILES.CIFAR10, { shuffle: false }))
-      .dataset.toArray()
+      .train.dataset.toArray()
     expect(datasetContent.length).equal(imagesContent.length)
-    expect((datasetContent[0] as tfNode.Tensor3D).shape).eql(imagesContent[0].shape)
+    expect((datasetContent[0] as tf.Tensor3D).shape).eql(imagesContent[0].shape)
   })
 
   it('loads single sample with label', async () => {
     const path = DIRS.CIFAR10 + '0.png'
-    const imageContent = tfNode.node.decodeImage(fs.readFileSync(path))
+    const imageContent = tf.node.decodeImage(fs.readFileSync(path))
     const datasetContent = await (await new NodeImageLoader(tasks.cifar10.task)
       .load(path, { labels: ['example'] })).toArray()
     expect((datasetContent[0] as any).xs.shape).eql(imageContent.shape)
@@ -51,12 +50,12 @@ describe('image loader', () => {
   it('loads multiple samples with labels', async () => {
     const labels = _.map(_.range(24), (label) => (label % 10))
     const stringLabels = _.map(labels, (label) => label.toString())
-    const oneHotLabels = tfNode.oneHot(labels, 10).arraySync()
+    const oneHotLabels = tf.oneHot(labels, 10).arraySync()
 
-    const imagesContent = FILES.CIFAR10.map((file) => tfNode.node.decodeImage(fs.readFileSync(file)))
+    const imagesContent = FILES.CIFAR10.map((file) => tf.node.decodeImage(fs.readFileSync(file)))
     const datasetContent = await (await new NodeImageLoader(tasks.cifar10.task)
       .loadAll(FILES.CIFAR10, { labels: stringLabels, shuffle: false }))
-      .dataset.toArray()
+      .train.dataset.toArray()
 
     expect(datasetContent.length).equal(imagesContent.length)
     _.forEach(
@@ -76,7 +75,7 @@ describe('image loader', () => {
 
   it('loads samples in order', async () => {
     const loader = new NodeImageLoader(tasks.cifar10.task)
-    const dataset = await ((await loader.loadAll(FILES.CIFAR10, { shuffle: false })).dataset).toArray()
+    const dataset = await ((await loader.loadAll(FILES.CIFAR10, { shuffle: false })).train.dataset).toArray()
 
     List(dataset).zip(List(FILES.CIFAR10))
       .forEach(async ([s, f]) => {
@@ -102,8 +101,8 @@ describe('image loader', () => {
 
   it('shuffles samples', async () => {
     const loader = new NodeImageLoader(tasks.cifar10.task)
-    const dataset = await (await loader.loadAll(FILES.CIFAR10, { shuffle: false })).dataset.toArray()
-    const shuffled = await (await loader.loadAll(FILES.CIFAR10, { shuffle: true })).dataset.toArray()
+    const dataset = await (await loader.loadAll(FILES.CIFAR10, { shuffle: false })).train.dataset.toArray()
+    const shuffled = await (await loader.loadAll(FILES.CIFAR10, { shuffle: true })).train.dataset.toArray()
 
     const misses = List(dataset).zip(List(shuffled)).map(([d, s]) =>
       tf.notEqual(d as tf.Tensor, s as tf.Tensor).any().dataSync()[0]

--- a/discojs/src/dataset/data_loader/image_loader.ts
+++ b/discojs/src/dataset/data_loader/image_loader.ts
@@ -2,7 +2,7 @@ import * as tf from '@tensorflow/tfjs'
 import { Range } from 'immutable'
 
 import { Dataset } from '../dataset_builder'
-import { DataLoader, DataConfig, Data } from './data_loader'
+import { DataLoader, DataConfig, Data, DataTuple } from './data_loader'
 
 /**
  * TODO @s314cy:
@@ -27,27 +27,14 @@ export abstract class ImageLoader<Source> extends DataLoader<Source> {
     return tf.data.array([tensorContainer])
   }
 
-  async loadAll (images: Source[], config?: DataConfig): Promise<Data> {
-    let labels: number[]
-    const indices = Range(0, images.length).toArray()
-    if (config?.labels !== undefined) {
-      const numberOfClasses = this.task.trainingInformation?.LABEL_LIST?.length
-      if (numberOfClasses === undefined) {
-        throw new Error('wanted labels but none found in task')
-      }
-
-      labels = tf.oneHot(tf.tensor1d(config.labels, 'int32'), numberOfClasses).arraySync() as number[]
-    }
-    if (config?.shuffle === undefined || config?.shuffle) {
-      this.shuffle(indices)
-    }
+  private async buildDataset (images: Source[], labels: number[], indices: number[], config?: DataConfig): Promise<Data> {
     const dataset = tf.data.generator(() => {
       const withLabels = config?.labels !== undefined
 
       let index = 0
       const iterator = {
         next: async () => {
-          if (index === images.length) {
+          if (index === indices.length) {
             return { done: true }
           }
           const sample = await this.readImageFrom(images[indices[index]])
@@ -67,7 +54,44 @@ export abstract class ImageLoader<Source> extends DataLoader<Source> {
 
     return {
       dataset,
-      size: images.length
+      size: indices.length
+    }
+  }
+
+  async loadAll (images: Source[], config?: DataConfig): Promise<DataTuple> {
+    let labels: number[] = []
+    const indices = Range(0, images.length).toArray()
+    if (config?.labels !== undefined) {
+      const numberOfClasses = this.task.trainingInformation?.LABEL_LIST?.length
+      if (numberOfClasses === undefined) {
+        throw new Error('wanted labels but none found in task')
+      }
+
+      labels = tf.oneHot(tf.tensor1d(config.labels, 'int32'), numberOfClasses).arraySync() as number[]
+    }
+    if (config?.shuffle === undefined || config?.shuffle) {
+      this.shuffle(indices)
+    }
+
+    if (config?.validationSplit === undefined) {
+      const dataset = await this.buildDataset(images, labels, indices, config)
+      return {
+        train: dataset,
+        validation: dataset
+      }
+    }
+
+    const trainSize = Math.floor(images.length * (1 - config.validationSplit))
+
+    const trainIndices = indices.slice(0, trainSize)
+    const valIndices = indices.slice(trainSize)
+
+    const trainDataset = await this.buildDataset(images, labels, trainIndices, config)
+    const valDataset = await this.buildDataset(images, labels, valIndices, config)
+
+    return {
+      train: trainDataset,
+      validation: valDataset
     }
   }
 

--- a/discojs/src/dataset/data_loader/index.ts
+++ b/discojs/src/dataset/data_loader/index.ts
@@ -1,3 +1,3 @@
-export { Data, DataConfig, DataLoader } from './data_loader'
+export { Data, DataTuple, DataConfig, DataLoader } from './data_loader'
 export { ImageLoader } from './image_loader'
 export { TabularLoader } from './tabular_loader'

--- a/discojs/src/dataset/data_loader/tabular_loader.spec.ts
+++ b/discojs/src/dataset/data_loader/tabular_loader.spec.ts
@@ -23,7 +23,7 @@ describe('tabular loader', () => {
         shuffle: false
       }
     )
-    const sample = await (await (await loaded).dataset.iterator()).next()
+    const sample = await (await (await loaded).train.dataset.iterator()).next()
     /**
      * Data loaders simply return a dataset object read from input sources.
      * They do NOT apply any transform/conversion, which is left to the
@@ -48,10 +48,10 @@ describe('tabular loader', () => {
     }
     const dataset = await (await loader
       .loadAll(inputFiles, config))
-      .dataset.toArray()
+      .train.dataset.toArray()
     const shuffled = await (await loader
       .loadAll(inputFiles, { ...config, shuffle: true }))
-      .dataset.toArray()
+      .train.dataset.toArray()
 
     const misses = List(dataset).zip(List(shuffled)).map(([d, s]) =>
       tf.notEqual((d as any).xs, (s as any).xs).any().dataSync()[0]

--- a/discojs/src/dataset/data_loader/tabular_loader.ts
+++ b/discojs/src/dataset/data_loader/tabular_loader.ts
@@ -1,4 +1,4 @@
-import { DataLoader, DataConfig, Data } from './data_loader'
+import { DataLoader, DataConfig, DataTuple } from './data_loader'
 import { Dataset } from '../dataset_builder'
 import { Task } from '../../task'
 import * as tf from '@tensorflow/tfjs'
@@ -75,15 +75,19 @@ export abstract class TabularLoader<Source> extends DataLoader<Source> {
     * Creates the CSV datasets based off the given sources, then fuses them into a single CSV
     * dataset.
     */
-  async loadAll (sources: Source[], config: DataConfig): Promise<Data> {
+  async loadAll (sources: Source[], config: DataConfig): Promise<DataTuple> {
     const datasets = await Promise.all(sources.map(async (source) =>
       await this.load(source, { ...config, shuffle: false })))
     const dataset = List(datasets).reduce((acc: Dataset, dataset) => acc.concatenate(dataset))
-    return {
+    const data = {
       dataset: config?.shuffle ? dataset.shuffle(BUFFER_SIZE) : dataset,
       // dataset.size does not work for csv datasets
       // https://github.com/tensorflow/tfjs/issues/5845
       size: 0
+    }
+    // TODO: Implement validation split for tabular data (tricky due to streaming)
+    return {
+      train: data
     }
   }
 }

--- a/discojs/src/dataset/dataset_builder.ts
+++ b/discojs/src/dataset/dataset_builder.ts
@@ -1,6 +1,6 @@
 import * as tf from '@tensorflow/tfjs'
 
-import { DataLoader, Data } from './data_loader/data_loader'
+import { DataLoader, DataTuple } from './data_loader/data_loader'
 import { Task } from '@/task'
 
 export type Dataset = tf.data.Dataset<tf.TensorContainer>
@@ -59,31 +59,31 @@ export class DatasetBuilder<Source> {
     return labels.flat()
   }
 
-  async build (): Promise<Data> {
+  async build (): Promise<DataTuple> {
     // Require that at leat one source collection is non-empty, but not both
     if ((this.sources.length > 0) === (this.labelledSources.size > 0)) {
       throw new Error('invalid sources')
     }
 
-    let data: Data
+    let dataTuple: DataTuple
     if (this.sources.length > 0) {
       // Labels are contained in the given sources
       const config = {
         features: this.task.trainingInformation?.inputColumns,
         labels: this.task.trainingInformation?.outputColumns
       }
-      data = await this.dataLoader.loadAll(this.sources, config)
+      dataTuple = await this.dataLoader.loadAll(this.sources, config)
     } else {
       // Labels are inferred from the file selection boxes
       const config = {
         labels: this.getLabels()
       }
       const sources = Array.from(this.labelledSources.values()).flat()
-      data = await this.dataLoader.loadAll(sources, config)
+      dataTuple = await this.dataLoader.loadAll(sources, config)
     }
     // TODO @s314cy: Support .csv labels for image datasets (supervised training or testing)
     this.built = true
-    return data
+    return dataTuple
   }
 
   isBuilt (): boolean {

--- a/discojs/src/tasks/titanic.ts
+++ b/discojs/src/tasks/titanic.ts
@@ -45,7 +45,7 @@ export const task: Task = {
     modelID: 'titanic-model',
     epochs: 20,
     roundDuration: 10,
-    validationSplit: 0.2,
+    validationSplit: 0,
     batchSize: 30,
     preprocessFunctions: [],
     modelCompileData: {

--- a/discojs/src/training/disco.ts
+++ b/discojs/src/training/disco.ts
@@ -28,11 +28,14 @@ export class Disco {
     this.trainer = trainerBuilder.build(this.client, scheme !== TrainingSchemes.LOCAL)
   }
 
-  async startTraining (data: dataset.Data): Promise<void> {
+  async startTraining (dataTuple: dataset.DataTuple): Promise<void> {
     this.logger.success(
       'Thank you for your contribution. Data preprocessing has started')
 
-    await (await this.trainer).trainModel(data.dataset)
+    // Use train as val dataset if val is undefined
+    const valDataset = dataTuple.validation !== undefined ? dataTuple.validation.dataset : dataTuple.train.dataset
+
+    await (await this.trainer).trainModel(dataTuple.train.dataset, valDataset)
   }
 
   // Stops the training function

--- a/discojs/src/training/trainer/trainer.ts
+++ b/discojs/src/training/trainer/trainer.ts
@@ -72,13 +72,13 @@ export abstract class Trainer {
    * Start training the model with the given dataset
    * @param dataset
    */
-  async trainModel (dataset: tf.data.Dataset<tf.TensorContainer>): Promise<void> {
+  async trainModel (dataset: tf.data.Dataset<tf.TensorContainer>, valDataset: tf.data.Dataset<tf.TensorContainer>): Promise<void> {
     this.resetStopTrainerState()
 
     // Assign callbacks and start training
     await this.model.fitDataset(dataset.batch(this.trainingInformation.batchSize), {
       epochs: this.trainingInformation.epochs,
-      validationData: dataset.batch(this.trainingInformation.batchSize),
+      validationData: valDataset.batch(this.trainingInformation.batchSize),
       callbacks: {
         onEpochEnd: (epoch, logs) => this.onEpochEnd(epoch, logs),
         onBatchEnd: async (epoch, logs) => await this.onBatchEnd(epoch, logs)

--- a/discojs/src/validation/validator.spec.ts
+++ b/discojs/src/validation/validator.spec.ts
@@ -15,8 +15,8 @@ describe('validator', () => {
       .map((subdir: string) => fs.readdirSync(dir + subdir)
         .map((file: string) => dir + subdir + file))
 
-    const data: Data = await new NodeImageLoader(simple_face.task)
-      .loadAll(files.flat(), { labels: files.flatMap((files, index) => Array(files.length).fill(index)) })
+    const data: Data = (await new NodeImageLoader(simple_face.task)
+      .loadAll(files.flat(), { labels: files.flatMap((files, index) => Array(files.length).fill(index)) })).train
     const validator = new Validator(
       simple_face.task,
       new ConsoleLogger(),
@@ -31,7 +31,7 @@ describe('validator', () => {
     )
     assert(
       validator.accuracy() > 0.3,
-        `expected accuracy greater than 0.3 but got ${validator.accuracy()}`
+      `expected accuracy greater than 0.3 but got ${validator.accuracy()}`
     )
   })
   // TODO: fix titanic model (nan accuracy)

--- a/server/tests/end_to_end.test.ts
+++ b/server/tests/end_to_end.test.ts
@@ -19,6 +19,7 @@ class NodeImageLoader extends dataset.ImageLoader<string> {
 
 class NodeTabularLoader extends dataset.TabularLoader<string> {
   loadTabularDatasetFrom (source: string, csvConfig: Record<string, unknown>): tf.data.CSVDataset {
+    console.log('loading!>>', source)
     return tf.data.csv(source, csvConfig)
   }
 }
@@ -40,7 +41,7 @@ describe('end to end', function () {
 
     const cifar10 = tasks.cifar10.task
 
-    const loaded = await new NodeImageLoader(cifar10).loadAll(files, { labels: labels })
+    const data = await new NodeImageLoader(cifar10).loadAll(files, { labels: labels })
 
     const client = await getClient(server, cifar10)
     await client.connect()
@@ -54,7 +55,7 @@ describe('end to end', function () {
       client
     )
 
-    await disco.startTraining(loaded)
+    await disco.startTraining(data)
   }
 
   it('runs titanic with two users', async () =>
@@ -63,20 +64,17 @@ describe('end to end', function () {
   async function titanicUser (): Promise<void> {
     const dir = '../discojs/example_training_data/titanic.csv'
 
+    // TODO: can load data, so path is right.
+    // console.log(await tf.data.csv('file://'.concat(dir)).toArray())
     const titanic = tasks.titanic.task
-    const loaded = await (new NodeTabularLoader(titanic, ',').load(
-      'file://'.concat(dir),
+    const data = await (new NodeTabularLoader(titanic, ',').loadAll(
+      ['file://'.concat(dir)],
       {
         features: titanic.trainingInformation?.inputColumns,
-        labels: titanic.trainingInformation?.outputColumns
+        labels: titanic.trainingInformation?.outputColumns,
+        shuffle: false
       }
     ))
-
-    // TODO: loaded.size is null, will be fixed when we move to batches
-    const data = {
-      dataset: loaded,
-      size: 100
-    }
 
     const client = await getClient(server, titanic)
     await client.connect()


### PR DESCRIPTION
Add validation split for images, this is straightforward since we simply split the indices of the image list. (Trickier to do for Tabular data as we stream the csv file, so it will be done in a seperate PR).