### PR TITLE
Overloading of WeightsContainer:map

### DIFF
--- a/discojs-core/src/weights/aggregation.ts
+++ b/discojs-core/src/weights/aggregation.ts
@@ -26,7 +26,7 @@ function centerWeights (weights: Iterable<WeightsLike | WeightsContainer>, curre
 }
 
 function clipWeights (modelList: List<WeightsContainer>, normArray: number[], tau: number): List<WeightsContainer> {
-  return modelList.map(weights => weights.mapWithIndex((w, i) => tf.prod(w, Math.min(1, tau / (normArray[i])))))
+  return modelList.map(weights => weights.map((w, i) => tf.prod(w, Math.min(1, tau / (normArray[i])))))
 }
 
 function computeQuantile (array: number[], q: number): number {

--- a/discojs-core/src/weights/weights_container.ts
+++ b/discojs-core/src/weights/weights_container.ts
@@ -32,11 +32,9 @@ export class WeightsContainer {
     )
   }
 
-  map (fn: (t: tf.Tensor) => tf.Tensor): WeightsContainer {
-    return new WeightsContainer(this._weights.map(fn))
-  }
-
-  mapWithIndex (fn: (t: tf.Tensor, i: number) => tf.Tensor): WeightsContainer {
+  map (fn: (t: tf.Tensor, i: number) => tf.Tensor): WeightsContainer
+  map (fn: (t: tf.Tensor) => tf.Tensor): WeightsContainer
+  map (fn: ((t: tf.Tensor) => tf.Tensor) | ((t: tf.Tensor, i: number) => tf.Tensor)): WeightsContainer {
     return new WeightsContainer(this._weights.map(fn))
   }
 


### PR DESCRIPTION
I approved #489 before realizing the opportunity for a clean function overload on `WeightsContainer:map`

@francesco98 