### PR TITLE
Add digest verification of downloaded model files

### DIFF
--- a/discojs/discojs-core/src/task/digest.ts
+++ b/discojs/discojs-core/src/task/digest.ts
@@ -1,0 +1,24 @@
+export interface Digest {
+  algorithm: string
+  value: string
+}
+
+export function isDigest (raw: unknown): raw is Digest {
+  if (typeof raw !== 'object') {
+    return false
+  }
+  if (raw === null) {
+    return false
+  }
+
+  const { algorithm, value } = raw as Record<string, unknown | undefined>
+
+  if (!(
+    typeof algorithm === 'string' &&
+    typeof value === 'string'
+  )) {
+    return false
+  }
+
+  return true
+}

--- a/discojs/discojs-core/src/task/task.ts
+++ b/discojs/discojs-core/src/task/task.ts
@@ -1,5 +1,6 @@
 import { isDisplayInformation, DisplayInformation } from './display_information'
 import { isTrainingInformation, TrainingInformation } from './training_information'
+import { isDigest, Digest } from './digest'
 
 export type TaskID = string
 
@@ -15,10 +16,13 @@ export function isTask (raw: unknown): raw is Task {
     return false
   }
 
-  const { taskID, displayInformation, trainingInformation } = raw as
-    Record<'taskID' | 'displayInformation' | 'trainingInformation', unknown | undefined>
+  const { taskID, digest, displayInformation, trainingInformation } = raw as
+    Record<'taskID' | 'digest' | 'displayInformation' | 'trainingInformation', unknown | undefined>
 
   if (typeof taskID !== 'string') {
+    return false
+  }
+  if (digest !== undefined && !isDigest(digest)) {
     return false
   }
   if (!isDisplayInformation(displayInformation)) {
@@ -37,6 +41,7 @@ export function isTask (raw: unknown): raw is Task {
 export interface Task {
   // TODO rename to ID
   taskID: TaskID
+  digest?: Digest
   displayInformation: DisplayInformation
   trainingInformation: TrainingInformation
 }

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -1,8 +1,9 @@
 import { Set } from 'immutable'
 import { EventEmitter } from 'node:events'
-import fs from 'fs'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
 
-import { tf, tasks as defaultTasks, Task } from '@epfml/discojs-node'
+import { tf, tasks as defaultTasks, Task, Path } from '@epfml/discojs-node'
 
 // default tasks and added ones
 // register 'taskAndModel' event to get tasks
@@ -35,22 +36,58 @@ export class TasksAndModels extends EventEmitter {
         model = await tf.loadLayersModel(`file://${modelPath}/model.json`)
       } else {
         // otherwise, init the task's model and save it
+        const modelURL = i.task.trainingInformation.modelURL
+        const digest = i.task.digest
         try {
-          const modelURL = i.task.trainingInformation.modelURL
           if (modelURL !== undefined) {
             model = await tf.loadLayersModel(modelURL)
           } else if ('model' in i && typeof i.model === 'function') {
             model = await i.model()
           } else {
-            console.warn('could not infer model from provided task object:', i)
+            console.warn('could not infer model from provided task object:', i.task.taskID)
             return
           }
         } catch (e: any) {
           console.error(e instanceof Error ? e.message : e.toString())
           return
         }
+
         fs.mkdirSync(modelPath, { recursive: true })
         await model.save(`file://${modelPath}`)
+
+        if (modelURL !== undefined && digest !== undefined) {
+          let weightsFiles: string | string[]
+          try {
+            const hash = createHash(digest.algorithm)
+            const modelConfigRaw = fs.readFileSync(`${modelPath}/model.json`)
+
+            const modelConfig = JSON.parse(modelConfigRaw.toString())
+            weightsFiles = modelConfig.weightsManifest[0].paths
+            if (!(
+              Array.isArray(weightsFiles) &&
+              typeof weightsFiles[0] === 'string'
+            )) {
+              throw new Error()
+            }
+            weightsFiles.forEach((file) => {
+              const data = fs.readFileSync(`${modelPath}/${file}`)
+              hash.update(data)
+            })
+
+            const computedDigest = hash.digest('base64')
+            if (computedDigest !== digest.value) {
+              console.warn('digest for', i.task.taskID, 'was\n', computedDigest, '\nbut expected\n', digest.value)
+              TasksAndModels.removeModelFiles(modelPath)
+              return
+            } else {
+              console.log('verified digest for', i.task.taskID)
+            }
+          } catch {
+            console.warn('could not compute digest for', i.task.taskID)
+            TasksAndModels.removeModelFiles(modelPath)
+            return
+          }
+        }
       }
       ret.addTaskAndModel(i.task, model)
     }))
@@ -61,5 +98,12 @@ export class TasksAndModels extends EventEmitter {
   addTaskAndModel (task: Task, model: tf.LayersModel): void {
     this.tasksAndModels = this.tasksAndModels.add([task, model])
     this.emit('taskAndModel', task, model)
+  }
+
+  static removeModelFiles (path: Path): void {
+    console.warn('removing nodel files at', path)
+    fs.rm(path, { recursive: true, force: true }, (err) => {
+      if (err !== null) console.error(err)
+    })
   }
 }

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -68,7 +68,7 @@ export class TasksAndModels extends EventEmitter {
             )) {
               throw new Error()
             }
-            weightsFiles.forEach((file) => {
+            weightsFiles.forEach((file: string) => {
               const data = fs.readFileSync(`${modelPath}/${file}`)
               hash.update(data)
             })

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -56,13 +56,12 @@ export class TasksAndModels extends EventEmitter {
         await model.save(`file://${modelPath}`)
 
         if (modelURL !== undefined && digest !== undefined) {
-          let weightsFiles: string | string[]
           try {
             const hash = createHash(digest.algorithm)
             const modelConfigRaw = fs.readFileSync(`${modelPath}/model.json`)
 
             const modelConfig = JSON.parse(modelConfigRaw.toString())
-            weightsFiles = modelConfig.weightsManifest[0].paths
+            const weightsFiles = modelConfig.weightsManifest[0].paths
             if (!(
               Array.isArray(weightsFiles) &&
               typeof weightsFiles[0] === 'string'


### PR DESCRIPTION
## Feature

When a task specifies a URL to download its initial model from, it may provide a digest to ensure the authenticity of the downloaded files. Supported algorithms are the ones supported by the OpenSSL version of the server. See the [docs](https://nodejs.org/api/crypto.html#cryptocreatehashalgorithm-options) for more info.

## Possible improvements

Don't store the downloaded files on the file system before verifying the digest. This means manually downloading the model files and verifying their content, instead of using `tf.loadLayersModel` which directly converts the downloaded files to a model object.

## Related issue

Fixes #494