### PR TITLE
Add simple simple pre processing definition for image 

### DIFF
--- a/benchmark/src/data.ts
+++ b/benchmark/src/data.ts
@@ -10,12 +10,6 @@ class NodeImageLoader extends dataset.ImageLoader<string> {
   async readImageFrom(source: string): Promise<tf.Tensor3D> {
     const imageBuffer = fs.readFileSync(source)
     let tensor = tf.node.decodeImage(imageBuffer)
-    //Add pre processing here:
-    // e.g: If resize needed uncomment the following
-    // tensor = tf.image.resizeBilinear(tensor, [
-    //   32, 32
-    // ])
-    tensor = tensor.div(tf.scalar(255))
     return tensor as tf.Tensor3D
   }
 }

--- a/discojs/src/dataset/data_loader/image_loader.spec.ts
+++ b/discojs/src/dataset/data_loader/image_loader.spec.ts
@@ -22,6 +22,8 @@ const FILES = Map(DIRS).map((readFilesFromDir)).toObject()
 describe('image loader', () => {
   it('loads single sample without label', async () => {
     const file = './example_training_data/9-mnist-example.png'
+    // Remove preProcessImage to make sure it laods raw content
+    tasks.mnist.task.preProcessImage = undefined
     const singletonDataset = await new NodeImageLoader(tasks.mnist.task).load(file)
     const imageContent = tf.node.decodeImage(fs.readFileSync(file))
     await Promise.all((await singletonDataset.toArrayForTest()).map(async (entry) => {

--- a/discojs/src/task/task.ts
+++ b/discojs/src/task/task.ts
@@ -1,5 +1,6 @@
 import { isDisplayInformation, DisplayInformation } from './display_information'
 import { TrainingInformation } from './training_information'
+import * as tf from '@tensorflow/tfjs'
 
 export type TaskID = string
 
@@ -24,7 +25,7 @@ export function isTask (raw: unknown): raw is Task {
     return false
   }
   if (displayInformation !== undefined &&
-      !isDisplayInformation(displayInformation)) {
+    !isDisplayInformation(displayInformation)) {
     return false
   }
 
@@ -35,9 +36,12 @@ export function isTask (raw: unknown): raw is Task {
   return true
 }
 
+export type PreProcessImage = (tensor: tf.Tensor3D) => tf.Tensor3D
+
 export interface Task {
   // TODO rename to ID
   taskID: TaskID
   displayInformation?: DisplayInformation
   trainingInformation?: TrainingInformation
+  preProcessImage?: PreProcessImage
 }

--- a/discojs/src/task/training_information.ts
+++ b/discojs/src/task/training_information.ts
@@ -7,7 +7,6 @@ export interface TrainingInformation {
   roundDuration: number
   validationSplit: number
   batchSize: number
-  preprocessFunctions: string[]
   modelCompileData: ModelCompileData
   dataType: string
   // maximum absolute value of a number in a randomly generated share for secure aggregation

--- a/discojs/src/tasks/cifar10.ts
+++ b/discojs/src/tasks/cifar10.ts
@@ -32,7 +32,6 @@ export const task: Task = {
     csvLabels: true,
     IMAGE_H: 32,
     IMAGE_W: 32,
-    preprocessFunctions: ['resize'],
     RESIZED_IMAGE_H: 224,
     RESIZED_IMAGE_W: 224,
     LABEL_LIST: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
@@ -49,6 +48,10 @@ export const task: Task = {
       { columnName: 'truck', columnData: 9 }
     ],
     scheme: 'Decentralized'
+  },
+  preProcessImage: (tensor: tf.Tensor3D): tf.Tensor3D => {
+    tensor = tensor.div(tf.scalar(255))
+    return tensor
   }
 }
 

--- a/discojs/src/tasks/lus_covid.ts
+++ b/discojs/src/tasks/lus_covid.ts
@@ -31,12 +31,15 @@ export const task: Task = {
     threshold: 2,
     IMAGE_H: 100,
     IMAGE_W: 100,
-    preprocessFunctions: [],
     LABEL_LIST: ['COVID-Positive', 'COVID-Negative'],
     NUM_CLASSES: 2,
     dataType: 'image',
     aggregateImagesById: true,
     scheme: 'Decentralized'
+  },
+  preProcessImage: (tensor: tf.Tensor3D): tf.Tensor3D => {
+    tensor = tensor.div(tf.scalar(255))
+    return tensor
   }
 }
 

--- a/discojs/src/tasks/mnist.ts
+++ b/discojs/src/tasks/mnist.ts
@@ -32,10 +32,13 @@ export const task: Task = {
 
     IMAGE_H: 28,
     IMAGE_W: 28,
-    preprocessFunctions: [],
     LABEL_LIST: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
     aggregateImagesById: false,
     scheme: 'Decentralized'
+  },
+  preProcessImage: (tensor: tf.Tensor3D): tf.Tensor3D => {
+    tensor = tensor.div(tf.scalar(255))
+    return tensor
   }
 }
 

--- a/discojs/src/tasks/simple_face.ts
+++ b/discojs/src/tasks/simple_face.ts
@@ -22,7 +22,6 @@ export const task: Task = {
     roundDuration: 1,
     validationSplit: 0.2,
     batchSize: 10,
-    preprocessFunctions: [],
     learningRate: 0.001,
     modelCompileData: {
       optimizer: 'sgd',
@@ -35,6 +34,10 @@ export const task: Task = {
     IMAGE_W: 200,
     LABEL_LIST: ['child', 'adult'],
     scheme: 'Federated'
+  },
+  preProcessImage: (tensor: tf.Tensor3D): tf.Tensor3D => {
+    tensor = tensor.div(tf.scalar(255))
+    return tensor
   }
 }
 

--- a/discojs/src/tasks/titanic.ts
+++ b/discojs/src/tasks/titanic.ts
@@ -49,7 +49,6 @@ export const task: Task = {
     roundDuration: 10,
     validationSplit: 0,
     batchSize: 30,
-    preprocessFunctions: [],
     modelCompileData: {
       optimizer: 'rmsprop',
       loss: 'binaryCrossentropy',


### PR DESCRIPTION
# We implement a simple image preprocessing definitions in a user friendly way.

## Introduction

Currently preprocessing is defined at the data loader, which is a bit far from the `Task.ts` file where both the task info and model reside. Ideally preprocessing is also define here to increase ease of use, which is what we do.

### Solution

The approach is to extend the `Task` object to include a preprocessing method, which is then called while loading images under the hood. The resulting preprocessing definition looks as follows:

```js
export const task: Task = {
  taskID: 'simple_face',
  ...
  },
  trainingInformation: {
    modelID: 'simple_face-model',
    epochs: 50,
    ...
    scheme: 'Federated'
  },
  preProcessImage: (tensor: tf.Tensor3D): tf.Tensor3D => {
    tensor = tensor.div(tf.scalar(255))
    return tensor
  }
}
```

We also update the `TASK.md` with information of how to add preprocessing and pre-trained models.

### Design issues

We note that the Task object is passed to the data loader, which is why it is convenient to place the preprocessing in the task itself, more importantly this also allows us to directly define the preprocessing in the same place as where the model and task info resides.

The issue is that the Task object is generic, so we might even define preprocessing in Titanic although it would not be called when data is being loaded. A fix is to make Task generic with respect to the data. We would have something like `Task<D>`, where `D` is the data type used during training, this way we could define a preprocessing based on that type as a function from `D` to `D`.

Closes #385 