### PR TITLE
Fix the Titanic dataset's download link

### DIFF
--- a/discojs-core/src/tasks/titanic.ts
+++ b/discojs-core/src/tasks/titanic.ts
@@ -5,7 +5,7 @@ export const task: Task = {
   displayInformation: {
     taskTitle: 'Titanic',
     summary: {
-      preview: "Test our platform by using a publicly available <b>tabular</b> dataset. <br><br> Download the passenger list from the Titanic shipwreck here: <a class='underline text-primary-dark dark:text-primary-light' href='https://github.com/epfml/disco/raw/develop/discojs/example_training_data/titanic_train.csv'>titanic_train.csv</a> (more info <a class='underline text-primary-dark dark:text-primary-light' href='https://www.kaggle.com/c/titanic'>here</a>). <br> This model predicts the type of person most likely to survive/die in the historic ship accident, based on their characteristics (sex, age, class etc.).",
+      preview: "Test our platform by using a publicly available <b>tabular</b> dataset. <br><br> Download the passenger list from the Titanic shipwreck here: <a class='underline text-primary-dark dark:text-primary-light' href='https://github.com/epfml/disco/raw/develop/example_training_data/titanic_train.csv'>titanic_train.csv</a> (more info <a class='underline text-primary-dark dark:text-primary-light' href='https://www.kaggle.com/c/titanic'>here</a>). <br> This model predicts the type of person most likely to survive/die in the historic ship accident, based on their characteristics (sex, age, class etc.).",
       overview: 'We all know the unfortunate story of the Titanic: this flamboyant new transatlantic boat that sunk in 1912 in the North Atlantic Ocean. Today, we revist this tragedy by trying to predict the survival odds of the passenger given some basic features.'
     },
     model: 'The current model does not normalize the given data and applies only a very simple pre-processing of the data.',


### PR DESCRIPTION
closes #484 by fixing the download link of the titanic task's dataset displayed in the web client (broke after moving `example_data_training/` in #474)