### PR TITLE
Download and infer from remote models

### DIFF
--- a/discojs/discojs-core/src/memory/base.ts
+++ b/discojs/discojs-core/src/memory/base.ts
@@ -9,6 +9,7 @@ export type Path = string
 
 export interface ModelInfo {
   type?: ModelType
+  version?: number
   taskID: TaskID
   name: string
 }
@@ -26,7 +27,9 @@ export abstract class Memory {
 
   abstract updateWorkingModel (source: ModelSource, model: tf.LayersModel): Promise<void>
 
-  abstract saveWorkingModel (source: ModelSource): Promise<void>
+  abstract saveWorkingModel (source: ModelSource): Promise<Path | undefined>
+
+  abstract saveModel (source: ModelSource, model: tf.LayersModel): Promise<Path | undefined>
 
   abstract downloadModel (source: ModelSource): Promise<void>
 
@@ -35,4 +38,6 @@ export abstract class Memory {
   abstract pathFor (source: ModelSource): Path | undefined
 
   abstract infoFor (source: ModelSource): ModelInfo | undefined
+
+  abstract duplicateSource (source: ModelSource): Promise<ModelInfo | undefined>
 }

--- a/discojs/discojs-core/src/memory/empty.ts
+++ b/discojs/discojs-core/src/memory/empty.ts
@@ -23,8 +23,12 @@ export class Empty extends Memory {
     // nothing to do
   }
 
-  async saveWorkingModel (): Promise<void> {
-    // nothing to do
+  async saveWorkingModel (): Promise<undefined> {
+    return undefined
+  }
+
+  async saveModel (): Promise<undefined> {
+    return undefined
   }
 
   async deleteModel (): Promise<void> {
@@ -41,5 +45,9 @@ export class Empty extends Memory {
 
   infoFor (): ModelInfo {
     throw new Error('empty')
+  }
+
+  async duplicateSource (): Promise<undefined> {
+    return undefined
   }
 }

--- a/server/src/get_server.ts
+++ b/server/src/get_server.ts
@@ -44,20 +44,21 @@ export class Disco {
     app.use('/', baseRouter.router)
 
     const server = app.listen(port ?? CONFIG.serverPort, () => {
-      console.log(`listening on port ${CONFIG.serverPort}`)
+      console.log(`Disco Server listening on ${CONFIG.serverUrl.href}`)
     })
 
-    console.info('Disco server initially loaded these tasks:')
+    console.info('Disco Server initially loaded the tasks below\n')
     console.table(
       Array.from(this.tasksAndModels.tasksAndModels).map(t => {
         return {
-          'Task id': t[0].taskID,
+          ID: t[0].taskID,
           Title: t[0].displayInformation.taskTitle,
-          'Data type': t[0].trainingInformation.dataType,
-          Epochs: t[0].trainingInformation.epochs
+          'Data Type': t[0].trainingInformation.dataType,
+          Scheme: t[0].trainingInformation.scheme
         }
       })
     )
+    console.log()
 
     return server
   }

--- a/web-client/src/components/sidebar/ModelLibrary.vue
+++ b/web-client/src/components/sidebar/ModelLibrary.vue
@@ -48,7 +48,10 @@
                 @click="openTesting(path)"
               >
                 <span>
-                  {{ metadata.name.substring(0, 16) }} <br>
+                  {{ metadata.name.slice(0, 16) }}
+                  <span v-if="metadata.version !== undefined && metadata.version !== 0">
+                    ({{ metadata.version }})
+                  </span><br>
                   <span class="text-xs">
                     {{ metadata.date }} at {{ metadata.hours }} <br>
                     {{ metadata.fileSize }} kB
@@ -153,6 +156,7 @@ export default defineComponent({
       if (modelInfo.type !== ModelType.WORKING) {
         try {
           await this.memory.loadModel(path)
+          await this.memoryStore.initModels()
         } catch (e) {
           console.log(e.message)
           this.$toast.error('Error')

--- a/web-client/src/components/validation/Validation.vue
+++ b/web-client/src/components/validation/Validation.vue
@@ -24,60 +24,129 @@
       </div>
     </div>
     <div v-show="validationStore.step === 0">
-      <div
-        v-if="memoryStore.models.size > 0"
-        class="grid gris-cols-1 md:grid-cols-2 lg:grid-cols-3 items-stretch gap-8 mt-8"
-      >
-        <div
-          v-for="[path, metadata] in memoryStore.models"
-          :key="path"
-          class="contents"
-        >
-          <ButtonCard
-            :click="() => selectModel(path)"
-            :button-placement="'left'"
-          >
+      <div class="flex flex-col gap-16">
+        <div v-if="memoryStore.models.size > 0">
+          <IconCard>
             <template #title>
-              {{ taskTitle(metadata.taskID) }}
+              Model Library — <span class="italic">Locally Available and Ready to Test</span>
             </template>
-            <template #text>
-              <div class="grid grid-cols-2 justify-items-between">
-                <p class="contents">
-                  <span>Model:</span>
-                  <span>{{ metadata.name.substring(0, 20) }}</span>
-                </p>
-                <p class="contents">
-                  <span>Date:</span>
-                  <span>{{ metadata.date }} at {{ metadata.hours }}</span>
-                </p>
-                <p class="contents">
-                  <span>Size:</span><span>{{ metadata.fileSize }} kB</span>
-                </p>
+            <template #content>
+              Test any model below against a validation dataset.
+              The models listed were downloaded from the remote server.
+              Perhaps you even contributed to their training!
+              Note that these models are currently stored within your browser's memory.
+              <div class="grid gris-cols-1 md:grid-cols-2 lg:grid-cols-3 items-stretch gap-8 mt-8">
+                <div
+                  v-for="[path, metadata] in memoryStore.models"
+                  :key="path"
+                  class="contents"
+                >
+                  <ButtonCard
+                    :click="() => selectModel(path)"
+                    :button-placement="'left'"
+                    class="shadow shadow-disco-cyan"
+                  >
+                    <template #title>
+                      {{ taskTitle(metadata.taskID) }}
+                    </template>
+                    <template #text>
+                      <div class="grid grid-cols-2 justify-items-between">
+                        <p class="contents">
+                          <span>Model:</span>
+                          <span>
+                            {{ metadata.name.slice(0, 20) }}
+                            <span v-if="metadata.version !== undefined && metadata.version !== 0">
+                              ({{ metadata.version }})
+                            </span>
+                          </span>
+                        </p>
+                        <p class="contents">
+                          <span>Date:</span>
+                          <span>{{ metadata.date }} at {{ metadata.hours }}</span>
+                        </p>
+                        <p class="contents">
+                          <span>Size:</span><span>{{ metadata.fileSize }} kB</span>
+                        </p>
+                        <p class="contents">
+                          <span>Type:</span><span>{{ metadata.type === ModelType.SAVED ? 'Saved' : 'Cached' }}</span>
+                        </p>
+                      </div>
+                    </template>
+                    <template #button>
+                      Test model
+                    </template>
+                  </ButtonCard>
+                </div>
               </div>
             </template>
-            <template #button>
-              Test model
+          </IconCard>
+        </div>
+        <div v-else>
+          <IconCard>
+            <template #title>
+              Empty Model Library
             </template>
-          </ButtonCard>
+            <template #content>
+              Disco failed to find any model stored locally. Please go to the <RouterLink
+                class="underline font-bold"
+                to="/list"
+              >
+                training page
+              </RouterLink>
+              or directly download a model below, from the Disco respository.
+            </template>
+          </IconCard>
+        </div>
+        <div v-if="federatedTasks.size > 0">
+          <IconCard>
+            <template #title>
+              <span class="font-disco font-normal text-xl">DIS</span>
+              <span class="font-disco font-normal text-xl text-disco-blue">CO</span>
+              Model Repository — <span class="italic">Download and Test</span>
+            </template>
+            <template #content>
+              Select any model below to download it. For federated tasks only.
+              The models listed are not currently stored in your browser's memory,
+              but are available and downloadable from the remote Disco server.
+              <div class="grid gris-cols-1 md:grid-cols-2 lg:grid-cols-3 items-stretch gap-8 mt-8">
+                <div
+                  v-for="task in federatedTasks.toArray()"
+                  :key="task.taskID"
+                  class="contents"
+                >
+                  <ButtonCard
+                    :click="() => downloadModel(task)"
+                    :button-placement="'left'"
+                    class="shadow shadow-disco-cyan"
+                  >
+                    <template #title>
+                      {{ task.displayInformation.taskTitle }}
+                    </template>
+                    <template #text>
+                      Download the latest {{ task.displayInformation.taskTitle }} model available on the remote server.
+                    </template>
+                    <template #button>
+                      Download
+                    </template>
+                  </ButtonCard>
+                </div>
+              </div>
+            </template>
+          </IconCard>
+        </div>
+        <div v-else>
+          <IconCard>
+            <template #title>
+              No Remote Models
+            </template>
+            <template #content>
+              Disco failed to fetch any model from the remote server. Is the Disco server running?
+            </template>
+          </IconCard>
         </div>
       </div>
-      <div v-else>
-        <IconCard>
-          <template #title>
-            No registered model
-          </template>
-          <template #content>
-            Please go to the <RouterLink
-              class="underline font-bold"
-              to="/list"
-            >
-              training page.
-            </RouterLink>
-          </template>
-        </IconCard>
-      </div>
     </div>
-    <div v-if="task !== undefined">
+    <div v-if="currentTask !== undefined">
       <!-- 1. CONNECT YOUR DATA -->
       <div v-show="validationStore.step === 1">
         <!-- Information specific to the validation panel -->
@@ -92,124 +161,125 @@
         </IconCard>
         <!-- Generic dataset information and input -->
         <Data
-          :task="task"
+          :task="currentTask"
           :dataset-builder="datasetBuilder"
         />
       </div>
       <!-- 2. TEST YOUR MODEL -->
       <Validator
         v-show="validationStore.step === 2"
-        :task="task"
+        :task="currentTask"
         :dataset-builder="datasetBuilder"
       />
     </div>
   </div>
 </template>
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script lang="ts" setup>
+import { watch, computed, shallowRef, onActivated, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
-import { mapStores } from 'pinia'
+import { storeToRefs } from 'pinia'
+import { List } from 'immutable'
 
-import { browser, EmptyMemory, Memory, Path, Task, data } from '@epfml/discojs'
+import { browser, EmptyMemory, Memory, Path, Task, data, ModelType, client as clients } from '@epfml/discojs'
 
+import { CONFIG } from '@/config'
 import { useMemoryStore } from '@/store/memory'
 import { useTasksStore } from '@/store/tasks'
 import { useValidationStore } from '@/store/validation'
+import { useToaster } from '@/composables/toaster'
 import CustomButton from '@/components/simple/CustomButton.vue'
 import Data from '@/components/data/Data.vue'
 import Validator from '@/components/validation/Validator.vue'
 import ButtonCard from '@/components/containers/ButtonCard.vue'
 import IconCard from '@/components/containers/IconCard.vue'
 
-export default defineComponent({
-  name: 'Testing',
-  components: {
-    Validator,
-    Data,
-    ButtonCard,
-    IconCard,
-    RouterLink,
-    CustomButton
-  },
-  data (): { task: Task } {
-    return {
-      task: undefined
-    }
-  },
-  computed: {
-    ...mapStores(useMemoryStore, useTasksStore, useValidationStore),
-    showPrev (): boolean {
-      return this.validationStore.step > 0
-    },
-    showNext (): boolean {
-      return this.validationStore.step > 0 && this.validationStore.step < 2
-    },
-    memory (): Memory {
-      return this.memoryStore.useIndexedDB ? new browser.IndexedDB() : new EmptyMemory()
-    },
-    validationState (): boolean {
-      return this.validationStore.state
-    },
-    datasetBuilder (): data.DatasetBuilder<File> | undefined {
-      if (this.task === undefined) {
-        return undefined
-      }
-      let dataLoader: data.DataLoader<File>
-      switch (this.task.trainingInformation.dataType) {
-        case 'tabular':
-          dataLoader = new browser.data.WebTabularLoader(this.task, ',')
-          break
-        case 'image':
-          dataLoader = new browser.data.WebImageLoader(this.task)
-          break
-        default:
-          throw new Error('not implemented')
-      }
-      return new data.DatasetBuilder(dataLoader, this.task)
-    }
-  },
-  watch: {
-    async validationState (_: boolean) {
-      if (this.validationStore.model !== undefined) {
-        await this.selectModel(this.validationStore.model)
-      }
-    }
-  },
-  async mounted (): Promise<void> {
-    await this.memoryStore.initModels()
-    // can't watch before mount
-    if (this.validationStore.model !== undefined) {
-      this.selectModel(this.validationStore.model)
-    }
-  },
-  async activated (): Promise<void> {
-    await this.memoryStore.initModels()
-  },
-  methods: {
-    async selectModel (path: Path): Promise<void> {
-      const task = this.tasksStore.tasks.get(this.memory.infoFor(path)?.taskID)
-      if (task !== undefined) {
-        this.task = task
-        this.validationStore.model = path
-        this.validationStore.step = 1
-      } else {
-        this.$toast.error('Model not found')
-      }
-    },
-    prevStep (): void {
-      this.validationStore.step--
-    },
-    nextStep (): void {
-      this.validationStore.step++
-    },
-    taskTitle (taskID: string): string {
-      const task = this.tasksStore.tasks.get(taskID)
-      if (task !== undefined) {
-        return task.displayInformation.taskTitle
-      } else {
-        this.$toast.error('Task not found')
-      }
-    }
+const validationStore = useValidationStore()
+const memoryStore = useMemoryStore()
+const tasksStore = useTasksStore()
+
+const { step: stepRef, state: stateRef } = storeToRefs(validationStore)
+
+const toaster = useToaster()
+
+const currentTask = shallowRef<Task | undefined>(undefined)
+
+const federatedTasks = computed<List<Task>>(() =>
+  tasksStore.tasks.filter((t) => t.trainingInformation.scheme === 'Federated').toList())
+const showPrev = computed<boolean>(() =>
+  validationStore.step > 0)
+const showNext = computed<boolean>(() =>
+  validationStore.step > 0 && validationStore.step < 2)
+const memory = computed<Memory>(() =>
+  memoryStore.useIndexedDB ? new browser.IndexedDB() : new EmptyMemory())
+const datasetBuilder = computed<data.DatasetBuilder<File> | undefined>(() => {
+  if (currentTask.value === undefined) {
+    return undefined
+  }
+  let dataLoader: data.DataLoader<File>
+  switch (currentTask.value.trainingInformation.dataType) {
+    case 'tabular':
+      dataLoader = new browser.data.WebTabularLoader(currentTask.value, ',')
+      break
+    case 'image':
+      dataLoader = new browser.data.WebImageLoader(currentTask.value)
+      break
+    default:
+      throw new Error('not implemented')
+  }
+  return new data.DatasetBuilder(dataLoader, currentTask.value)
+})
+
+watch(stateRef, () => {
+  if (validationStore.model !== undefined) {
+    selectModel(validationStore.model)
   }
 })
+watch(stepRef, async (v) => {
+  if (v === 0) {
+    await memoryStore.initModels()
+  }
+})
+
+onMounted(async () => {
+  await memoryStore.initModels()
+  // can't watch before mount
+  if (validationStore.model !== undefined) {
+    selectModel(validationStore.model)
+  }
+})
+onActivated(async () => {
+  await memoryStore.initModels()
+})
+
+const downloadModel = async (task: Task): Promise<void> => {
+  const client = new clients.Local(CONFIG.serverUrl, task)
+  const model = await client.getLatestModel()
+  const source = {
+    type: ModelType.SAVED,
+    taskID: task.taskID,
+    name: task.trainingInformation.modelID
+  }
+  await memory.value.saveModel(source, model)
+  await memoryStore.initModels()
+}
+const selectModel = (path: Path): void => {
+  const selectedTask = tasksStore.tasks.get(memory.value.infoFor(path)?.taskID)
+  if (selectedTask !== undefined) {
+    currentTask.value = selectedTask
+    validationStore.model = path
+    validationStore.step = 1
+  } else {
+    toaster.error('Model not found')
+  }
+}
+const prevStep = (): void => { validationStore.step-- }
+const nextStep = (): void => { validationStore.step++ }
+const taskTitle = (taskID: string): string => {
+  const titled = tasksStore.tasks.get(taskID)
+  if (titled !== undefined) {
+    return titled.displayInformation.taskTitle
+  } else {
+    toaster.error('Task not found')
+  }
+}
 </script>

--- a/web-client/src/store/memory.ts
+++ b/web-client/src/store/memory.ts
@@ -30,10 +30,11 @@ export const useMemoryStore = defineStore('memory', () => {
     const models = await tf.io.listModels()
     for (const path in models) {
       // eslint-disable-next-line no-unused-vars
-      const [location, _, directory, task, name] = path.split('/')
+      const [location, _, directory, task, fullName] = path.split('/')
       if (location !== 'indexeddb:') {
         continue
       }
+      const [name, version] = fullName.split('@')
 
       const metadata = models[path]
       const date = new Date(metadata.dateSaved)
@@ -59,7 +60,8 @@ export const useMemoryStore = defineStore('memory', () => {
         type: directory === 'working' ? ModelType.WORKING : ModelType.SAVED,
         date: dateSaved,
         hours: hourSaved,
-        fileSize: Math.round(size / 1024)
+        fileSize: Math.round(size / 1024),
+        version: version !== undefined ? Number(version) : 0
       })
     }
   }


### PR DESCRIPTION
## List of changes

* server
  * prints prettier console messages
* web-client/validation 
  * displays a list of the latest models available on the remote server (one for each task)
  * allows the user to directly validate one of such remote models
  * uses the composition API
* discjos/memory
  * supports saved model duplicates

## Related issue

Fixes #497 