### PR TITLE
Add model URL support

### DIFF
--- a/discojs/discojs-core/src/task/training_information.ts
+++ b/discojs/discojs-core/src/task/training_information.ts
@@ -23,6 +23,7 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     'outputColumns' |
     'IMAGE_H' |
     'IMAGE_W' |
+    'modelURL' |
     'learningRate' |
     'decentralizedSecure' |
     'maxShareValue' |
@@ -45,6 +46,8 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     outputColumns,
     IMAGE_H,
     IMAGE_W,
+    roundDuration,
+    modelURL,
     learningRate,
     decentralizedSecure,
     maxShareValue,
@@ -59,8 +62,9 @@ export function isTrainingInformation (raw: unknown): raw is TrainingInformation
     typeof modelID !== 'string' ||
     typeof epochs !== 'number' ||
     typeof batchSize !== 'number' ||
-    // typeof roundDuration !== 'number' ||
+    typeof roundDuration !== 'number' ||
     typeof validationSplit !== 'number' ||
+    (modelURL !== undefined && typeof modelURL !== 'string') ||
     (noiseScale !== undefined && typeof noiseScale !== 'number') ||
     (clippingRadius !== undefined && typeof clippingRadius !== 'number') ||
     (learningRate !== undefined && typeof learningRate !== 'number') ||
