### PR TITLE
Modules import TFJS from Disco.js and use a unique TFJS backend

### DIFF
--- a/benchmark/src/benchmark.ts
+++ b/benchmark/src/benchmark.ts
@@ -1,11 +1,11 @@
 import {Range} from 'immutable'
 import {Server} from 'node:http'
-import {client, ConsoleLogger, training, TrainingSchemes, EmptyMemory, informant, TrainerLog} from 'discojs'
+import {tf, client, ConsoleLogger, training, TrainingSchemes, EmptyMemory, informant, TrainerLog} from 'discojs'
+import '@tensorflow/tfjs-node'
 
 import {startServer, getClient, saveLog} from './utils'
 import {getTaskData} from './data'
 import {args} from './args'
-
 
 const NUMBER_OF_USERS = args.numberOfUsers
 let TASK = args.task
@@ -34,6 +34,8 @@ async function runUser(server: Server): Promise<TrainerLog> {
 }
 
 async function main(): Promise<void> {
+  await tf.ready()
+  console.log(`Loaded ${tf.getBackend()} backend`)
   const server = await startServer()
 
   const logs = await Promise.all(

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@meforma/vue-toaster": "1",
-        "@tensorflow/tfjs": "3",
         "apexcharts": "3",
         "autoprefixer": "^10",
         "aws-sdk": "2",
@@ -33,7 +32,7 @@
         "tippy.js": "6",
         "ts-node-register": "1",
         "vee-validate": "4",
-        "vue": "^3.2.37",
+        "vue": "3",
         "vue-i18n": "9",
         "vue-router": "4",
         "vue3-apexcharts": "1",
@@ -2307,129 +2306,6 @@
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "dev": true
     },
-    "node_modules/@tensorflow/tfjs": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.18.0.tgz",
-      "integrity": "sha512-mOzz4jJdgIpqFS7EHndVuxrQnLUDVIKGyTqOPTYps89fZwcOFfTVxi4BHemDNQpqlVE8IaGh9UUxVXpjgPY5+Q==",
-      "dependencies": {
-        "@tensorflow/tfjs-backend-cpu": "3.18.0",
-        "@tensorflow/tfjs-backend-webgl": "3.18.0",
-        "@tensorflow/tfjs-converter": "3.18.0",
-        "@tensorflow/tfjs-core": "3.18.0",
-        "@tensorflow/tfjs-data": "3.18.0",
-        "@tensorflow/tfjs-layers": "3.18.0",
-        "argparse": "^1.0.10",
-        "chalk": "^4.1.0",
-        "core-js": "3",
-        "regenerator-runtime": "^0.13.5",
-        "yargs": "^16.0.3"
-      },
-      "bin": {
-        "tfjs-custom-module": "dist/tools/custom_module/cli.js"
-      }
-    },
-    "node_modules/@tensorflow/tfjs-backend-cpu": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.18.0.tgz",
-      "integrity": "sha512-LcSqlylzGtpgngcMFIL3q9Q3eVaPRJ7ITZt7ivhzkCj4R5ZsnPa9qM3DCVihkQ77heAwSw4hPTo2jp5C4mJ4Cg==",
-      "dependencies": {
-        "@types/seedrandom": "2.4.27",
-        "seedrandom": "2.4.3"
-      },
-      "engines": {
-        "yarn": ">= 1.3.2"
-      },
-      "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.18.0"
-      }
-    },
-    "node_modules/@tensorflow/tfjs-backend-cpu/node_modules/seedrandom": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-      "integrity": "sha512-2CkZ9Wn2dS4mMUWQaXLsOAfGD+irMlLEeSP3cMxpGbgyOOzJGFa+MWCOMTOCMyZinHRPxyOj/S/C57li/1to6Q=="
-    },
-    "node_modules/@tensorflow/tfjs-backend-webgl": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.18.0.tgz",
-      "integrity": "sha512-3NknSzS1oX2BEBOrpjPMZl823S12RgshQthmIbG6QADHb4bCJA8aM4UjWpw+3bNQnRKbRDQdFbuvj10Un79s2A==",
-      "dependencies": {
-        "@tensorflow/tfjs-backend-cpu": "3.18.0",
-        "@types/offscreencanvas": "~2019.3.0",
-        "@types/seedrandom": "2.4.27",
-        "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.6",
-        "seedrandom": "2.4.3"
-      },
-      "engines": {
-        "yarn": ">= 1.3.2"
-      },
-      "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.18.0"
-      }
-    },
-    "node_modules/@tensorflow/tfjs-backend-webgl/node_modules/seedrandom": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-      "integrity": "sha512-2CkZ9Wn2dS4mMUWQaXLsOAfGD+irMlLEeSP3cMxpGbgyOOzJGFa+MWCOMTOCMyZinHRPxyOj/S/C57li/1to6Q=="
-    },
-    "node_modules/@tensorflow/tfjs-converter": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.18.0.tgz",
-      "integrity": "sha512-hpChA+zVNQOVwRnCfqDb1WI9jbEAKA6DuEm4m75Zb3dIlE6VVooDmAaHBhlc++z2q2G1sBzF9A4Bv48SUpN6vA==",
-      "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.18.0"
-      }
-    },
-    "node_modules/@tensorflow/tfjs-core": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.18.0.tgz",
-      "integrity": "sha512-gMxisZozqsr5sCKlphF/eVBLg91MjlBiN60tjX8hJAu0WlSn6Gi5k65GNIL+Pq6hrxpvImcfdCmTH/2XJVZ0Mg==",
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "@types/offscreencanvas": "~2019.3.0",
-        "@types/seedrandom": "2.4.27",
-        "@types/webgl-ext": "0.0.30",
-        "@webgpu/types": "^0.1.16",
-        "long": "4.0.0",
-        "node-fetch": "~2.6.1",
-        "seedrandom": "2.4.3"
-      },
-      "engines": {
-        "yarn": ">= 1.3.2"
-      }
-    },
-    "node_modules/@tensorflow/tfjs-core/node_modules/seedrandom": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-      "integrity": "sha512-2CkZ9Wn2dS4mMUWQaXLsOAfGD+irMlLEeSP3cMxpGbgyOOzJGFa+MWCOMTOCMyZinHRPxyOj/S/C57li/1to6Q=="
-    },
-    "node_modules/@tensorflow/tfjs-layers": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.18.0.tgz",
-      "integrity": "sha512-AV7yDnPlH+RCcq8VPqkX1iyEchObE+e66m0XmJvLj+ncfKHYLa+39ZNroUA+OgB2/cMG6jgq77R4EhZbT6hwJA==",
-      "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.18.0"
-      }
-    },
-    "node_modules/@tensorflow/tfjs/node_modules/@tensorflow/tfjs-data": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.18.0.tgz",
-      "integrity": "sha512-s43vISJh8K/UN2E2zGRhtj/Kyn8dr4ll8EQkapwzm7fGO9afXCnMsTp6rkZq3fFXouCYA2k1B/j7JssIDr50+w==",
-      "dependencies": {
-        "@types/node-fetch": "^2.1.2",
-        "node-fetch": "~2.6.1"
-      },
-      "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.18.0",
-        "seedrandom": "~2.4.3"
-      }
-    },
-    "node_modules/@tensorflow/tfjs/node_modules/seedrandom": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
-      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==",
-      "peer": true
-    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2862,11 +2738,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
       "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -2905,25 +2776,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
       "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
