### PR TITLE
Fix bug in Validation Panel, use Composition API in some components

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "dev": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "test": "vue-cli-service test:unit tests",

--- a/browser/src/components/sidebar/ModelLibrary.vue
+++ b/browser/src/components/sidebar/ModelLibrary.vue
@@ -96,7 +96,7 @@ import LoadIcon from '../../assets/svg/LoadIcon.vue'
 import StackIcon from '../../assets/svg/StackIcon.vue'
 import TippyCard from './containers/TippyCard.vue'
 import TippyContainer from './containers/TippyContainer.vue'
-import { error, success } from '@/toast'
+import { toaster } from '@/toast'
 
 export default {
   name: 'ModelLibrary',
@@ -138,10 +138,9 @@ export default {
       try {
         await this.$store.commit('deleteModel', path)
         await this.memory.deleteModel(path)
-        success(this.$toast, 'Successfully deleted the model')
+        toaster.success('Successfully deleted the model')
       } catch (e) {
-        error(this.$toast, 'Error')
-        console.log(e.message)
+        toaster.error(e.message)
       }
     },
 
@@ -161,11 +160,11 @@ export default {
           await this.memory.loadSavedModel(path)
         } catch (e) {
           console.log(e.message)
-          error(this.$toast, 'Error')
+          toaster.error('Error')
         }
-        success(this.$toast, `Loaded ${modelInfo.name}, ready for next training session.`)
+        toaster.success(`Loaded ${modelInfo.name}, ready for next training session.`)
       } else {
-        error(this.$toast, 'Model is already loaded')
+        toaster.error('Model is already loaded')
       }
     }
   }

--- a/browser/src/components/training/Training.vue
+++ b/browser/src/components/training/Training.vue
@@ -49,7 +49,7 @@ import { dataset, EmptyMemory, isTask, informant, TrainingInformant, TrainingSch
 
 import { getClient } from '@/clients'
 import { IndexedDB } from '@/memory'
-import { error } from '@/toast'
+import { toaster } from '@/toast'
 import TrainingInformation from '@/components/training/TrainingInformation.vue'
 import CustomButton from '@/components/simple/CustomButton.vue'
 
@@ -144,7 +144,7 @@ export default defineComponent({
         await this.disco.startTraining(this.dataset)
         this.startedTraining = false
       } catch (e) {
-        error(this.$toast, e instanceof Error ? e.message : e.toString())
+        toaster.error(e instanceof Error ? e.message : e.toString())
 
         // clean generated state
         this.distributedTraining = false

--- a/browser/src/components/validation/ValidationBar.vue
+++ b/browser/src/components/validation/ValidationBar.vue
@@ -76,24 +76,13 @@
     </div>
   </div>
 </template>
-<script lang="ts">
+<script setup lang="ts">
+import { defineProps } from 'vue'
+
 import ProgressIcon from '@/components/navigation/ProgressIcon.vue'
 
-export default {
-  name: 'ValidationBar',
-  components: {
-    ProgressIcon
-  },
-  props: {
-    step: {
-      type: Number,
-      default: 0
-    }
-  },
-  methods: {
-    isActive (step: number) {
-      return step <= this.step
-    }
-  }
-}
+interface Props { step: number }
+
+const props = defineProps<Props>()
+const isActive = (step: number): boolean => step <= props.step
 </script>

--- a/browser/src/main.ts
+++ b/browser/src/main.ts
@@ -5,7 +5,7 @@ import Toaster from '@meforma/vue-toaster'
 
 import App from '@/components/App.vue'
 import router from '@/router'
-import store from '@/store'
+import { store, key } from '@/store'
 import { createCustomI18n } from './locales/i18n'
 
 import '@/assets/css/tailwind.css'
@@ -27,12 +27,9 @@ tf.ready()
 const app = createApp(App)
 const i18n = createCustomI18n()
 app
-  .use(store)
+  .use(store, key)
   .use(VueApexCharts)
   .use(i18n)
-  .use(Toaster, {
-    // display time of the toast notications
-    duration: 3000
-  })
+  .use(Toaster, { duration: 5000 })
   .use(router)
   .mount('#app')

--- a/browser/src/store/index.ts
+++ b/browser/src/store/index.ts
@@ -1,7 +1,8 @@
 import { loadTasks } from '@/tasks'
 
 import { tf, ModelType, Path, Task, TaskID } from 'discojs'
-import { ActionContext, createStore } from 'vuex'
+import { InjectionKey } from 'vue'
+import { ActionContext, createStore, useStore as baseUseStore, Store } from 'vuex'
 
 const MIN_STEP = 0
 const MAX_STEP = 4
@@ -9,7 +10,7 @@ const MAX_STEP = 4
 // TODO better typing
 type ModelMetadata = any
 
-interface State {
+export interface State {
   tasks: Map<TaskID, Task>,
   steps: Map<TaskID, number>,
   models: Map<Path, ModelMetadata>,
@@ -20,7 +21,10 @@ interface State {
   testingState: boolean
 }
 
-export const store = createStore({
+// eslint-disable-next-line symbol-description
+export const key: InjectionKey<Store<State>> = Symbol()
+
+export const store = createStore<State>({
   state (): State {
     return {
       tasks: new Map(),
@@ -134,4 +138,6 @@ export const store = createStore({
   }
 })
 
-export default store
+export function useStore (): Store<State> {
+  return baseUseStore(key)
+}

--- a/browser/src/toast.ts
+++ b/browser/src/toast.ts
@@ -1,37 +1,8 @@
-/**
- * Convenient wrapper functions for Vue Toaster https://github.com/MeForma/vue-toaster
- */
-
-const TIMEOUT = 30000 // ms
-
-function notification (type: string, toast: any, message: string) {
-  toast.show(message, { type: type })
-  setTimeout(toast.clear, TIMEOUT)
-}
+import { createToaster } from '@meforma/vue-toaster'
 
 /**
- * Display an error toast with the given message
- * @param toast the toast object
- * @param message the message to be displayed
+ * Convenient wrapper of Vue Toaster https://github.com/MeForma/vue-toaster for
+ * Vue components using the composition API
  */
-export function error (toast: any, message: string): void {
-  notification('error', toast, message)
-}
 
-/**
- * Display a success toast with the given message
- * @param toast the toast object
- * @param message the message to be displayed
- */
-export function success (toast: any, message: string): void {
-  notification('success', toast, message)
-}
-
-/**
- * Display a warning toast with the given message
- * @param toast the toast object
- * @param message the message to be displayed
- */
-export function warning (toast: any, message: string): void {
-  notification('warning', toast, message)
-}
+export const toaster = createToaster({ duration: 5000 })


### PR DESCRIPTION
* fixes a feature-breaking bug encountered when navigating through the validation panel in certain ways
* always display the validation accuracy stat and graph (even before testing), just like the training panel does
* the web client is now started with `npm run dev` instead of `npm run serve`, just like the discojs server
* composition API:
  * the store object is now typed and compatible with vue's composition API
  * the toaster is now compatible with the composition API and the notifications are displayed for a longer duration
    * btw, the `clear` function called with `setTimeout` in a lot of places is useless, since the toasts are given a duration...
  * `validation/Validator.vue` is now written with the composition API (made the features/bugfixes mentioned above easier to implement)