### PR TITLE
Explain Disco's abbreviation on home page

### DIFF
--- a/browser/src/components/home/Home.vue
+++ b/browser/src/components/home/Home.vue
@@ -1,8 +1,13 @@
 <template>
   <div>
     <!-- Disco logo -->
-    <DiscoGIF class="mx-auto mb-[10%]" />
-
+    <div class="flex flex-col justify-center mb-[8%] space-y-10">
+      <DiscoGIF class="mx-auto" />
+      <span class="text-4xl text-center text-slate-600">
+        <span class="text-disco-blue font-disco font-semibold">[DIS]</span>tributed
+        <span class="text-disco-cyan font-disco font-semibold">[CO]</span>llaborative Learning
+      </span>
+    </div>
     <GetStarted v-if="gotStarted" />
     <Landing
       v-else


### PR DESCRIPTION
closes #376

<img width="1441" alt="Screenshot 2022-07-14 at 15 23 00" src="https://user-images.githubusercontent.com/22985663/178992974-927032bb-d281-4c3a-8ed5-bb98b138631e.png">
