### PR TITLE
Fix for 447 - Error when clearing or adding new files after training

### DIFF
--- a/discojs/src/dataset/dataset_builder.ts
+++ b/discojs/src/dataset/dataset_builder.ts
@@ -22,7 +22,7 @@ export class DatasetBuilder<Source> {
 
   addFiles (sources: Source[], label?: string): void {
     if (this.built) {
-      throw new Error('builder already consumed')
+      this.resetBuiltState()
     }
     if (label === undefined) {
       this.sources = this.sources.concat(sources)
@@ -38,13 +38,19 @@ export class DatasetBuilder<Source> {
 
   clearFiles (label?: string): void {
     if (this.built) {
-      throw new Error('builder already consumed')
+      this.resetBuiltState()
     }
     if (label === undefined) {
       this.sources = []
     } else {
       this.labelledSources.delete(label)
     }
+  }
+
+  // If files are added or removed, then this should be called since the latest
+  // version of the dataset_builder has not yet been built.
+  private resetBuiltState (): void {
+    this.built = false
   }
 
   private getLabels (): string[] {


### PR DESCRIPTION
As pointed out in #447, after training it is no longer possible to clear the files or add new data.

A simple fix is to remove to error and reset the state and let it be mutable, @s314cy was not sure if it would work at the time because of the vue state. 

fixes #447