### PR TITLE
Fixing issue preventing tasks to be shown

### DIFF
--- a/discojs/discojs-core/src/dataset/data/image_data.ts
+++ b/discojs/discojs-core/src/dataset/data/image_data.ts
@@ -13,9 +13,7 @@ export class ImageData extends Data {
     // better error handling. An incorrectly formatted image in the dataset might still
     // cause an error during training, because of the lazy aspect of the dataset; we only
     // verify the first sample.
-    if (!task.trainingInformation.preprocessingFunctions?.includes(ImagePreprocessing.Resize) ||
-      task.trainingInformation.RESIZED_IMAGE_H === undefined ||
-      task.trainingInformation.RESIZED_IMAGE_W === undefined) {
+    if (!task.trainingInformation.preprocessingFunctions?.includes(ImagePreprocessing.Resize)) {
       try {
         const sample = (await dataset.take(1).toArray())[0]
         // TODO: We suppose the presence of labels

--- a/discojs/discojs-core/src/dataset/data/preprocessing.ts
+++ b/discojs/discojs-core/src/dataset/data/preprocessing.ts
@@ -23,10 +23,10 @@ export function getPreprocessImage (task: Task): PreprocessImage {
       xs = xs.div(tf.scalar(255))
     }
     if (info.preprocessingFunctions?.includes(ImagePreprocessing.Resize) &&
-      info.RESIZED_IMAGE_H !== undefined &&
-      info.RESIZED_IMAGE_W !== undefined) {
+      info.IMAGE_H !== undefined &&
+      info.IMAGE_W !== undefined) {
       xs = tf.image.resizeBilinear(xs, [
-        info.RESIZED_IMAGE_H, info.RESIZED_IMAGE_W
+        info.IMAGE_H, info.IMAGE_W
       ])
     }
     return {

--- a/discojs/discojs-core/src/task/training_information.ts
+++ b/discojs/discojs-core/src/task/training_information.ts
@@ -77,21 +77,24 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     return false
   }
 
-  // interdepences on data type
-  switch (dataType) {
-    case 'image':
-      if ((IMAGE_H !== undefined && typeof IMAGE_H !== 'number') || (IMAGE_W !== undefined && typeof IMAGE_W !== 'number')) {
-        return false
-      }
-      break
-    case 'tabular':
-      if (!(Array.isArray(inputColumns) && inputColumns.every((e) => typeof e === 'string'))) {
-        return false
-      }
-      if (!(Array.isArray(outputColumns) && outputColumns.every((e) => typeof e === 'string'))) {
-        return false
-      }
-      break
+  if (dataType === 'image') {
+    const resizeDefined = (RESIZED_IMAGE_H !== undefined && typeof RESIZED_IMAGE_H !== 'number') || (RESIZED_IMAGE_W !== undefined && typeof RESIZED_IMAGE_W !== 'number')
+    const originalDefined = (IMAGE_H !== undefined && typeof IMAGE_H !== 'number') || (IMAGE_W !== undefined && typeof IMAGE_W !== 'number')
+
+    if (originalDefined) {
+      return !resizeDefined
+    }
+
+    if (resizeDefined) {
+      return !originalDefined
+    }
+  } else if (dataType === 'tabular') {
+    if (!(Array.isArray(inputColumns) && inputColumns.every((e) => typeof e === 'string'))) {
+      return false
+    }
+    if (!(Array.isArray(outputColumns) && outputColumns.every((e) => typeof e === 'string'))) {
+      return false
+    }
   }
 
   console.log(1)

--- a/discojs/discojs-core/src/task/training_information.ts
+++ b/discojs/discojs-core/src/task/training_information.ts
@@ -80,7 +80,7 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
   // interdepences on data type
   switch (dataType) {
     case 'image':
-      if (typeof IMAGE_H !== 'number' || typeof IMAGE_W !== 'number') {
+      if ((IMAGE_H !== undefined && typeof IMAGE_H !== 'number') || (IMAGE_W !== undefined && typeof IMAGE_W !== 'number')) {
         return false
       }
       break

--- a/discojs/discojs-core/src/task/training_information.ts
+++ b/discojs/discojs-core/src/task/training_information.ts
@@ -23,8 +23,6 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     'outputColumns' |
     'IMAGE_H' |
     'IMAGE_W' |
-    'RESIZED_IMAGE_H' |
-    'RESIZED_IMAGE_W' |
     'learningRate' |
     'decentralizedSecure' |
     'maxShareValue' |
@@ -47,8 +45,6 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     outputColumns,
     IMAGE_H,
     IMAGE_W,
-    RESIZED_IMAGE_H,
-    RESIZED_IMAGE_W,
     learningRate,
     decentralizedSecure,
     maxShareValue,
@@ -65,8 +61,6 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     typeof batchSize !== 'number' ||
     // typeof roundDuration !== 'number' ||
     typeof validationSplit !== 'number' ||
-    (RESIZED_IMAGE_H !== undefined && typeof RESIZED_IMAGE_H !== 'number') ||
-    (RESIZED_IMAGE_W !== undefined && typeof RESIZED_IMAGE_W !== 'number') ||
     (noiseScale !== undefined && typeof noiseScale !== 'number') ||
     (clippingRadius !== undefined && typeof clippingRadius !== 'number') ||
     (learningRate !== undefined && typeof learningRate !== 'number') ||
@@ -77,24 +71,21 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     return false
   }
 
-  if (dataType === 'image') {
-    const resizeDefined = (RESIZED_IMAGE_H !== undefined && typeof RESIZED_IMAGE_H !== 'number') || (RESIZED_IMAGE_W !== undefined && typeof RESIZED_IMAGE_W !== 'number')
-    const originalDefined = (IMAGE_H !== undefined && typeof IMAGE_H !== 'number') || (IMAGE_W !== undefined && typeof IMAGE_W !== 'number')
-
-    if (originalDefined) {
-      return !resizeDefined
-    }
-
-    if (resizeDefined) {
-      return !originalDefined
-    }
-  } else if (dataType === 'tabular') {
-    if (!(Array.isArray(inputColumns) && inputColumns.every((e) => typeof e === 'string'))) {
-      return false
-    }
-    if (!(Array.isArray(outputColumns) && outputColumns.every((e) => typeof e === 'string'))) {
-      return false
-    }
+  // interdepences on data type
+  switch (dataType) {
+    case 'image':
+      if (typeof IMAGE_H !== 'number' || typeof IMAGE_W !== 'number') {
+        return false
+      }
+      break
+    case 'tabular':
+      if (!(Array.isArray(inputColumns) && inputColumns.every((e) => typeof e === 'string'))) {
+        return false
+      }
+      if (!(Array.isArray(outputColumns) && outputColumns.every((e) => typeof e === 'string'))) {
+        return false
+      }
+      break
   }
 
   console.log(1)
@@ -154,14 +145,10 @@ export interface TrainingInformation {
   inputColumns?: string[]
   // outputColumns: for tabular data, the columns to be predicted by the model
   outputColumns?: string[]
-  // IMAGE_H height of image
+  // IMAGE_H height of image (or RESIZED_IMAGE_H if ImagePreprocessing.Resize in preprocessingFunctions)
   IMAGE_H?: number
-  // IMAGE_W width of image
+  // IMAGE_W width of image (or RESIZED_IMAGE_W if ImagePreprocessing.Resize in preprocessingFunctions)
   IMAGE_W?: number
-  // RESIZED_IMAGE_H: New image width, note that you must add ImagePreprocessing.Resize in the preprocessingFunctions.
-  RESIZED_IMAGE_H?: number
-  // RESIZED_IMAGE_W: New image width, note that you must add ImagePreprocessing.Resize in the preprocessingFunctions.
-  RESIZED_IMAGE_W?: number
   // LABEL_LIST of classes, e.g. if two class of images, one with dogs and one with cats, then we would
   // define ['dogs', 'cats'].
   LABEL_LIST?: string[]

--- a/discojs/discojs-core/src/tasks/cifar10.ts
+++ b/discojs/discojs-core/src/tasks/cifar10.ts
@@ -29,8 +29,6 @@ export const task: Task = {
     IMAGE_H: 32,
     IMAGE_W: 32,
     preprocessingFunctions: [],
-    RESIZED_IMAGE_H: 224,
-    RESIZED_IMAGE_W: 224,
     LABEL_LIST: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
     scheme: 'Decentralized',
     noiseScale: undefined,

--- a/discojs/discojs-core/src/tasks/geotags.ts
+++ b/discojs/discojs-core/src/tasks/geotags.ts
@@ -26,10 +26,10 @@ export const task: Task = {
       metrics: ['accuracy']
     },
     dataType: 'image',
+    IMAGE_H: 224,
+    IMAGE_W: 224,
     preprocessingFunctions: [ImagePreprocessing.Resize],
     LABEL_LIST: Range(0, 140).map(String).toArray(),
-    RESIZED_IMAGE_H: 224,
-    RESIZED_IMAGE_W: 224,
     scheme: 'Federated',
     noiseScale: undefined,
     clippingRadius: 20,

--- a/discojs/discojs-core/src/tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/tasks/lus_covid.ts
@@ -27,8 +27,8 @@ export const task: Task = {
       metrics: ['accuracy']
     },
     learningRate: 0.001,
-    RESIZED_IMAGE_H: 100,
-    RESIZED_IMAGE_W: 100,
+    IMAGE_H: 100,
+    IMAGE_W: 100,
     preprocessingFunctions: [ImagePreprocessing.Resize],
     LABEL_LIST: ['COVID-Positive', 'COVID-Negative'],
     dataType: 'image',

--- a/discojs/discojs-core/src/tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/tasks/lus_covid.ts
@@ -27,8 +27,6 @@ export const task: Task = {
       metrics: ['accuracy']
     },
     learningRate: 0.001,
-    IMAGE_H: 224,
-    IMAGE_W: 224,
     RESIZED_IMAGE_H: 100,
     RESIZED_IMAGE_W: 100,
     preprocessingFunctions: [ImagePreprocessing.Resize],


### PR DESCRIPTION
### Discojs library

The two fields RESIZED_IMAGE_H and RESIZED_IMAGE_W have been removed because `preprocessingFunctions` is enough. 

If `ImagePreprocessing.Resize` is a preprocessing function, then the target image size after resizing it is IMAGE_H * IMAGE_W. Otherwise, we already expect to have images of size IMAGE_H * IMAGE_W.