### PR TITLE
Update TF.js and fix the validation panel for image tasks

### DIFF
--- a/discojs/discojs-core/src/dataset/data_loader/image_loader.ts
+++ b/discojs/discojs-core/src/dataset/data_loader/image_loader.ts
@@ -70,11 +70,11 @@ export abstract class ImageLoader<Source> extends DataLoader<Source> {
       this.shuffle(indices)
     }
 
-    if (config?.validationSplit === undefined) {
+    if (config?.validationSplit === undefined || config?.validationSplit === 0) {
       const dataset = await this.buildDataset(images, labels, indices, config)
       return {
         train: dataset,
-        validation: dataset
+        validation: undefined
       }
     }
 

--- a/discojs/package-lock.json
+++ b/discojs/package-lock.json
@@ -7,8 +7,8 @@
       "name": "@epfml/discojs-dependencies",
       "dependencies": {
         "@koush/wrtc": "0.5",
-        "@tensorflow/tfjs": "3",
-        "@tensorflow/tfjs-node": "3",
+        "@tensorflow/tfjs": "^4.0.0",
+        "@tensorflow/tfjs-node": "^4.0.0",
         "@types/msgpack-lite": "0.1",
         "axios": "0.27",
         "immutable": "4",
@@ -307,16 +307,16 @@
       }
     },
     "node_modules/@tensorflow/tfjs": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.21.0.tgz",
-      "integrity": "sha512-khcARd3/872llL/oF4ouR40qlT71mylU66PGT8kHP/GJ5YKj44sv8lDRjU7lOVlJK7jsJFWEsNVHI3eMc/GWNQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-4.0.0.tgz",
+      "integrity": "sha512-L4DNdK32oKRl9/Epxj9HedD470DFkvLWiqFNhY8P5QUbhrZ8aHHOwMa6+eOi/PeMKAUoxvCBhMP2iRNUkl6C+g==",
       "dependencies": {
-        "@tensorflow/tfjs-backend-cpu": "3.21.0",
-        "@tensorflow/tfjs-backend-webgl": "3.21.0",
-        "@tensorflow/tfjs-converter": "3.21.0",
-        "@tensorflow/tfjs-core": "3.21.0",
-        "@tensorflow/tfjs-data": "3.21.0",
-        "@tensorflow/tfjs-layers": "3.21.0",
+        "@tensorflow/tfjs-backend-cpu": "4.0.0",
+        "@tensorflow/tfjs-backend-webgl": "4.0.0",
+        "@tensorflow/tfjs-converter": "4.0.0",
+        "@tensorflow/tfjs-core": "4.0.0",
+        "@tensorflow/tfjs-data": "4.0.0",
+        "@tensorflow/tfjs-layers": "4.0.0",
         "argparse": "^1.0.10",
         "chalk": "^4.1.0",
         "core-js": "3",
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@tensorflow/tfjs-backend-cpu": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.21.0.tgz",
-      "integrity": "sha512-88S21UAdzyK0CsLUrH17GPTD+26E85OP9CqmLZslaWjWUmBkeTQ5Zqyp6iK+gELnLxPx6q7JsNEeFuPv4254lQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-4.0.0.tgz",
+      "integrity": "sha512-Y9ok6VBMir1MVbkcK+h34hF4ZzHZKOrdjAOeE5eFbSuegJHY/AXWcZEU589VTnEE4AU+SUdjjfp6yvAtU17GAA==",
       "dependencies": {
         "@types/seedrandom": "^2.4.28",
         "seedrandom": "^3.0.5"
@@ -339,15 +339,15 @@
         "yarn": ">= 1.3.2"
       },
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.21.0"
+        "@tensorflow/tfjs-core": "4.0.0"
       }
     },
     "node_modules/@tensorflow/tfjs-backend-webgl": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.21.0.tgz",
-      "integrity": "sha512-N4zitIAT9IX8B8oe489qM3f3VcESxGZIZvHmVP8varOQakTvTX859aaPo1s8hK1qCy4BjSGbweooZe4U8D4kTQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-4.0.0.tgz",
+      "integrity": "sha512-JfTtmdwlnJbV4CRxXLJr5MM0Yzj6WfMXAwM/bjTuDKQsyYdNzq75E72A4B0c+XwSIZb7MnVyUmRkZYeGTCqwtg==",
       "dependencies": {
-        "@tensorflow/tfjs-backend-cpu": "3.21.0",
+        "@tensorflow/tfjs-backend-cpu": "4.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "^2.4.28",
         "@types/webgl-ext": "0.0.30",
@@ -358,27 +358,27 @@
         "yarn": ">= 1.3.2"
       },
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.21.0"
+        "@tensorflow/tfjs-core": "4.0.0"
       }
     },
     "node_modules/@tensorflow/tfjs-converter": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.21.0.tgz",
