### PR TITLE
URI: not a constructor fix. 

### DIFF
--- a/discojs/src/client/decentralized/base.ts
+++ b/discojs/src/client/decentralized/base.ts
@@ -109,7 +109,8 @@ function to check if a given boolean condition is true, checks continuously unti
   deals with message reception from decentralized client perspective (messages received by client)
    */
   protected async connectServer (url: URL): Promise<isomorphic.WebSocket> {
-    const ws = new isomorphic.WebSocket(url)
+    const WS = typeof window !== 'undefined' ? window.WebSocket : isomorphic.WebSocket
+    const ws = new WS(url)
     ws.binaryType = 'arraybuffer'
 
     ws.onmessage = async (event: isomorphic.MessageEvent) => {
@@ -121,10 +122,10 @@ function to check if a given boolean condition is true, checks continuously unti
       // check message type to choose correct action
       if (this.instanceOfMessageGeneral(msg)) {
         if (this.instanceOfServerClientIDMessage(msg)) {
-        // updated ID
+          // updated ID
           this.ID = msg.peerID
         } else if (this.instanceOfServerReadyClients(msg)) {
-        // updated connected peers
+          // updated connected peers
           if (!this.peersLocked) {
             this.peers = msg.peerList
             this.peersLocked = true
@@ -159,7 +160,6 @@ function to check if a given boolean condition is true, checks continuously unti
         throw new Error(`unknown protocol: ${this.url.protocol}`)
     }
     serverURL.pathname += `deai/${this.task.taskID}`
-
     this.server = await this.connectServer(serverURL)
   }
 

--- a/discojs/src/client/decentralized/base.ts
+++ b/discojs/src/client/decentralized/base.ts
@@ -1,7 +1,7 @@
 import { List } from 'immutable'
 import isomorphic from 'isomorphic-ws'
 import msgpack from 'msgpack-lite'
-import { URL } from 'url'
+import * as nodeUrl from 'url'
 import { Task } from '@/task'
 
 import { TrainingInformant, Weights, aggregation, privacy } from '../..'
@@ -146,6 +146,7 @@ function to check if a given boolean condition is true, checks continuously unti
    * Initialize the connection to the peers and to the other nodes.
    */
   async connect (): Promise<void> {
+    const URL = typeof window !== 'undefined' ? window.URL : nodeUrl.URL
     const serverURL = new URL('', this.url.href)
     switch (this.url.protocol) {
       case 'http:':

--- a/discojs/tsconfig.json
+++ b/discojs/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     // TODO ES6 disallow server's test
     "target": "ES5",
-    "lib": ["ES5"],
+    "lib": ["ES5", "dom"],
 
     "strict": true,
 


### PR DESCRIPTION
URI: not a constructor fix. Issue due to URI being a nodejs object only.

Fixed using: https://stackoverflow.com/questions/46416439/unable-to-import-url-class-in-nodejs-typescript-app, and then adding `dom` in the tsconfig to access the window object.

The URI object now seems to work in the browser, however there are now new errors:

In decent/base.ts:

    const ws = new isomorphic.WebSocket(url)

yields isomorphic.WebSocket(url) not a constructor.

Similarly, the issue seems to be with nodejs / browser package compatibility. 

fixes #378