-    },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.3.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.3.0.tgz",
-      "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2948,11 +2805,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
-    },
-    "node_modules/@types/seedrandom": {
-      "version": "2.4.27",
-      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.27.tgz",
-      "integrity": "sha512-YvMLqFak/7rt//lPBtEHv3M4sRNA+HGxrhFZ+DQs9K2IkYJbNwVIb8avtJfhDiuaUBX/AW0jnjv48FV8h3u9bQ=="
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -2981,16 +2833,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/webgl-ext": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz",
-      "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
-    },
-    "node_modules/@types/webgl2": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.6.tgz",
-      "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ=="
     },
     "node_modules/@types/webpack-env": {
       "version": "1.16.3",
@@ -4719,11 +4561,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4932,6 +4769,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4940,6 +4778,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4993,6 +4832,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -5078,7 +4918,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -5578,6 +5419,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5740,6 +5582,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -5773,6 +5616,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -5801,6 +5645,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7005,6 +6850,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7246,7 +7092,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -8806,19 +8653,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -8901,6 +8735,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -9086,6 +8921,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9629,6 +9465,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10521,11 +10358,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "node_modules/loupe": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
@@ -10701,6 +10533,7 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10709,6 +10542,7 @@
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.51.0"
       },
@@ -11567,6 +11401,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13201,6 +13036,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13899,7 +13735,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "node_modules/stable": {
       "version": "0.1.8",
@@ -13934,6 +13771,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -13967,6 +13805,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -14070,6 +13909,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14559,7 +14399,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "node_modules/ts-loader": {
       "version": "9.2.8",
@@ -15160,7 +15001,8 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "node_modules/webpack": {
       "version": "5.72.0",
@@ -15594,6 +15436,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -15660,6 +15503,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -15739,6 +15583,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -15755,6 +15600,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -15772,6 +15618,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -17527,111 +17374,6 @@
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "dev": true
     },
-    "@tensorflow/tfjs": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.18.0.tgz",
-      "integrity": "sha512-mOzz4jJdgIpqFS7EHndVuxrQnLUDVIKGyTqOPTYps89fZwcOFfTVxi4BHemDNQpqlVE8IaGh9UUxVXpjgPY5+Q==",
-      "requires": {
-        "@tensorflow/tfjs-backend-cpu": "3.18.0",
-        "@tensorflow/tfjs-backend-webgl": "3.18.0",
-        "@tensorflow/tfjs-converter": "3.18.0",
-        "@tensorflow/tfjs-core": "3.18.0",
-        "@tensorflow/tfjs-data": "3.18.0",
-        "@tensorflow/tfjs-layers": "3.18.0",
-        "argparse": "^1.0.10",
-        "chalk": "^4.1.0",
-        "core-js": "3",
-        "regenerator-runtime": "^0.13.5",
-        "yargs": "^16.0.3"
-      },
-      "dependencies": {
-        "@tensorflow/tfjs-data": {
-          "version": "3.18.0",
-          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.18.0.tgz",
-          "integrity": "sha512-s43vISJh8K/UN2E2zGRhtj/Kyn8dr4ll8EQkapwzm7fGO9afXCnMsTp6rkZq3fFXouCYA2k1B/j7JssIDr50+w==",
-          "requires": {
-            "@types/node-fetch": "^2.1.2",
-            "node-fetch": "~2.6.1"
-          }
-        },
-        "seedrandom": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
-          "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==",
-          "peer": true
-        }
-      }
-    },
-    "@tensorflow/tfjs-backend-cpu": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.18.0.tgz",
-      "integrity": "sha512-LcSqlylzGtpgngcMFIL3q9Q3eVaPRJ7ITZt7ivhzkCj4R5ZsnPa9qM3DCVihkQ77heAwSw4hPTo2jp5C4mJ4Cg==",
-      "requires": {
-        "@types/seedrandom": "2.4.27",
-        "seedrandom": "2.4.3"
-      },
-      "dependencies": {
-        "seedrandom": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-          "integrity": "sha512-2CkZ9Wn2dS4mMUWQaXLsOAfGD+irMlLEeSP3cMxpGbgyOOzJGFa+MWCOMTOCMyZinHRPxyOj/S/C57li/1to6Q=="
-        }
-      }
-    },
-    "@tensorflow/tfjs-backend-webgl": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.18.0.tgz",
-      "integrity": "sha512-3NknSzS1oX2BEBOrpjPMZl823S12RgshQthmIbG6QADHb4bCJA8aM4UjWpw+3bNQnRKbRDQdFbuvj10Un79s2A==",
-      "requires": {
-        "@tensorflow/tfjs-backend-cpu": "3.18.0",
-        "@types/offscreencanvas": "~2019.3.0",
-        "@types/seedrandom": "2.4.27",
-        "@types/webgl-ext": "0.0.30",
-        "@types/webgl2": "0.0.6",
-        "seedrandom": "2.4.3"
-      },
-      "dependencies": {
-        "seedrandom": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-          "integrity": "sha512-2CkZ9Wn2dS4mMUWQaXLsOAfGD+irMlLEeSP3cMxpGbgyOOzJGFa+MWCOMTOCMyZinHRPxyOj/S/C57li/1to6Q=="
-        }
-      }
-    },
-    "@tensorflow/tfjs-converter": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.18.0.tgz",
-      "integrity": "sha512-hpChA+zVNQOVwRnCfqDb1WI9jbEAKA6DuEm4m75Zb3dIlE6VVooDmAaHBhlc++z2q2G1sBzF9A4Bv48SUpN6vA==",
-      "requires": {}
-    },
-    "@tensorflow/tfjs-core": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.18.0.tgz",
-      "integrity": "sha512-gMxisZozqsr5sCKlphF/eVBLg91MjlBiN60tjX8hJAu0WlSn6Gi5k65GNIL+Pq6hrxpvImcfdCmTH/2XJVZ0Mg==",
-      "requires": {
-        "@types/long": "^4.0.1",
-        "@types/offscreencanvas": "~2019.3.0",
-        "@types/seedrandom": "2.4.27",
-        "@types/webgl-ext": "0.0.30",
-        "@webgpu/types": "^0.1.16",
-        "long": "4.0.0",
-        "node-fetch": "~2.6.1",
-        "seedrandom": "2.4.3"
-      },
-      "dependencies": {
-        "seedrandom": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
-          "integrity": "sha512-2CkZ9Wn2dS4mMUWQaXLsOAfGD+irMlLEeSP3cMxpGbgyOOzJGFa+MWCOMTOCMyZinHRPxyOj/S/C57li/1to6Q=="
-        }
-      }
-    },
-    "@tensorflow/tfjs-layers": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.18.0.tgz",
-      "integrity": "sha512-AV7yDnPlH+RCcq8VPqkX1iyEchObE+e66m0XmJvLj+ncfKHYLa+39ZNroUA+OgB2/cMG6jgq77R4EhZbT6hwJA==",
-      "requires": {}
-    },
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -18058,11 +17800,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
       "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
     },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -18101,25 +17838,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
       "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
     },