-      "integrity": "sha512-12Y4zVDq3yW+wSjSDpSv4HnpL2sDZrNiGSg8XNiDE4HQBdjdA+a+Q3sZF/8NV9y2yoBhL5L7V4mMLDdbZBd9/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.0.0.tgz",
+      "integrity": "sha512-VU53ZB9blQyF1geB0xbloedYI6d52yQ0U56uPSS9AcjexrAShnN7VIjfNtCFYeLDmVe3M/frkAuIZmWAv66iMw==",
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.21.0"
+        "@tensorflow/tfjs-core": "4.0.0"
       }
     },
     "node_modules/@tensorflow/tfjs-core": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.21.0.tgz",
-      "integrity": "sha512-YSfsswOqWfd+M4bXIhT3hwtAb+IV8+ODwIxwdFR/7jTAPZP1wMVnSlpKnXHAN64HFOiP+Tm3HmKusEZ0+09A0w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-4.0.0.tgz",
+      "integrity": "sha512-RrTgHPT8Xo6vsBvaRkee1YOoH3lv0lEtS3ISGRcHsUy8mkT8ZIMNou4zaJuIBQ7bVPXOeOFFeTbjDvWVtYypxQ==",
       "dependencies": {
         "@types/long": "^4.0.1",
-        "@types/offscreencanvas": "~2019.3.0",
+        "@types/offscreencanvas": "~2019.7.0",
         "@types/seedrandom": "^2.4.28",
         "@types/webgl-ext": "0.0.30",
-        "@webgpu/types": "0.1.16",
+        "@webgpu/types": "0.1.21",
         "long": "4.0.0",
         "node-fetch": "~2.6.1",
         "seedrandom": "^3.0.5"
@@ -387,36 +387,41 @@
         "yarn": ">= 1.3.2"
       }
     },
+    "node_modules/@tensorflow/tfjs-core/node_modules/@types/offscreencanvas": {
+      "version": "2019.7.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
+    },
     "node_modules/@tensorflow/tfjs-data": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.21.0.tgz",
-      "integrity": "sha512-eFLfw2wIcFNxnP2Iv/SnVlihehzKMumk1b5Prcx1ixk/SbkCo5u0Lt7OVOWaEOKVqvB2sT+dJcTjAh6lrCC/QA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-4.0.0.tgz",
+      "integrity": "sha512-mtpKx4nGfEFBH/QqElmvELBh13T8WDuNC6G8ZkK8W0laW5DiHXinUYzRBc8IQ9XrM32d1m2V5NIpeIfo49BGuw==",
       "dependencies": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.6.1",
         "string_decoder": "^1.3.0"
       },
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.21.0",
+        "@tensorflow/tfjs-core": "4.0.0",
         "seedrandom": "^3.0.5"
       }
     },
     "node_modules/@tensorflow/tfjs-layers": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.21.0.tgz",
-      "integrity": "sha512-CMVXsraakXgnXEnqD9QbtResA7nvV7Jz20pGmjFIodcQkClgmFFhdCG5N+zlVRHEz7VKG2OyfhltZ0dBq/OAhA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.0.0.tgz",
+      "integrity": "sha512-StDOBLaJQr3dL2McM5Dne60yDnwzS98CxxJ0DOH8zq3ZOwY1Zg1GshCebHTy8zEYAbv6vga9JO19nXLVuSa3yQ==",
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "3.21.0"
+        "@tensorflow/tfjs-core": "4.0.0"
       }
     },
     "node_modules/@tensorflow/tfjs-node": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-3.21.1.tgz",
-      "integrity": "sha512-WV77fiuux6E5RR7FRD8RL3yCruhoHjZMI9yybztGLItJwco2YVjHr6h4TOjaZcIMnxu9748iV118MN2ZeLXbdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-4.0.0.tgz",
+      "integrity": "sha512-r+82X0C78ssFOqfVs6x70f3knMzZljVD9Emlnih5d/xpxccS0cZUSNG8tshQV7p5C5nNmiSt5n1XEvn9Qa2hsg==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "1.0.9",
-        "@tensorflow/tfjs": "3.21.0",
+        "@tensorflow/tfjs": "4.0.0",
         "adm-zip": "^0.5.2",
         "google-protobuf": "^3.9.2",
         "https-proxy-agent": "^2.2.1",
