### PR TITLE
introduces rework of events communication to remove polling

### DIFF
--- a/discojs/discojs-core/src/client/decentralized/event_connection.ts
+++ b/discojs/discojs-core/src/client/decentralized/event_connection.ts
@@ -1,0 +1,76 @@
+import isomorphic from 'isomorphic-ws'
+import { EventEmitter } from 'events'
+import msgpack from 'msgpack-lite'
+import * as messages from './messages'
+
+export interface EventConnection {
+  on: <K extends messages.type>(type: K, handler: (event: messages.NarrowMessage<K>) => void) => void
+  once: <K extends messages.type>(type: K, handler: (event: messages.NarrowMessage<K>) => void) => void
+  send: <T extends messages.Message>(msg: T) => void
+  disconnect: () => void
+}
+
+export async function waitMessage<T extends messages.type> (connection: EventConnection, type: T): Promise<messages.NarrowMessage<T>> {
+  return await new Promise((resolve) => {
+    // "once" is important because we can't resolve the same promise multiple time
+    connection.once(type, (event) => {
+      resolve(event)
+    })
+  })
+}
+
+export class WebSocketServer implements EventConnection {
+  private constructor (
+    private readonly socket: WebSocket,
+    private readonly eventEmitter: EventEmitter
+  ) { }
+
+  static async connect (url: URL): Promise<WebSocketServer> {
+    const WS = typeof window !== 'undefined' ? window.WebSocket : isomorphic.WebSocket
+    const ws: WebSocket = new WS(url)
+    ws.binaryType = 'arraybuffer'
+
+    const emitter: EventEmitter = new EventEmitter()
+    const server: WebSocketServer = new WebSocketServer(ws, emitter)
+
+    ws.onmessage = (event: isomorphic.MessageEvent) => {
+      if (!(event.data instanceof ArrayBuffer)) {
+        throw new Error('server did not send an ArrayBuffer')
+      }
+
+      const msg = msgpack.decode(new Uint8Array(event.data))
+      if (!messages.isMessageFromServer(msg)) {
+        throw new Error(`invalid message received: ${JSON.stringify(msg)}`)
+      }
+
+      emitter.emit(msg.type.toString(), msg)
+    }
+
+    return await new Promise((resolve, reject) => {
+      ws.onerror = (err: isomorphic.ErrorEvent) =>
+        reject(new Error(`connecting server: ${err.message}`)) // eslint-disable-line @typescript-eslint/restrict-template-expressions
+      ws.onopen = () => resolve(server)
+    })
+  }
+
+  disconnect (): void {
+    this.socket.close()
+  }
+
+  // Not straigtforward way of making sure the handler take the correct message type as a parameter, for typesafety
+  on<K extends messages.type>(type: K, handler: (event: messages.NarrowMessage<K>) => void): void {
+    this.eventEmitter.on(type.toString(), handler)
+  }
+
+  once<K extends messages.type>(type: K, handler: (event: messages.NarrowMessage<K>) => void): void {
+    this.eventEmitter.once(type.toString(), handler)
+  }
+
+  send (msg: messages.Message): void {
+    if (!messages.isMessageToServer(msg)) {
+      throw new Error(`can't send this type of message: ${JSON.stringify(msg)}`)
+    }
+
+    this.socket.send(msgpack.encode(msg))
+  }
+}

--- a/discojs/discojs-core/src/client/decentralized/messages.ts
+++ b/discojs/discojs-core/src/client/decentralized/messages.ts
@@ -4,6 +4,9 @@ import { weights } from '../../serialization'
 
 import { isPeerID, PeerID as PeerIDType } from './types'
 
