### PR TITLE
Implementing byzantine-tolerant aggregator formula

### DIFF
--- a/discojs/src/aggregation.ts
+++ b/discojs/src/aggregation.ts
@@ -60,7 +60,7 @@ export function averageWeights (peersWeights: List<Weights>): Weights {
 }
 
 // See: https://arxiv.org/abs/2012.10333
-export function averageCenteredClippingWeights (peersWeights: List<Weights>, currentModel: Weights): Weights {
+export function averageCenteredClippingWeights (peersWeights: List<Weights>, currentModel: Weights, tauPercentile: number): Weights {
   // Computing the centered peers weights with respect to the previous model aggragation
   const centeredPeersWeights: List<Weights> = applyArithmeticToWeightsAndModel(peersWeights, currentModel, tf.sub)
 
@@ -68,7 +68,7 @@ export function averageCenteredClippingWeights (peersWeights: List<Weights>, cur
   const normArray: number[] = Array.from(centeredPeersWeights.map(model => frobeniusNorm(model)))
 
   // Computing the parameter tau as third percentile with respect to the norm array
-  const tau: number = computeQuantile(normArray, 0.75)
+  const tau: number = computeQuantile(normArray, tauPercentile)
 
   // Computing the centered clipped peers weights given the norm array and the parameter tau
   const centeredMean: List<Weights> = clipWeights(centeredPeersWeights, normArray, tau)

--- a/discojs/src/aggregation.ts
+++ b/discojs/src/aggregation.ts
@@ -33,3 +33,12 @@ export function averageWeights (peersWeights: List<Weights>): Weights {
   const numberOfPeers = peersWeights.size
   return sumWeights(peersWeights).map((w) => w.div(numberOfPeers))
 }
+
+export function averageCenteredClipping (peersWeights: List<Weights>, previousWeights: Weights, tau: number): Weights {
+  const subtractedWeights: List<List<tf.Tensor>> = peersWeights.map(weights => List(weights).zip(List(previousWeights)).map(([w1, w2]) => w1.sub(w2)))
+  const norm: List<number> = subtractedWeights.map(weights => Math.sqrt(weights.map((w) => w.square().sum().dataSync()[0]).reduce((a: number, b) => a + b)))
+
+  const centeredMean: List<List<tf.Tensor>> = subtractedWeights.map(weights => weights.map((w, i) => tf.prod(w, Math.min(1, 1 / (norm.get(i) ?? 1)))))
+
+  return averageWeights(centeredMean.map(weights => Array.from(weights)))
+}

--- a/discojs/src/aggregation.ts
+++ b/discojs/src/aggregation.ts
@@ -3,15 +3,24 @@ import { List } from 'immutable'
 import * as tf from '@tensorflow/tfjs'
 
 import { Weights } from './types'
+import { computeQuantile, frobeniusNorm } from './utility'
+
+// Private functions
+function checkWeights (peersWeights: List<Weights>): boolean {
+  const firstWeightSize = peersWeights.first()?.length
+
+  return firstWeightSize !== undefined && peersWeights.rest().every((ws) => ws.length === firstWeightSize)
+}
+
+function clipWeights (modelList: List<Weights>, normArray: number[], tau: number): List<Weights> {
+  return modelList.map(weights => weights.map((w, i) => tf.prod(w, Math.min(1, tau / (normArray[i])))))
+}
 
 function applyArithmeticToWeights (peersWeights: List<Weights>, tfjsArithmeticFunction: (arg1: tf.Tensor, arg2: tf.Tensor) => tf.Tensor): Weights {
   console.log('Aggregating a list of', peersWeights.size, 'weight vectors.')
-  const firstWeightSize = peersWeights.first()?.length
-  if (firstWeightSize === undefined) {
-    throw new Error('no weights to average')
-  }
-  if (!peersWeights.rest().every((ws) => ws.length === firstWeightSize)) {
-    throw new Error('weights dimensions are different for some of the summands')
+
+  if (!checkWeights(peersWeights)) {
+    throw new Error('peersWeights are not valid')
   }
 
   const peersAverageWeights = peersWeights.reduce((accum: Weights, weights) => {
@@ -20,6 +29,22 @@ function applyArithmeticToWeights (peersWeights: List<Weights>, tfjsArithmeticFu
 
   return peersAverageWeights
 }
+
+function applyArithmeticToWeightsAndModel (peersWeights: List<Weights>, model: Weights, tfjsArithmeticFunction: (arg1: tf.Tensor, arg2: tf.Tensor) => tf.Tensor): List<Weights> {
+  console.log('Computing operation between weights and previous aggregated model')
+
+  if (!checkWeights(peersWeights)) {
+    throw new Error('peersWeights are not valid')
+  }
+
+  return peersWeights.map(weights =>
+    List(weights)
+      .zip(List(model))
+      .map(([w1, w2]) => tfjsArithmeticFunction(w1, w2)))
+    .map(element => Array.from(element))
+}
+
+// Public functions for aggregating weights
 
 export function sumWeights (peersWeights: List<Weights>): Weights {
   return applyArithmeticToWeights(peersWeights, tf.add)
@@ -34,17 +59,20 @@ export function averageWeights (peersWeights: List<Weights>): Weights {
   return sumWeights(peersWeights).map((w) => w.div(numberOfPeers))
 }
 
-// Implementation of: https://arxiv.org/abs/2012.10333
-export function averageCenteredClipping (peersWeights: List<Weights>, previousWeights: Weights, tau: number): Weights {
-  // It computes the difference between the current and the previous weights
-  const weightsDiff: List<List<tf.Tensor>> = peersWeights.map(weights => List(weights).zip(List(previousWeights)).map(([w1, w2]) => w1.sub(w2)))
+// See: https://arxiv.org/abs/2012.10333
+export function averageCenteredClippingWeights (peersWeights: List<Weights>, currentModel: Weights): Weights {
+  // Computing the centered peers weights with respect to the previous model aggragation
+  const centeredPeersWeights: List<Weights> = applyArithmeticToWeightsAndModel(peersWeights, currentModel, tf.sub)
 
-  // It computes the Frobenius norm of the difference between current and previous weights
-  const norm: List<number> = weightsDiff.map(weights => Math.sqrt(weights.map((w) => w.square().sum().dataSync()[0]).reduce((a: number, b) => a + b)))
+  // Computing the Matrix Norm (Frobenius Norm) of the centered peers weights
+  const normArray: number[] = Array.from(centeredPeersWeights.map(model => frobeniusNorm(model)))
 
-  // It computes the centered clipped quantity for each weight, clipping tau/norm(i) at 1.
-  const centeredMean: List<List<tf.Tensor>> = weightsDiff.map(weights => weights.map((w, i) => tf.prod(w, Math.min(1, tau / (norm.get(i) ?? 1)))))
+  // Computing the parameter tau as third percentile with respect to the norm array
+  const tau: number = computeQuantile(normArray, 0.75)
 
-  // It aggregates weights using the centered clipped quantities
+  // Computing the centered clipped peers weights given the norm array and the parameter tau
+  const centeredMean: List<Weights> = clipWeights(centeredPeersWeights, normArray, tau)
+
+  // Aggregating all centered clipped peers weights
   return averageWeights(centeredMean.map(weights => Array.from(weights)))
 }

--- a/discojs/src/privacy.ts
+++ b/discojs/src/privacy.ts
@@ -2,6 +2,7 @@ import { List } from 'immutable'
 import { Weights } from '@/types'
 import { Task } from '@/task'
 import { tf } from '.'
+import { frobeniusNorm } from './utility'
 
 /**
  * Add task-parametrized Gaussian noise to and clip the weights update between the previous and current rounds.
@@ -23,7 +24,7 @@ export function addDifferentialPrivacy (updatedWeights: Weights, staleWeights: W
 
   if (clippingRadius !== undefined) {
     // Frobenius norm
-    const norm = Math.sqrt(weightsDiff.map((w) => w.square().sum().dataSync()[0]).reduce((a: number, b) => a + b))
+    const norm = frobeniusNorm(weightsDiff)
     newWeightsDiff = weightsDiff.map((w) => {
       const clipped = w.div(Math.max(1, norm / clippingRadius))
       if (noiseScale !== undefined) {

--- a/discojs/src/privacy.ts
+++ b/discojs/src/privacy.ts
@@ -24,7 +24,7 @@ export function addDifferentialPrivacy (updatedWeights: Weights, staleWeights: W
 
   if (clippingRadius !== undefined) {
     // Frobenius norm
-    const norm = frobeniusNorm(weightsDiff)
+    const norm = frobeniusNorm(Array.from(weightsDiff))
     newWeightsDiff = weightsDiff.map((w) => {
       const clipped = w.div(Math.max(1, norm / clippingRadius))
       if (noiseScale !== undefined) {

--- a/discojs/src/task/training_information.ts
+++ b/discojs/src/task/training_information.ts
@@ -48,11 +48,11 @@ export interface TrainingInformation {
   // decentralizedSecure: Secure Aggregation on/off:
   // Boolean. true for secure aggregation to be used, if the training scheme is decentralized, false otherwise
   decentralizedSecure?: boolean
-  // byzantineAggregator: Byzantine aggregatore on/off:
-  // Boolean. true to use byzantine aggregation, if the training scheme is federated, false otherwise
-  byzantineAggregator?: boolean
-  // tauPercentile: it indicates the percentile to take when choosing the tau for byzantine-tolerant aggregator:
-  // Number (>0 && <1). It must be a number between 0 and 1 and it is used only if byzantineAggregator is true.
+  // byzantineRobustAggregator: Byzantine robust aggregator on/off:
+  // Boolean. true to use byzantine robust aggregation, if the training scheme is federated, false otherwise
+  byzantineRobustAggregator?: boolean
+  // tauPercentile: it indicates the percentile to take when choosing the tau for byzantine robust aggregator:
+  // Number (>0 && <1). It must be a number between 0 and 1 and it is used only if byzantineRobustAggregator is true.
   tauPercentile?: number
   // maxShareValue: Secure Aggregation: maximum absolute value of a number in a randomly generated share
   // default is 100, must be a positive number, check the ~/disco/information/PRIVACY.md file for more information on significance of maxShareValue selection

--- a/discojs/src/task/training_information.ts
+++ b/discojs/src/task/training_information.ts
@@ -48,6 +48,12 @@ export interface TrainingInformation {
   // decentralizedSecure: Secure Aggregation on/off:
   // Boolean. true for secure aggregation to be used, if the training scheme is decentralized, false otherwise
   decentralizedSecure?: boolean
+  // byzantineAggregator: Byzantine aggregatore on/off:
+  // Boolean. true to use byzantine aggregation, if the training scheme is federated, false otherwise
+  byzantineAggregator?: boolean
+  // tauPercentile: it indicates the percentile to take when choosing the tau for byzantine-tolerant aggregator:
+  // Number (>0 && <1). It must be a number between 0 and 1 and it is used only if byzantineAggregator is true.
+  tauPercentile?: number
   // maxShareValue: Secure Aggregation: maximum absolute value of a number in a randomly generated share
   // default is 100, must be a positive number, check the ~/disco/information/PRIVACY.md file for more information on significance of maxShareValue selection
   // only relevant if secure aggregation is true (for either federated or decentralized learning)

--- a/discojs/src/utility.ts
+++ b/discojs/src/utility.ts
@@ -1,0 +1,18 @@
+import { Weights } from '.'
+
+// See: https://en.wikipedia.org/wiki/Matrix_norm
+export function frobeniusNorm (model: Weights): number {
+  return Math.sqrt(model.map((w) => w.square().sum().dataSync()[0]).reduce((a: number, b) => a + b))
+}
+
+export function computeQuantile (array: number[], q: number): number {
+  const sorted = array.sort((a, b) => a - b)
+  const pos = (sorted.length - 1) * q
+  const base = Math.floor(pos)
+  const rest = pos - base
+  if (sorted[base + 1] !== undefined) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base])
+  } else {
+    return sorted[base]
+  }
+}

--- a/server/src/router/federated.ts
+++ b/server/src/router/federated.ts
@@ -107,14 +107,14 @@ export class Federated extends Server {
       round: 0
     })
 
-    const isByzantine: boolean = task.trainingInformation?.byzantineAggregator ?? false
+    const isByzantineRobust: boolean = task.trainingInformation?.byzantineRobustAggregator ?? false
     const tauPercentile: number = task.trainingInformation?.tauPercentile ?? 0
 
     const buffer = new AsyncBuffer(
       task.taskID,
       BUFFER_CAPACITY,
       async (weights: Weights[]) =>
-        await this.aggregateAndStoreWeights(model, weights, isByzantine, tauPercentile)
+        await this.aggregateAndStoreWeights(model, weights, isByzantineRobust, tauPercentile)
     )
     this.asyncBuffersMap = this.asyncBuffersMap.set(task.taskID, buffer)
 
@@ -273,11 +273,11 @@ export class Federated extends Server {
   private async aggregateAndStoreWeights (
     model: tf.LayersModel,
     weights: Weights[],
-    byzantineAggregator: boolean,
+    byzantineRobustAggregator: boolean,
     tauPercentile: number
   ): Promise<void> {
     // Get averaged weights
-    const averagedWeights = byzantineAggregator && tauPercentile > 0 && tauPercentile < 1
+    const averagedWeights = byzantineRobustAggregator && tauPercentile > 0 && tauPercentile < 1
       ? aggregation.averageCenteredClippingWeights(List<Weights>(weights), model.getWeights(), tauPercentile)
       : aggregation.averageWeights(List<Weights>(weights))
 

--- a/server/src/router/federated.ts
+++ b/server/src/router/federated.ts
@@ -107,11 +107,14 @@ export class Federated extends Server {
       round: 0
     })
 
+    const isByzantine: boolean = task.trainingInformation?.byzantineAggregator ?? false
+    const tauPercentile: number = task.trainingInformation?.tauPercentile ?? 0
+
     const buffer = new AsyncBuffer(
       task.taskID,
       BUFFER_CAPACITY,
       async (weights: Weights[]) =>
-        await this.aggregateAndStoreWeights(model, weights)
+        await this.aggregateAndStoreWeights(model, weights, isByzantine, tauPercentile)
     )
     this.asyncBuffersMap = this.asyncBuffersMap.set(task.taskID, buffer)
 
@@ -269,10 +272,14 @@ export class Federated extends Server {
    */
   private async aggregateAndStoreWeights (
     model: tf.LayersModel,
-    weights: Weights[]
+    weights: Weights[],
+    byzantineAggregator: boolean,
+    tauPercentile: number
   ): Promise<void> {
     // Get averaged weights
-    const averagedWeights = aggregation.averageWeights(List<Weights>(weights))
+    const averagedWeights = byzantineAggregator && tauPercentile > 0 && tauPercentile < 1
+      ? aggregation.averageCenteredClippingWeights(List<Weights>(weights), model.getWeights(), tauPercentile)
+      : aggregation.averageWeights(List<Weights>(weights))
 
     // Update model
     model.setWeights(averagedWeights)


### PR DESCRIPTION
### Library (discojs)

New byzantine-tolerant aggregator added. A new utility file has been created to contain all generic operations (norm, quantile, etc).
New parameters in the `TrainingInformation` interfaces added to include the byzantine-tolerant aggregator in the aggregation phase and to specify the tau percentile to use while applying the formula. 

### Server

Changes in Federated class to include byzantine-tolerant aggregator, if the model wants to use it (looking at TrainingInformation parameters)