@@ -869,9 +874,9 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.16.tgz",
-      "integrity": "sha512-9E61voMP4+Rze02jlTXud++Htpjyyk8vw5Hyw9FGRrmhHQg2GqbuOfwf5Klrb8vTxc2XWI3EfO7RUHMpxTj26A=="
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -5197,16 +5202,16 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-3.21.0.tgz",
-      "integrity": "sha512-khcARd3/872llL/oF4ouR40qlT71mylU66PGT8kHP/GJ5YKj44sv8lDRjU7lOVlJK7jsJFWEsNVHI3eMc/GWNQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-4.0.0.tgz",
+      "integrity": "sha512-L4DNdK32oKRl9/Epxj9HedD470DFkvLWiqFNhY8P5QUbhrZ8aHHOwMa6+eOi/PeMKAUoxvCBhMP2iRNUkl6C+g==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "3.21.0",
-        "@tensorflow/tfjs-backend-webgl": "3.21.0",
-        "@tensorflow/tfjs-converter": "3.21.0",
-        "@tensorflow/tfjs-core": "3.21.0",
-        "@tensorflow/tfjs-data": "3.21.0",
-        "@tensorflow/tfjs-layers": "3.21.0",
+        "@tensorflow/tfjs-backend-cpu": "4.0.0",
+        "@tensorflow/tfjs-backend-webgl": "4.0.0",
+        "@tensorflow/tfjs-converter": "4.0.0",
+        "@tensorflow/tfjs-core": "4.0.0",
+        "@tensorflow/tfjs-data": "4.0.0",
+        "@tensorflow/tfjs-layers": "4.0.0",
         "argparse": "^1.0.10",
         "chalk": "^4.1.0",
         "core-js": "3",
@@ -5215,20 +5220,20 @@
       }
     },
     "@tensorflow/tfjs-backend-cpu": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-3.21.0.tgz",
-      "integrity": "sha512-88S21UAdzyK0CsLUrH17GPTD+26E85OP9CqmLZslaWjWUmBkeTQ5Zqyp6iK+gELnLxPx6q7JsNEeFuPv4254lQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-4.0.0.tgz",
+      "integrity": "sha512-Y9ok6VBMir1MVbkcK+h34hF4ZzHZKOrdjAOeE5eFbSuegJHY/AXWcZEU589VTnEE4AU+SUdjjfp6yvAtU17GAA==",
       "requires": {
         "@types/seedrandom": "^2.4.28",
         "seedrandom": "^3.0.5"
       }
     },
     "@tensorflow/tfjs-backend-webgl": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-3.21.0.tgz",
-      "integrity": "sha512-N4zitIAT9IX8B8oe489qM3f3VcESxGZIZvHmVP8varOQakTvTX859aaPo1s8hK1qCy4BjSGbweooZe4U8D4kTQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-4.0.0.tgz",
+      "integrity": "sha512-JfTtmdwlnJbV4CRxXLJr5MM0Yzj6WfMXAwM/bjTuDKQsyYdNzq75E72A4B0c+XwSIZb7MnVyUmRkZYeGTCqwtg==",
       "requires": {
-        "@tensorflow/tfjs-backend-cpu": "3.21.0",
+        "@tensorflow/tfjs-backend-cpu": "4.0.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "^2.4.28",
         "@types/webgl-ext": "0.0.30",
@@ -5237,30 +5242,37 @@
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-3.21.0.tgz",
-      "integrity": "sha512-12Y4zVDq3yW+wSjSDpSv4HnpL2sDZrNiGSg8XNiDE4HQBdjdA+a+Q3sZF/8NV9y2yoBhL5L7V4mMLDdbZBd9/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.0.0.tgz",
+      "integrity": "sha512-VU53ZB9blQyF1geB0xbloedYI6d52yQ0U56uPSS9AcjexrAShnN7VIjfNtCFYeLDmVe3M/frkAuIZmWAv66iMw==",
       "requires": {}
     },
     "@tensorflow/tfjs-core": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-3.21.0.tgz",