+// Retrieve a specific message interface from the type D. i.e. NarrowMessage<messages.type.PeerId> => messages.PeerId type
+export type NarrowMessage<D> = Extract<Message, { type: D }>
+
 export enum type {
   clientConnected,
 
@@ -19,7 +22,7 @@ export enum type {
   PartialSums
 }
 
-export interface clientConnectedMessage {
+export interface clientConnected {
   type: type.clientConnected
 }
 
@@ -74,13 +77,18 @@ export interface PartialSums {
   partials: weights.Encoded
 }
 
+export type Message =
+  MessageFromServer |
+  MessageToServer |
+  PeerMessage
+
 export type MessageFromServer =
-  clientConnectedMessage |
   PeerID |
   SignalForPeer |
   PeersForRound
 
 export type MessageToServer =
+  clientConnected |
   SignalForPeer |
   PeerIsReady
 
@@ -110,8 +118,6 @@ export function isMessageFromServer (o: unknown): o is MessageFromServer {
   }
 
   switch (o.type) {
-    case type.clientConnected:
-      return true
     case type.PeerID:
       return 'id' in o && isPeerID(o.id)
     case type.SignalForPeer:
@@ -130,6 +136,8 @@ export function isMessageToServer (o: unknown): o is MessageToServer {
   }
 
   switch (o.type) {
+    case type.clientConnected:
+      return true
     case type.SignalForPeer:
       return 'peer' in o && isPeerID(o.peer) &&
         'signal' in o // TODO check signal content?

--- a/discojs/discojs-core/src/client/decentralized/utils.ts
+++ b/discojs/discojs-core/src/client/decentralized/utils.ts
@@ -2,7 +2,13 @@
 const TICK = 100
 
 // Time to wait for the others in milliseconds.
-const MAX_WAIT_PER_ROUND = 10_000
+export const MAX_WAIT_PER_ROUND = 10_000
+
+export async function timeout (ms: number): Promise<never> {
+  return await new Promise((resolve, reject) => {
+    setTimeout(() => reject(new Error('timeout')), ms)
+  })
+}
 
 // check if a given boolean condition is true, checks continuously until maxWait time is reached
 export async function pauseUntil (condition: () => boolean): Promise<void> {

--- a/server/src/router/federated.ts
+++ b/server/src/router/federated.ts
@@ -132,6 +132,7 @@ export class Federated extends Server {
     model: tf.LayersModel,
     req: express.Request
   ): void {
+    this.sendConnectedMsg(ws)
     const clientId = req.params.clientId
     console.info('client', clientId, 'joined', task.taskID)
 

--- a/server/src/router/server.ts
+++ b/server/src/router/server.ts
@@ -41,7 +41,6 @@ export abstract class Server {
 
     this.ownRouter.ws(this.buildRoute(task), (ws, req) => {
       if (this.isValidUrl(req.url)) {
-        this.sendConnectedMsg(ws)
         this.handle(task, ws, model, req)
       } else {
         ws.terminate()
@@ -67,8 +66,6 @@ export abstract class Server {
   protected abstract get description (): string
 
   protected abstract buildRoute (task: Task): string
-
-  protected abstract sendConnectedMsg (ws: WebSocket): void
 
   protected abstract initTask (task: Task, model: tf.LayersModel): void
 


### PR DESCRIPTION
My first PR in TypeScript, fun language!

TL;DR:
* a new EventConnection abstracts the network events communication and allow for useful extensions
* ability to `await` an event to describe async event flows in a linear way
* Remove `pauseUntil` for client-server messages in decentralized client

# The problem

We have polling in multiple place in the code with the method `pauseUntil` which resolve a promise based on a `setInterval`, this is not very elegant and hide the relation between the events received via WebSockets and the actual consequences.

See this comment https://github.com/epfml/disco/pull/348#discussion_r979838963

>the issue is that data generation (the WS & peer connections) and data consumption (the other funcs) aren't linked. the best way would have to represent theses connections as an async stream/iterable/generator of messages, so that the consumers can await the next message and directly act on the received value, thus keeping the processing local to a function. that would also ensure that the server/peers are sending the correct sequence of messages
>
>so I would look into turning theses connections into [async generators](https://javascript.info/async-iterators-generators#async-generators-finally), or a good old [EventEmitter](https://danilafe.com/blog/typescript_typesafe_events/)

The change is more intricate than it seems, removing the polling involves rethinking about the whole flow of events in the client if we want it to look good.

Currently, we process the events in their own isolated scope of code, which is generally fine, but here we have other part of the code that relies on these events to do their work. It's not really clear what the sequence of event is and how the code depends on it. Ideally, the "consumer" of the event can directly process the pertinent data locally.
The aim of this PR is to do exactly that, we want to represent the events as a "stream" of messages and be able to consume them when needed. Using `async/await` we can highlight the communication flow in a clear/linear way.

# Proposed solution

This is a suggestion on how we could handle these events in a cleanlier way, this is currently only applied to the client-server message in the decentralized workflow. I don't advocate this is a perfect way of doing, feel free to challenge it if you have another idea to solve the problem.

## Abstracting the websocket connection

The idea is to hide the fact that the network connection is implemented by WebSocket from the clients code.
We leave the websocket part handle the network and we rewrap the message as "Events" that are propagated to the rest of the application. This also allows us to easily consume only one type of event, contrary to the provided websocket listener only has the `message` event and we have to check the content everytime to know the actual structure, and also to receive every message type.
Now we have an `EventConnection` that can listens to specific events, and can be implemented by whatever needed protocol, without changing the client code. It wraps arround an `EventEmitter` to propagate event in the rest of the code.

## Why not async generator?
I'm not really familiar with generators but it doesn't seems to be the tool for the job.
When a message is retrieved from the generator it is "consumed", then no other part of the code can read the same message easily. With the eventEmitter we can have multiple listeners on the same event type and they will all get executed.

## EventEmitter is Node API
https://nodejs.org/api/events.html
It shouldn't work in the browser by default without replacing it by a library with equivalent API. I still need to test if the browser work with this code. If not I'll check the webpack config, or we can just implements our own cross-platform `EventEmitter` directly in the code.

EDIT: events seems to work in the browser too

## Others

* I reversed the `clientConnected` logic. Before, the server was sending the connected and peerId message immediately on socket opening, this means that the client could *theorically* finish "connecting" before having received its peerId. Now the client `connect` tell the server it has connected and only returns when it receive its peerId. (Old behavior still in federated server and client)
* I tried to leverage Generics to force some typesafety when passing handler for specific events.
---

## Tests

When I run
```
npx mocha --exit -r ts-node/register 'tests/end_to_end_decentralized.ts'
```

on the `develop` branch, I get random fail with timeout from peers, it does not looks like it's linked to a specific behavior on my machine, it might be due to inconsistency with sending and receiving event at the right time.
The good news is that my implementation seems to fix that, I run the test 20 times on both branches with a script:

```
develop: 20 runs, 2 success, 18 fail
remove-pause-until: 20 runs, 20 success, 0 fail
```

EDIT: strangely, the tests seems to work much more consistently on the pipeline, even without my modified code, I encounter the fail only locally

If the solution is satisfying enough, I can go on and try to generalize it for the peer2peer messages and for the federated client in another PR.