### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   npm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 
 on:
   release:

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -73,7 +73,7 @@
     },
     "../discojs": {
       "name": "@epfml/discojs",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "axios": "0.27",
         "immutable": "4",

--- a/discojs/package-lock.json
+++ b/discojs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@epfml/discojs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@epfml/discojs",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "axios": "0.27",
         "immutable": "4",

--- a/discojs/package.json
+++ b/discojs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epfml/discojs",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -45,7 +45,7 @@
     },
     "../discojs": {
       "name": "@epfml/discojs",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "axios": "0.27",
         "immutable": "4",


### PR DESCRIPTION
So, GitHub events are hardly described, from the example, it seems that we need to trigger on the 'created' event and not the 'published' one (:

And yeah, forgot to bump the version in `discojs/package.json`

When that's merged, I'll tag it and push it to `production`, then that should fall into place :crossed_fingers:  