### PR TITLE
adds generic training functions for trainer

### DIFF
--- a/discojs/discojs-core/src/index.browser.ts
+++ b/discojs/discojs-core/src/index.browser.ts
@@ -14,7 +14,7 @@ export { AsyncBuffer } from './async_buffer'
 export { AsyncInformant } from './async_informant'
 export { Logger, ConsoleLogger, TrainerLog } from './logging'
 export { Memory, ModelType, ModelInfo, Path, ModelSource, Empty as EmptyMemory } from './memory'
-export { Disco, TrainingSchemes } from './training'
+export { Disco, TrainingSchemes, TrainingFunction, fitModelFunctions } from './training'
 export { Validator } from './validation'
 
 export * from './task'

--- a/discojs/discojs-core/src/index.node.ts
+++ b/discojs/discojs-core/src/index.node.ts
@@ -14,7 +14,7 @@ export { AsyncBuffer } from './async_buffer'
 export { AsyncInformant } from './async_informant'
 export { Logger, ConsoleLogger, TrainerLog } from './logging'
 export { Memory, ModelType, ModelInfo, Path, ModelSource, Empty as EmptyMemory } from './memory'
-export { Disco, TrainingSchemes } from './training'
+export { Disco, TrainingSchemes, TrainingFunction, fitModelFunctions } from './training'
 export { Validator } from './validation'
 
 export * from './task'

--- a/discojs/discojs-core/src/training/disco.ts
+++ b/discojs/discojs-core/src/training/disco.ts
@@ -6,7 +6,8 @@ import {
   TrainingInformant, informant as informants,
   TrainingSchemes,
   Memory, EmptyMemory,
-  ConsoleLogger
+  ConsoleLogger,
+  TrainingFunction
 } from '..'
 import { Trainer } from './trainer/trainer'
 import { TrainerBuilder } from './trainer/trainer_builder'
@@ -19,6 +20,7 @@ interface DiscoOptions {
   informant?: TrainingInformant
   logger?: Logger
   memory?: Memory
+  customTrainingFunction?: TrainingFunction
 }
 
 // Handles the training loop, server communication & provides the user with feedback.
@@ -87,7 +89,7 @@ export class Disco {
     this.memory = options.memory
     this.logger = options.logger
 
-    const trainerBuilder = new TrainerBuilder(this.memory, this.task, options.informant)
+    const trainerBuilder = new TrainerBuilder(this.memory, this.task, options.informant, options.customTrainingFunction)
     this.trainer = trainerBuilder.build(this.client, options.scheme !== TrainingSchemes.LOCAL)
   }
 
@@ -102,7 +104,7 @@ export class Disco {
       : trainDataset
 
     await this.client.connect()
-    await (await this.trainer).trainModel(trainDataset.dataset, valDataset.dataset)
+    await (await this.trainer).fitModel(trainDataset.dataset, valDataset.dataset)
   }
 
   // Stops the training function. Does not disconnect the client.

--- a/discojs/discojs-core/src/training/index.ts
+++ b/discojs/discojs-core/src/training/index.ts
@@ -1,2 +1,3 @@
 export { Disco } from './disco'
+export { TrainingFunction, fitModelFunctions } from './training_functions'
 export { TrainingSchemes } from './training_schemes'

--- a/discojs/discojs-core/src/training/trainer/distributed_trainer.ts
+++ b/discojs/discojs-core/src/training/trainer/distributed_trainer.ts
@@ -1,4 +1,4 @@
-import { tf, Client, Memory, Task, TrainingInformant, WeightsContainer } from '../..'
+import { tf, Client, Memory, Task, TrainingInformant, TrainingFunction, WeightsContainer } from '../..'
 
 import { Trainer } from './trainer'
 
