### PR TITLE
Small fixes for `cli` README and code

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -22,7 +22,9 @@ npm run start -- -t cifar10 -u 4 -e 15 -r 5
 
 - install node 16 and ensure it is activated on opening any new terminal (e.g. `nvm use 16`)
 - clone this repository
-- `npm ci` within `discojs`, `server` and `benchmark`
+- download the `example_training_data.tar.gz` file and extract it into the root of the repository
+  - simply execute [get_training_data.sh](../get_training_data.sh)
+- `npm ci` within `discojs` and `server`
 - `cd discojs; rm -rf dist; npm run build`
 
 ## Custom Tasks

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,13 +9,13 @@ frequently the clients communicate with each other), ...
 To train cifar10, using 4 federated clients for 15 epochs with a round duration of 5 batches, all you have to do is type
 
 ```
-npm run benchmark -- --task cifar10 --numberOfUsers 4 --epochs 15 --roundDuration 5
+npm run start -- --task cifar10 --numberOfUsers 4 --epochs 15 --roundDuration 5
 ```
 
 or also using the shorter alias notation
 
 ```
-npm run benchmark -- -t cifar10 -u 4 -e 15 -r 5
+npm run start -- -t cifar10 -u 4 -e 15 -r 5
 ```
 
 ## Quick-install guide
@@ -24,12 +24,6 @@ npm run benchmark -- -t cifar10 -u 4 -e 15 -r 5
 - clone this repository
 - `npm ci` within `discojs`, `server` and `benchmark`
 - `cd discojs; rm -rf dist; npm run build`
-
-## Running the benchmark
-
-- `cd benchmark`
-- `npm run benchmark` to run the benchmark with the default setting, to see the available flags run
-- `npm run benchmark -- --help`
 
 ## Custom Tasks
 
@@ -125,5 +119,5 @@ supportedTasks = supportedTasks.set(tasks.simple_face.task.taskID, tasks.simple_
 Now you are done and you should be able to run your task as follows
 
 ```
-npm run benchmark -- --task simple_face --numberOfUsers 4 --epochs 15 --roundDuration 5
+npm run start -- --task simple_face --numberOfUsers 4 --epochs 15 --roundDuration 5
 ```

--- a/get_training_data.sh
+++ b/get_training_data.sh
@@ -4,4 +4,3 @@ ARCHIVE="example_training_data.tar.gz"
 cd $DIR
 curl -L "http://deai-313515.appspot.com.storage.googleapis.com/$ARCHIVE" -o $ARCHIVE
 tar -xf $ARCHIVE
-

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -41,6 +41,8 @@ export class TasksAndModels extends EventEmitter {
           console.error(e instanceof Error ? e.message : e.toString())
           return
         }
+        // Create the directory if it does not exist
+        fs.mkdirSync(modelPath, { recursive: true })
         await model.save(`file://${modelPath}`)
       }
       ret.addTaskAndModel(i.task, model)


### PR DESCRIPTION
- Removed benchmark and fixed script name in README.md
- Renamed `get_training_data` file to `get_training_data.sh` and referenced it in `cli` README
- Fixed `ENOENT: no such file or directory, mkdir <path>` error when no folder named `models` exists in `cli` by recursively creating expected output directories