-      "integrity": "sha512-YSfsswOqWfd+M4bXIhT3hwtAb+IV8+ODwIxwdFR/7jTAPZP1wMVnSlpKnXHAN64HFOiP+Tm3HmKusEZ0+09A0w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-4.0.0.tgz",
+      "integrity": "sha512-RrTgHPT8Xo6vsBvaRkee1YOoH3lv0lEtS3ISGRcHsUy8mkT8ZIMNou4zaJuIBQ7bVPXOeOFFeTbjDvWVtYypxQ==",
       "requires": {
         "@types/long": "^4.0.1",
-        "@types/offscreencanvas": "~2019.3.0",
+        "@types/offscreencanvas": "~2019.7.0",
         "@types/seedrandom": "^2.4.28",
         "@types/webgl-ext": "0.0.30",
-        "@webgpu/types": "0.1.16",
+        "@webgpu/types": "0.1.21",
         "long": "4.0.0",
         "node-fetch": "~2.6.1",
         "seedrandom": "^3.0.5"
+      },
+      "dependencies": {
+        "@types/offscreencanvas": {
+          "version": "2019.7.0",
+          "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+          "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
+        }
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-3.21.0.tgz",
-      "integrity": "sha512-eFLfw2wIcFNxnP2Iv/SnVlihehzKMumk1b5Prcx1ixk/SbkCo5u0Lt7OVOWaEOKVqvB2sT+dJcTjAh6lrCC/QA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-4.0.0.tgz",
+      "integrity": "sha512-mtpKx4nGfEFBH/QqElmvELBh13T8WDuNC6G8ZkK8W0laW5DiHXinUYzRBc8IQ9XrM32d1m2V5NIpeIfo49BGuw==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.6.1",
@@ -5268,18 +5280,18 @@
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-3.21.0.tgz",
-      "integrity": "sha512-CMVXsraakXgnXEnqD9QbtResA7nvV7Jz20pGmjFIodcQkClgmFFhdCG5N+zlVRHEz7VKG2OyfhltZ0dBq/OAhA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.0.0.tgz",
+      "integrity": "sha512-StDOBLaJQr3dL2McM5Dne60yDnwzS98CxxJ0DOH8zq3ZOwY1Zg1GshCebHTy8zEYAbv6vga9JO19nXLVuSa3yQ==",
       "requires": {}
     },
     "@tensorflow/tfjs-node": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-3.21.1.tgz",
-      "integrity": "sha512-WV77fiuux6E5RR7FRD8RL3yCruhoHjZMI9yybztGLItJwco2YVjHr6h4TOjaZcIMnxu9748iV118MN2ZeLXbdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-4.0.0.tgz",
+      "integrity": "sha512-r+82X0C78ssFOqfVs6x70f3knMzZljVD9Emlnih5d/xpxccS0cZUSNG8tshQV7p5C5nNmiSt5n1XEvn9Qa2hsg==",
       "requires": {
         "@mapbox/node-pre-gyp": "1.0.9",
-        "@tensorflow/tfjs": "3.21.0",
+        "@tensorflow/tfjs": "4.0.0",
         "adm-zip": "^0.5.2",
         "google-protobuf": "^3.9.2",
         "https-proxy-agent": "^2.2.1",
@@ -5633,9 +5645,9 @@
       "dev": true
     },
     "@webgpu/types": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.16.tgz",
-      "integrity": "sha512-9E61voMP4+Rze02jlTXud++Htpjyyk8vw5Hyw9FGRrmhHQg2GqbuOfwf5Klrb8vTxc2XWI3EfO7RUHMpxTj26A=="
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="
     },
     "abbrev": {
       "version": "1.1.1",

--- a/discojs/package.json
+++ b/discojs/package.json
@@ -15,8 +15,8 @@
   "homepage": "https://github.com/epfml/disco#readme",
   "dependencies": {
     "@koush/wrtc": "0.5",
-    "@tensorflow/tfjs": "3",
-    "@tensorflow/tfjs-node": "3",
+    "@tensorflow/tfjs": "4",
+    "@tensorflow/tfjs-node": "4",
     "@types/msgpack-lite": "0.1",
     "axios": "0.27",
     "immutable": "4",

--- a/web-client/src/components/validation/Validator.vue
+++ b/web-client/src/components/validation/Validator.vue
@@ -101,7 +101,7 @@ async function assessModel (): Promise<void> {
     return toaster.error('Model was not found')
   }
 
-  const testingSet: dataset.Data = (await props.datasetBuilder.build({ validationSplit: 0 })).train
+  const testingSet: dataset.Data = (await props.datasetBuilder.build()).train
 
   toaster.success('Model testing started')
 


### PR DESCRIPTION
## List of changes
- `discojs-core/src/dataset/data_loader/image_loader.ts`
  - When the validation split is undefined, do not return the training `Data` object twice
  - When a validation split of 0 is given, do not attempt to construct an empty validation `Data` object (which would cause data checking errors) but a single training `Data` object instead, which is similar to the case of an undefined validation split.

## Fixed issues

Fixes #498 by upgrading TF.js to v4.0.0. As described by the docs of the release, there is no breaking changes for projects using TypeScript `>=4.4` (we're using v4.4).

Fixes the validation panel for tasks with image data.