### PR TITLE
gh-pages as single commit

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -33,3 +33,4 @@ jobs:
         with:
           branch: gh-pages
           folder: web-client/dist
+          single-commit: true

--- a/web-client/src/assets/gif/DiscoGIF.vue
+++ b/web-client/src/assets/gif/DiscoGIF.vue
@@ -1,5 +1,5 @@
 <template>
-  <img src="https://storage.googleapis.com/deai-313515.appspot.com/gifs/decentralized_render.gif">
+  <img src="https://storage.googleapis.com/deai-313515.appspot.com/gifs/disco_middle.gif">
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue'


### PR DESCRIPTION
Just to ensure the `gh-pages` deployment branch doesn't explode in size, since it contains all the build files of the web client.

Also, fixed the landing page's GIF.