### PR TITLE
Web Client: hotfix task params display & description

### DIFF
--- a/web-client/src/components/training/Description.vue
+++ b/web-client/src/components/training/Description.vue
@@ -58,15 +58,21 @@
               "
               class="grid grid-cols-3 gap-4"
             >
-              <span>{{ field.name }}</span>
+              <span>{{ field.description ?? field.name }}</span>
               <div class="col-span-2">
                 <span>
                   {{
-                    prettifyField(
-                      field,
-                      task.trainingInformation.modelCompileData,
-                      section.id === 'modelCompileData'
-                    )
+                    section.id === 'modelCompileData' ?
+                      prettifyField(
+                        field,
+                        task.trainingInformation.modelCompileData,
+                        true
+                      ) :
+                      prettifyField(
+                        field,
+                        task.trainingInformation,
+                        false
+                      )
                   }}
                 </span>
               </div>

--- a/web-client/src/task_creation_form.ts
+++ b/web-client/src/task_creation_form.ts
@@ -372,7 +372,8 @@ export const modelCompileData: FormSection = {
     },
     {
       id: 'metrics',
-      name: 'Metrics (multiple can be selected)',
+      name: 'Metrics',
+      description: 'Metrics (multiple can be selected)',
       yup: yup.array().of(yup.string()).min(1).required(),
       type: 'select-multiple',
       options: [
@@ -408,7 +409,8 @@ export const privacyParameters: FormSection = {
     },
     {
       id: 'clippingRadius',
-      name: 'Differential Privacy: Clipping Radius',
+      name: 'Clipping Radius',
+      description: 'Differential Privacy: Clipping Radius',
       yup: yup.number().positive(),
       as: 'input',
       type: 'number'


### PR DESCRIPTION
## What got fixed?

In the Web Client, task params outside of `modelCompileData` are not correctly displayed in the task description menu. Also, two parameters have the wrong description/name.

## Related PR

PR #528