@@ -14,9 +14,10 @@ export class DistributedTrainer extends Trainer {
     memory: Memory,
     model: tf.LayersModel,
     private readonly previousRoundModel: tf.LayersModel,
-    private readonly client: Client
+    private readonly client: Client,
+    trainModelFunction?: TrainingFunction
   ) {
-    super(task, trainingInformant, memory, model)
+    super(task, trainingInformant, memory, model, trainModelFunction)
   }
 
   /**

--- a/discojs/discojs-core/src/training/trainer/trainer_builder.ts
+++ b/discojs/discojs-core/src/training/trainer/trainer_builder.ts
@@ -1,4 +1,4 @@
-import { tf, Client, Task, TrainingInformant, Memory, ModelType, ModelInfo } from '../..'
+import { tf, Client, Task, TrainingInformant, TrainingFunction, Memory, ModelType, ModelInfo } from '../..'
 
 import { DistributedTrainer } from './distributed_trainer'
 import { LocalTrainer } from './local_trainer'
@@ -11,7 +11,8 @@ export class TrainerBuilder {
   constructor (
     private readonly memory: Memory,
     private readonly task: Task,
-    private readonly trainingInformant: TrainingInformant
+    private readonly trainingInformant: TrainingInformant,
+    private readonly trainingFunction?: TrainingFunction
   ) {}
 
   /**
@@ -30,14 +31,16 @@ export class TrainerBuilder {
         this.memory,
         model,
         model,
-        client
+        client,
+        this.trainingFunction
       )
     } else {
       return new LocalTrainer(
         this.task,
         this.trainingInformant,
         this.memory,
-        model
+        model,
+        this.trainingFunction
       )
     }
   }

--- a/discojs/discojs-core/src/training/training_functions.ts
+++ b/discojs/discojs-core/src/training/training_functions.ts
@@ -1,5 +1,14 @@
 import { tf, TrainingInformation } from '..'
 
+/**
+ * The training function is the function that will be called to train the model.
+ * The model is trained locally with the given dataset, which means that it will only have access to the data of the user local machine.
+ * This all happens in the client, so this data is not sent to the server, only the resulting model is.
+ *
+ * Every few batches, represented by the round duration ('onRoundEnd' trainer function), the model will be updated with the new aggregated weights (in the case of the distributed trainer). Depending on the training scheme, weights are aggregated on the server (federated), or between peers (decentralized).
+ * The following trainings will be done with the updated model.
+ * You need to be aware that the model is subject to regular changes in your training functions.
+ */
 export type TrainingFunction =
   (model: tf.LayersModel,
     trainingInformation: TrainingInformation,

--- a/discojs/discojs-core/src/training/training_functions.ts
+++ b/discojs/discojs-core/src/training/training_functions.ts
@@ -1,0 +1,33 @@
+import { tf, TrainingInformation } from '..'
+
+export type TrainingFunction =
+  (model: tf.LayersModel,
+    trainingInformation: TrainingInformation,
+    dataset: tf.data.Dataset<tf.TensorContainer>,
+    valDataset: tf.data.Dataset<tf.TensorContainer>,
+    onEpochEnd: (epoch: number, logs?: tf.Logs) => void,
+    onBatchEnd: (epoch: number, logs?: tf.Logs) => Promise<void>,
+    onTrainEnd: (logs?: tf.Logs) => Promise<void>) => Promise<void>
+
+/**
+* Default training method used when none specified. Simply use the tensorflow fitDataset method.
+*/
+const defaultTraining: TrainingFunction = async (model, trainingInformation, dataset, valDataset, onEpochEnd, onBatchEnd, onTrainEnd) => {
+  await model.fitDataset(dataset, {
+    epochs: trainingInformation.epochs,
+    validationData: valDataset,
+    callbacks: {
+      onEpochEnd: onEpochEnd,
+      onBatchEnd: onBatchEnd,
+      onTrainEnd: onTrainEnd
+    }
+  })
+}
+
+enum TrainingType {
+  default = 'default'
+}
+
+export const fitModelFunctions: Record<TrainingType, TrainingFunction> = {
+  default: defaultTraining
+}


### PR DESCRIPTION
This allows to pass a custom training function when creating a `Trainer`, this could be useful for:

* Custom sampling of the dataset for specific training loops
* Custom training loop (seems like TF.js fitDataset mostly expect gradient-based optimizers)

This enables users of the lib to write a client with completely custom training, and this allows us to eventually define more training loops that could be used in later tasks.
Currently only the default training is proposed by the lib (TF.js fitDataset), but it can be freely extended by users

Some info about the training function:

> The training function is the function that will be called to train the model.
> The model is trained locally with the given dataset, which means that it will only have access to the data of the user local machine.
> This all happens in the client, so this data is not sent to the server, only the resulting model is.
> 
> Every few batches, represented by the round duration ('onRoundEnd' trainer function), the model will be sent to the server and then updated with the new aggregated weights (in the case of the distributed trainer). The following trainings will be done with the updated model.
> You need to be aware that the model is subject to regular changes in your training functions.