-    "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
-    },
-    "@types/offscreencanvas": {
-      "version": "2019.3.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.3.0.tgz",
-      "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -18144,11 +17867,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
-    },
-    "@types/seedrandom": {
-      "version": "2.4.27",
-      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.27.tgz",
-      "integrity": "sha512-YvMLqFak/7rt//lPBtEHv3M4sRNA+HGxrhFZ+DQs9K2IkYJbNwVIb8avtJfhDiuaUBX/AW0jnjv48FV8h3u9bQ=="
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -18177,16 +17895,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/webgl-ext": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz",
-      "integrity": "sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg=="
-    },
-    "@types/webgl2": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.6.tgz",
-      "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ=="
     },
     "@types/webpack-env": {
       "version": "1.16.3",
@@ -19500,11 +19208,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -19665,12 +19368,14 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -19718,6 +19423,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -19788,7 +19494,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -20177,6 +19884,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -20292,6 +20000,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -20319,6 +20028,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -20344,6 +20054,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -21294,7 +21005,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -21515,7 +21227,8 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -22731,16 +22444,6 @@
         }
       }
     },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -22800,7 +22503,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -22942,7 +22646,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -23340,7 +23045,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
@@ -24032,11 +23738,6 @@
         }
       }
     },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "loupe": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
@@ -24187,12 +23888,14 @@
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "dev": true,
       "requires": {
         "mime-db": "1.51.0"
       }
