### PR TITLE
Adding byzantine-tolerant aggregator

### DIFF
--- a/discojs-core/src/privacy.ts
+++ b/discojs-core/src/privacy.ts
@@ -18,9 +18,7 @@ export function addDifferentialPrivacy (updatedWeights: WeightsContainer, staleW
 
   if (clippingRadius !== undefined) {
     // Frobenius norm
-    const norm = Math.sqrt(
-      weightsDiff.map((w) => w.square().sum())
-        .reduce((a, b) => a.add(b)).dataSync()[0])
+    const norm = weightsDiff.frobeniusNorm()
 
     newWeightsDiff = weightsDiff.map((w) => {
       const clipped = w.div(Math.max(1, norm / clippingRadius))

--- a/discojs-core/src/task/training_information.ts
+++ b/discojs-core/src/task/training_information.ts
@@ -176,6 +176,12 @@ export interface TrainingInformation {
   // decentralizedSecure: Secure Aggregation on/off:
   // Boolean. true for secure aggregation to be used, if the training scheme is decentralized, false otherwise
   decentralizedSecure?: boolean
+  // byzantineRobustAggregator: Byzantine robust aggregator on/off:
+  // Boolean. true to use byzantine robust aggregation, if the training scheme is federated, false otherwise
+  byzantineRobustAggregator?: boolean
+  // tauPercentile: it indicates the percentile to take when choosing the tau for byzantine robust aggregator:
+  // Number (>0 && <1). It must be a number between 0 and 1 and it is used only if byzantineRobustAggregator is true.
+  tauPercentile?: number
   // maxShareValue: Secure Aggregation: maximum absolute value of a number in a randomly generated share
   // default is 100, must be a positive number, check the ~/disco/information/PRIVACY.md file for more information on significance of maxShareValue selection
   // only relevant if secure aggregation is true (for either federated or decentralized learning)

--- a/discojs-core/src/weights/aggregation.ts
+++ b/discojs-core/src/weights/aggregation.ts
@@ -21,7 +21,7 @@ function parseWeights (weights: Iterable<WeightsLike | WeightsContainer>): List<
   return r
 }
 
-function centerWeights(weights: Iterable<WeightsLike | WeightsContainer>, currentModel: WeightsContainer): List<WeightsContainer> {
+function centerWeights (weights: Iterable<WeightsLike | WeightsContainer>, currentModel: WeightsContainer): List<WeightsContainer> {
   return parseWeights(weights).map(model => model.mapWith(currentModel, tf.sub))
 }
 

--- a/discojs-core/src/weights/aggregation.ts
+++ b/discojs-core/src/weights/aggregation.ts
@@ -21,6 +21,26 @@ function parseWeights (weights: Iterable<WeightsLike | WeightsContainer>): List<
   return r
 }
 
+function centerWeights(weights: Iterable<WeightsLike | WeightsContainer>, currentModel: WeightsContainer): List<WeightsContainer> {
+  return parseWeights(weights).map(model => model.mapWith(currentModel, tf.sub))
+}
+
+function clipWeights (modelList: List<WeightsContainer>, normArray: number[], tau: number): List<WeightsContainer> {
+  return modelList.map(weights => weights.mapWithIndex((w, i) => tf.prod(w, Math.min(1, tau / (normArray[i])))))
+}
+
+function computeQuantile (array: number[], q: number): number {
+  const sorted = array.sort((a, b) => a - b)
+  const pos = (sorted.length - 1) * q
+  const base = Math.floor(pos)
+  const rest = pos - base
+  if (sorted[base + 1] !== undefined) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base])
+  } else {
+    return sorted[base]
+  }
+}
+
 function reduce (
   weights: Iterable<WeightsLike | WeightsContainer>,
   fn: (a: tf.Tensor, b: tf.Tensor) => tf.Tensor
@@ -41,6 +61,24 @@ export function diff (weights: Iterable<WeightsLike | WeightsContainer>): Weight
 export function avg (weights: Iterable<WeightsLike | WeightsContainer>): WeightsContainer {
   const size = List(weights).size
   return sum(weights).map((ws) => ws.div(size))
+}
+
+// See: https://arxiv.org/abs/2012.10333
+export function avgClippingWeights (peersWeights: Iterable<WeightsLike | WeightsContainer>, currentModel: WeightsContainer, tauPercentile: number): WeightsContainer {
+  // Computing the centered peers weights with respect to the previous model aggragation
+  const centeredPeersWeights: List<WeightsContainer> = centerWeights(peersWeights, currentModel)
+
+  // Computing the Matrix Norm (Frobenius Norm) of the centered peers weights
+  const normArray: number[] = Array.from(centeredPeersWeights.map(model => model.frobeniusNorm()))
+
+  // Computing the parameter tau as third percentile with respect to the norm array
+  const tau: number = computeQuantile(normArray, tauPercentile)
+
+  // Computing the centered clipped peers weights given the norm array and the parameter tau
+  const centeredMean: List<WeightsContainer> = clipWeights(centeredPeersWeights, normArray, tau)
+
+  // Aggregating all centered clipped peers weights
+  return avg(centeredMean)
 }
 
 // TODO: implement equal in WeightsContainer

--- a/discojs-core/src/weights/weights_container.ts
+++ b/discojs-core/src/weights/weights_container.ts
@@ -48,7 +48,7 @@ export class WeightsContainer {
     return this._weights.get(index)
   }
 
-  frobeniusNorm() {
+  frobeniusNorm (): number {
     return Math.sqrt(this.map((w) => w.square().sum()).reduce((a, b) => a.add(b)).dataSync()[0])
   }
 

--- a/discojs-core/src/weights/weights_container.ts
+++ b/discojs-core/src/weights/weights_container.ts
@@ -36,12 +36,20 @@ export class WeightsContainer {
     return new WeightsContainer(this._weights.map(fn))
   }
 
+  mapWithIndex (fn: (t: tf.Tensor, i: number) => tf.Tensor): WeightsContainer {
+    return new WeightsContainer(this._weights.map(fn))
+  }
+
   reduce (fn: (acc: tf.Tensor, t: tf.Tensor) => tf.Tensor): tf.Tensor {
     return this._weights.reduce(fn)
   }
 
   get (index: number): tf.Tensor | undefined {
     return this._weights.get(index)
+  }
+
+  frobeniusNorm() {
+    return Math.sqrt(this.map((w) => w.square().sum()).reduce((a, b) => a.add(b)).dataSync()[0])
   }
 
   static of (...weights: TensorLike[]): WeightsContainer {

--- a/server/src/router/federated.ts
+++ b/server/src/router/federated.ts
@@ -277,8 +277,8 @@ export class Federated extends Server {
     tauPercentile: number
   ): Promise<void> {
     // Get averaged weights
-    const averagedWeights = byzantineRobustAggregator && tauPercentile > 0 && tauPercentile < 1 
-      ? aggregation.avgClippingWeights(weights, WeightsContainer.from(model), tauPercentile) 
+    const averagedWeights = byzantineRobustAggregator && tauPercentile > 0 && tauPercentile < 1
+      ? aggregation.avgClippingWeights(weights, WeightsContainer.from(model), tauPercentile)
       : aggregation.avg(weights)
 
     // Update model


### PR DESCRIPTION
### Library (discojs)
New byzantine-tolerant aggregator added. 
New parameters in the TrainingInformation interfaces added to include the byzantine-tolerant aggregator in the aggregation phase and to specify the tau percentile to use while applying the formula.

### Server
Changes in Federated class to include byzantine-tolerant aggregator, if the model wants to use it (looking at TrainingInformation parameters)