@@ -147,6 +151,8 @@ export interface TrainingInformation {
   IMAGE_H?: number
   // IMAGE_W width of image (or RESIZED_IMAGE_W if ImagePreprocessing.Resize in preprocessingFunctions)
   IMAGE_W?: number
+  // Model URL to download the base task model from. Useful for pretrained or/and hosted models.
+  modelURL?: string
   // LABEL_LIST of classes, e.g. if two class of images, one with dogs and one with cats, then we would
   // define ['dogs', 'cats'].
   LABEL_LIST?: string[]

--- a/discojs/discojs-core/src/tasks/simple_face.ts
+++ b/discojs/discojs-core/src/tasks/simple_face.ts
@@ -1,4 +1,4 @@
-import { tf, dataset, Task } from '..'
+import { dataset, Task } from '..'
 
 export const task: Task = {
   taskID: 'simple_face',
@@ -17,6 +17,7 @@ export const task: Task = {
   trainingInformation: {
     modelID: 'simple_face-model',
     epochs: 50,
+    modelURL: 'https://storage.googleapis.com/deai-313515.appspot.com/models/mobileNetV2_35_alpha_2_classes/model.json',
     roundDuration: 1,
     validationSplit: 0.2,
     batchSize: 10,
@@ -35,11 +36,4 @@ export const task: Task = {
     noiseScale: undefined,
     clippingRadius: undefined
   }
-}
-
-// code executed server-side only
-export async function model (): Promise<tf.LayersModel> {
-  return await tf.loadLayersModel(
-    'https://storage.googleapis.com/deai-313515.appspot.com/models/mobileNetV2_35_alpha_2_classes/model.json'
-  )
 }

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -36,7 +36,15 @@ export class TasksAndModels extends EventEmitter {
       } else {
         // otherwise, init the task's model and save it
         try {
-          model = await i.model()
+          const modelURL = i.task.trainingInformation.modelURL
+          if (modelURL !== undefined) {
+            model = await tf.loadLayersModel(modelURL)
+          } else if ('model' in i && typeof i.model === 'function') {
+            model = await i.model()
+          } else {
+            console.warn('could not infer model from provided task object:', i)
+            return
+          }
         } catch (e: any) {
           console.error(e instanceof Error ? e.message : e.toString())
           return

--- a/web-client/src/components/task_creation_form/containers/FileContainer.vue
+++ b/web-client/src/components/task_creation_form/containers/FileContainer.vue
@@ -1,17 +1,15 @@
 <template>
   <div>
-    <div class="h-72 my-3">
+    <div
+      class="h-72 my-3"
+    >
       <div
         class="
-          relative
-          h-full
-          hover:cursor-pointer
-          border-dashed border-2 border-gray-500
-          dark:border-primary
-          flex flex-col
-          justify-center
-          items-center
+          relative h-full
+          border-dashed border-2 border-disco-cyan
+          flex flex-col justify-center items-center
         "
+        :class="available ? 'hover:cursor-pointer' : 'hover:cursor-not-allowed'"
       >
         <div class="absolute">
           <div class="flex flex-col items-center">
@@ -26,33 +24,34 @@
               /></svg><span class="block text-gray-400 font-normal">Drag and drop your file anywhere or</span>
             <span class="block text-gray-400 font-normal">or</span>
             <label
-              :for="`hidden_${props.field.id}`"
+              :for="`hidden_${field.id}`"
               class="
                 block
                 font-normal
-                mt-2
-                p-2
+                mt-2 p-2
                 rounded-sm
                 text-slate-700
                 transition-colors
                 duration-200
-                bg-white
-                hover:text-disco-cyan hover:bg-slate-100
+                bg-slate-100
                 focus:outline-none
               "
+              :class="available ? 'hover:cursor-pointer hover:text-disco-cyan' : 'hover:cursor-not-allowed'"
             >select file</label>
             <VeeField
-              :id="props.field.id"
+              :id="field.id"
               v-model="fileName"
-              :name="props.field.id"
+              :name="field.id"
               hidden
             />
             <input
-              :id="`hidden_${props.field.id}`"
+              :id="`hidden_${field.id}`"
+              :accept="field.extension"
+              :disable="!available"
               type="file"
-              :accept="props.field.extension"
               class="h-full w-full"
               multiple
+              :disabled="!available"
               hidden
               @change="onChange"
             >
@@ -63,7 +62,7 @@
     <div
       class="flex justify-between items-center text-gray-400"
     >
-      <span>Accepted file type: {{ props.field.extension }} only</span>
+      <span>Accepted file type: {{ field.extension }} only</span>
       <span class="flex items-center"><i class="fa fa-lock mr-1" /> secure</span>
     </div>
   </div>
@@ -76,10 +75,16 @@ import { Field as VeeField } from 'vee-validate'
 import { HTMLInputEvent } from '@/types'
 import { FormField } from '@/task_creation_form'
 
-interface Props {
-  field: FormField
-}
-const props = defineProps<Props>()
+const { field, available = true } = defineProps({
+  field: {
+    type: Object as () => FormField,
+    required: true
+  },
+  available: {
+    type: Boolean,
+    default: true
+  }
+})
 
 interface Emits {
   (e: 'input', files: FileList): void
@@ -92,7 +97,6 @@ const onChange = (e: HTMLInputEvent): void => {
   const files = e.target.files
   // fill in the vee-field to trigger yup validation
   fileName.value = (files.length > 0) ? files[0].name : ''
-  console.log(fileName.value)
   emit('input', files)
 }
 </script>

--- a/web-client/src/components/task_creation_form/containers/SelectContainer.vue
+++ b/web-client/src/components/task_creation_form/containers/SelectContainer.vue
@@ -7,15 +7,10 @@
     :select="props.field.type === 'select-multiple'"
     :multiple="props.field.type === 'select-multiple'"
     class="
-      bg-transparent
-      border-b
-      m-auto
-      block
-      focus:outline-none focus:border-green-500
-      w-full
-      mb-6
+      bg-gray-100 rounded-md border p-2 mt-1
+      block w-full
       text-gray-700
-      pb-1
+      focus:outline-none focus:border-disco-cyan
     "
   >
     <option

--- a/web-client/src/components/task_creation_form/containers/TextContainer.vue
+++ b/web-client/src/components/task_creation_form/containers/TextContainer.vue
@@ -1,6 +1,7 @@
 <template>
   <CustomField
-    :field="props.field"
+    :field="field"
+    :available="available"
     :rows="rows"
   />
 </template>
@@ -11,10 +12,16 @@ import { computed, defineProps } from 'vue'
 import { FormField } from '@/task_creation_form'
 import CustomField from '@/components/task_creation_form/simple/CustomField.vue'
 
-interface Props {
-  field: FormField
-}
-const props = defineProps<Props>()
+const props = defineProps({
+  field: {
+    type: Object as () => FormField,
+    required: true
+  },
+  available: {
+    type: Boolean,
+    default: true
+  }
+})
 
 const rows = computed(() => props.field.as === 'textarea' ? 6 : undefined)
 </script>

--- a/web-client/src/components/task_creation_form/simple/CustomField.vue
+++ b/web-client/src/components/task_creation_form/simple/CustomField.vue
@@ -3,15 +3,12 @@
     :id="props.field.id"
     :name="props.field.id"
     class="
-      bg-transparent
-      border-b
-      block
-      focus:outline-none focus:border-green-500
-      w-full
-      mb-6
-      text-gray-700
-      pb-1
+    bg-gray-100 rounded-md border px-3 py-2 mt-1
+      block w-full
+    text-gray-700
+      focus:outline-none focus:border-disco-cyan
     "
+    :class="{ 'hover:cursor-not-allowed': !available }"
     :as="props.field.as"
     :type="props.field.type"
     :placeholder="props.field.default"
@@ -41,6 +38,10 @@ const props = defineProps({
   step: {
     type: String,
     default: undefined
+  },
+  available: {
+    type: Boolean,
+    default: true
   }
 })
 </script>

--- a/web-client/src/task_creation_form.ts
+++ b/web-client/src/task_creation_form.ts
@@ -21,6 +21,7 @@ export interface FormField {
   elements?: FormElement[]
   dependencies?: FormDependency
   extension?: '.bin' | '.json'
+  description?: string
 }
 
 export interface FormSection {
@@ -29,7 +30,7 @@ export interface FormSection {
   fields: FormField[]
 }
 
-const otherReq = (req: string) => {
+const otherReq = (req: any) => {
   return {
     is: req,
     then: (schema: yup.AnySchema) => schema.required()
@@ -426,18 +427,30 @@ const modelFiles: FormSection = {
   title: 'Model Files',
   fields: [
     {
+      id: 'modelURL',
+      name: 'Model URL',
+      description: 'URL endpoint serving the model files. See <a class="text-disco-cyan hover:text-disco-blue" target="_blank" href="https://www.tensorflow.org/js/guide/save_load#https">TF.js docs</a> for more information.',
+      type: 'text',
+      yup: yup
+        .string()
+        .when(['modelFile', 'weightsFile'], otherReq((value: string) => !value)),
+      default: 'https://example.com/model.json'
+    },
+    {
       id: 'modelFile',
-      name: 'TensorFlow.js Model in JSON format',
+      name: 'Model File',
+      description: 'TensorFlow.js Model in JSON format',
       type: 'file',
-      yup: yup.string().required(),
+      yup: yup.string().when('modelURL', otherReq((value: string) => !value)),
       extension: '.json',
       default: 'model.json'
     },
     {
       id: 'weightsFile',
-      name: 'TensorFlow.js Model Weights in .bin format',
+      name: 'Weights Files',
+      description: 'TensorFlow.js Model Weights in .bin format',
       type: 'file',
-      yup: yup.string().required(),
+      yup: yup.string().when('modelURL', otherReq((value: string) => !value)),
       extension: '.bin',
       default: 'weights.bin'
     }


### PR DESCRIPTION
## Features

1. Tasks now support the `modelURL` string field. If defined, the Disco server will download the initial model of the task from the remote model URL. This means that tasks defining this parameter don't need to provide a `model` function!

2. The Task Creation Form now also supports model URLs. Before submitting the form, a user must provide either _all_ model files or a model URL. The form prevents the user from providing both.

3. The Task Creation Form received design improvements :)

## Linked issue

This PR is linked to #494, as it adds backend support for the `modelURL` field.