@@ -24859,6 +24562,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -26036,7 +25740,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -26608,7 +26313,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "stable": {
       "version": "0.1.8",
@@ -26640,6 +26346,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -26670,6 +26377,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -26743,6 +26451,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -27102,7 +26811,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "ts-loader": {
       "version": "9.2.8",
@@ -27590,7 +27300,8 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "webpack": {
       "version": "5.72.0",
@@ -27904,6 +27615,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -27964,6 +27676,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -28016,7 +27729,8 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",
@@ -28027,6 +27741,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -28040,7 +27755,8 @@
     "yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/browser/package.json
+++ b/browser/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@meforma/vue-toaster": "1",
-    "@tensorflow/tfjs": "3",
     "apexcharts": "3",
     "autoprefixer": "^10",
     "aws-sdk": "2",

--- a/browser/src/components/validation/Validator.vue
+++ b/browser/src/components/validation/Validator.vue
@@ -121,7 +121,6 @@ export default defineComponent({
       const dataset: dataset.Data = (await this.datasetBuilder
         .build({ validationSplit: 0 }))
         .train
-      console.log(dataset)
       success(this.$toast, 'Model testing started!')
       try {
         await this.validator.assess(dataset)

--- a/browser/src/data_loader.ts
+++ b/browser/src/data_loader.ts
@@ -1,6 +1,4 @@
-import * as tf from '@tensorflow/tfjs'
-
-import { dataset } from 'discojs'
+import { tf, dataset } from 'discojs'
 
 export class WebImageLoader extends dataset.ImageLoader<File> {
   async readImageFrom (source: File): Promise<tf.Tensor3D> {

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -11,6 +11,12 @@ import { createCustomI18n } from './locales/i18n'
 import '@/assets/css/tailwind.css'
 import '@/assets/css/styles.css'
 
+import { tf } from 'discojs'
+
+tf.ready()
+  .then(() => console.log(`Loaded ${tf.getBackend()} backend`))
+  .catch(console.error)
+
 /* if (
   process.env.NODE_ENV === 'development' &&
   process.env.DEV_TOOLS === 'enabled'

--- a/browser/src/memory.ts
+++ b/browser/src/memory.ts
@@ -6,10 +6,9 @@
  * folder via the model library. The working/ folder is only used by the backend.
  * The working model is loaded from IndexedDB for training (model.fit) only.
  */
-import * as tf from '@tensorflow/tfjs'
 import path from 'path'
 
-import { Memory, ModelType, Path, ModelInfo, ModelSource } from 'discojs'
+import { tf, Memory, ModelType, Path, ModelInfo, ModelSource } from 'discojs'
 
 export class IndexedDB extends Memory {
   pathFor (source: ModelSource): Path {

--- a/browser/src/store/index.ts
+++ b/browser/src/store/index.ts
@@ -1,8 +1,7 @@
 import { loadTasks } from '@/tasks'
 
-import { ModelType, Path, Task, TaskID } from 'discojs'
+import { tf, ModelType, Path, Task, TaskID } from 'discojs'
 import { ActionContext, createStore } from 'vuex'
-import * as tf from '@tensorflow/tfjs'
 
 const MIN_STEP = 0
 const MAX_STEP = 4

--- a/browser/src/types.ts
+++ b/browser/src/types.ts
@@ -1,3 +1,3 @@
-import * as tf from '@tensorflow/tfjs'
+import { tf } from 'discojs'
 
 export type Weights = tf.Tensor[]

--- a/discojs/src/aggregation.spec.ts
+++ b/discojs/src/aggregation.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { Set } from 'immutable'
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '.'
 
 import { averageWeights } from './aggregation'
 

--- a/discojs/src/async_informant.test.ts
+++ b/discojs/src/async_informant.test.ts
@@ -1,4 +1,3 @@
-
 import { AsyncInformant } from '../src/async_informant'
 import { AsyncBuffer } from '../src/async_buffer'
 

--- a/discojs/src/dataset/data_loader/image_loader.spec.ts
+++ b/discojs/src/dataset/data_loader/image_loader.spec.ts
@@ -1,10 +1,10 @@
 import { assert, expect } from 'chai'
-import * as tf from '@tensorflow/tfjs-node'
 import fs from 'fs'
 import _ from 'lodash'
 
 import { dataset, tasks } from '../..'
 import { List, Map, Range } from 'immutable'
+import * as tf from '@tensorflow/tfjs-node'
 
 export class NodeImageLoader extends dataset.ImageLoader<string> {
   async readImageFrom (source: string): Promise<tf.Tensor3D> {

--- a/discojs/src/dataset/data_loader/image_loader.ts
+++ b/discojs/src/dataset/data_loader/image_loader.ts
@@ -1,6 +1,6 @@
-import * as tf from '@tensorflow/tfjs'
 import { Range } from 'immutable'
 
+import { tf } from '../..'
 import { Dataset } from '../dataset_builder'
 import { DataLoader, DataConfig, Data, DataTuple } from './data_loader'
 

--- a/discojs/src/dataset/data_loader/tabular_loader.spec.ts
+++ b/discojs/src/dataset/data_loader/tabular_loader.spec.ts
@@ -1,7 +1,6 @@
 import { assert, expect } from 'chai'
-import * as tf from '@tensorflow/tfjs-node'
 
-import { dataset, tasks } from '../..'
+import { tf, dataset, tasks } from '../..'
 import { List } from 'immutable'
 
 export class NodeTabularLoader extends dataset.TabularLoader<string> {

--- a/discojs/src/dataset/data_loader/tabular_loader.ts
+++ b/discojs/src/dataset/data_loader/tabular_loader.ts
@@ -1,7 +1,7 @@
 import { DataLoader, DataConfig, DataTuple } from './data_loader'
 import { Dataset } from '../dataset_builder'
 import { Task } from '../../task'
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '../..'
 import { List, Map, Set } from 'immutable'
 
 // window size from which the dataset shuffling will sample

--- a/discojs/src/index.ts
+++ b/discojs/src/index.ts
@@ -19,3 +19,5 @@ export { Validator } from './validation'
 
 export { TrainingInformation, DisplayInformation, isTask, Task, isTaskID, TaskID } from './task'
 export * from './types'
+
+export { tf } from './tfjs'

--- a/discojs/src/logging/trainer_logger.ts
+++ b/discojs/src/logging/trainer_logger.ts
@@ -1,6 +1,6 @@
-import * as tf from '@tensorflow/tfjs'
 import { List } from 'immutable'
 
+import { tf } from '..'
 import { ConsoleLogger } from '.'
 
 export class TrainerLog {

--- a/discojs/src/memory/empty.ts
+++ b/discojs/src/memory/empty.ts
@@ -1,4 +1,4 @@
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '..'
 
 import { Memory, ModelInfo, Path } from './base'
 

--- a/discojs/src/privacy.ts
+++ b/discojs/src/privacy.ts
@@ -1,7 +1,7 @@
 import { List } from 'immutable'
 import { Weights } from '@/types'
 import { Task } from '@/task'
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '.'
 
 /**
  * Add task-parametrized Gaussian noise to and clip the weights update between the previous and current rounds.

--- a/discojs/src/serialization/model.spec.ts
+++ b/discojs/src/serialization/model.spec.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '..'
 
 import { encode, decode, isEncoded, Encoded } from './model'
 import * as tasks from '../tasks'

--- a/discojs/src/serialization/model.ts
+++ b/discojs/src/serialization/model.ts
@@ -1,4 +1,4 @@
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '..'
 import msgpack from 'msgpack-lite'
 
 export type Encoded = number[]

--- a/discojs/src/serialization/weights.ts
+++ b/discojs/src/serialization/weights.ts
@@ -1,4 +1,4 @@
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '..'
 import * as msgpack from 'msgpack-lite'
 
 import { Weights } from '@/types'

--- a/discojs/src/tfjs.ts
+++ b/discojs/src/tfjs.ts
@@ -1,0 +1,3 @@
+import * as tf from '@tensorflow/tfjs'
+
+export { tf }

--- a/discojs/src/training/trainer/trainer_builder.ts
+++ b/discojs/src/training/trainer/trainer_builder.ts
@@ -1,7 +1,6 @@
 import { ModelInfo } from '@/memory'
-import * as tf from '@tensorflow/tfjs'
 
-import { Client, Task, TrainingInformant, Memory, ModelType } from '../..'
+import { tf, Client, Task, TrainingInformant, Memory, ModelType } from '../..'
 
 import { DistributedTrainer } from './distributed_trainer'
 import { LocalTrainer } from './local_trainer'

--- a/discojs/src/types.ts
+++ b/discojs/src/types.ts
@@ -1,4 +1,4 @@
-import * as tf from '@tensorflow/tfjs'
+import { tf } from '.'
 
 // Filesystem reference
 export type Path = string

--- a/server/src/router/decentralized.ts
+++ b/server/src/router/decentralized.ts
@@ -1,8 +1,7 @@
 import express from 'express'
 import expressWS from 'express-ws'
-import * as tf from '@tensorflow/tfjs'
 
-import { Task } from 'discojs'
+import { tf, Task } from 'discojs'
 
 import { TasksAndModels } from '../tasks'
 import { SignalingServer } from './signaling_server'

--- a/server/src/router/federated.ts
+++ b/server/src/router/federated.ts
@@ -1,9 +1,8 @@
 import express, { Request, Response } from 'express'
 import { List, Map, Set } from 'immutable'
 import msgpack from 'msgpack-lite'
-import * as tf from '@tensorflow/tfjs-node'
 
-import { serialization, aggregation, AsyncInformant, Task, isTaskID, TaskID, AsyncBuffer, Weights } from 'discojs'
+import { tf, serialization, aggregation, AsyncInformant, Task, isTaskID, TaskID, AsyncBuffer, Weights } from 'discojs'
 
 import { Config } from '../config'
 import { TasksAndModels } from '../tasks'

--- a/server/src/router/tasks.ts
+++ b/server/src/router/tasks.ts
@@ -1,8 +1,7 @@
 import express, { Request, Response } from 'express'
 import { Set } from 'immutable'
-import * as tf from '@tensorflow/tfjs'
 
-import { serialization, isTask, Task, TaskID } from 'discojs'
+import { tf, serialization, isTask, Task, TaskID } from 'discojs'
 
 import { Config } from '../config'
 import { TasksAndModels } from '../tasks'

--- a/server/src/run_server.ts
+++ b/server/src/run_server.ts
@@ -1,5 +1,11 @@
 import { CONFIG } from './config'
 import { getApp } from './get_server'
+import { tf } from 'discojs'
+import '@tensorflow/tfjs-node'
+
+tf.ready()
+  .then(() => console.log(`Loaded ${tf.getBackend()} backend`))
+  .catch(console.error)
 
 getApp()
   .then((app) => app.listen(CONFIG.serverPort))


### PR DESCRIPTION
closes #371 and closes #379, enables #363 for later

all modules (server, browser & benchmark) import their tfjs from discojs, and the tfjs backend is set to the corresponding module's environment (either browser or node)

this ensures each module shares the same backend as their imported instance of discojs

note that discojs now imports tfjs only, i.e. without the c++ bindings, which means using discojs on node with greater performance requires to manually import the tfjs-node backend (for lack of a better workaround)