### PR TITLE
Add converter script to keras

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,19 +28,15 @@ which should output something similar to `arm64`. Then, `npm i @tensorflow/tfjs`
 
 4. Execute `npm run dev` and you are done!
 
-### Problem: Importing models or weights from different frameworks like Pytorch to TensorflowJS
+### Problem: Importing models or weights from Pytorch to TensorflowJS
 
 ### Solution:
 
-The pipeline for any conversion scheme that takes a model in a framework X (imagine Pytorch as a guiding example) goes usually as follows :
 
-Framework X -> ONNX -> Keras -> TensorflowJS
+There exist several libraries that try to perform automatic conversion between frameworks, which we do not recommend as most of the tools have compatibility issues if the model contains components which differ strongly in implementation between the two frameworks.
+The simplest way to obtain a TensorflowJS model is to first obtain a Tensorflow/Keras model, stored as a .h5 file, and then convert it using TensorflowJS's converter tool, which transforms a Tensorflow/Keras model to TensorflowJS. To obtain the Keras/Tensorflow model from we strongly recommend to directly develop the model in Keras : most of Pytorch components have their equivalent counterpart in Tensorflow/Keras, and translating model architectures between these two frameworks can be done in a straightforward way. One caveat is that, weights currently cannot be converted from the Pytorch `.pth` format to the Keras `.h5` format, so the model must be retrained.
 
-Any conversion tool that takes a model written in a framework X (take Pytorch as an example) will likely rely on an intermediate conversion to ONNX. Depending on your framework, there exists several libraries that perform the first conversion of the pipeline. For Pytorch, such a conversion can be found [here](https://pytorch.org/docs/stable/onnx.html).
-
-The major issue comes from the second conversion in the pipeline. There currently exists only one external library [here](https://github.com/gmalivenko/onnx2keras) that performs said conversion, however this library is not maintained anymore and has many compatibility issues. For simple Sequential models, the conversion works correctly. However, when adding batch_normalization layers, custom modules which require Attention mechanisms, or components which exist in Pytorch but not directly in Keras, the conversion will fail. Unless the model is very simple, we strongly recommend to directly develop the model in Keras : most of Pytorch components have their equivalent counterpart in Tensorflow/Keras. One caveat is that, weights currently cannot be converted from the Pytorch `.pth` format to the Keras `.h5` format.
-
-Then, given your keras model file, to convert it to a TensorFlowJS model:
+Given your keras model file, to convert it to a TensorFlowJS model:
 ```bash
 $ tensorflowjs_converter --input_format=keras my_model_name.h5 /tfjs_model
 ```
@@ -50,9 +46,11 @@ Side Note : If you already have a TensorFlow saved model, the conversion to Tens
 $ tensorflowjs_converter --input_format=tf_saved_model my_tensorflow_saved_model /tmp/tfjs_model
 ```
 
-Make sure to convert to TF.js [LayersModel](https://www.tensorflow.org/js/guide/models_and_layers) (not GraphModel, as the latter are inferene only, so can not be trained).
+Make sure to convert to TF.js [LayersModel](https://www.tensorflow.org/js/guide/models_and_layers) (not GraphModel, as the latter are inference only, so can not be trained).
 
 Following the `tensorflowjs_converter` command, you will recover two files : a .json describing your model architecture, and a collection of .bin files describing your model weights, which are ready to be uploaded on DisCo. In order to do so, refer to our documentation [here](/TASK.md)
 Note that the following conversion is only possible in cases of models for which TensorFlowJS possesses the [corresponding modules](https://js.tensorflow.org/api/latest/).
+
+
 
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,3 +27,32 @@ which should output something similar to `arm64`. Then, `npm i @tensorflow/tfjs`
    If you do not have nvm installed, it can be downloaded from [here](https://github.com/coreybutler/nvm-windows).
 
 4. Execute `npm run dev` and you are done!
+
+### Problem: Importing models or weights from different frameworks like Pytorch to TensorflowJS
+
+### Solution:
+
+The pipeline for any conversion scheme that takes a model in a framework X (imagine Pytorch as a guiding example) goes usually as follows :
+
+Framework X -> ONNX -> Keras -> TensorflowJS
+
+Any conversion tool that takes a model written in a framework X (take Pytorch as an example) will likely rely on an intermediate conversion to ONNX. Depending on your framework, there exists several libraries that perform the first conversion of the pipeline. For Pytorch, such a conversion can be found [here](https://pytorch.org/docs/stable/onnx.html).
+
+The major issue comes from the second conversion in the pipeline. There currently exists only one external library [here](https://github.com/gmalivenko/onnx2keras) that performs said conversion, however this library is not maintained anymore and has many compatibility issues. For simple Sequential models, the conversion works correctly. However, when adding batch_normalization layers, custom modules which require Attention mechanisms, or components which exist in Pytorch but not directly in Keras, the conversion will fail. Unless the model is very simple, we strongly recommend to directly develop the model in Keras : most of Pytorch components have their equivalent counterpart in Tensorflow/Keras. One caveat is that, weights currently cannot be converted from the Pytorch `.pth` format to the Keras `.h5` format.
+
+Then, given your keras model file, to convert it to a TensorFlowJS model:
+```bash
+$ tensorflowjs_converter --input_format=keras my_model_name.h5 /tfjs_model
+```
+
+Side Note : If you already have a TensorFlow saved model, the conversion to TensorFlowJS is straightforward with the following command :
+```bash
+$ tensorflowjs_converter --input_format=tf_saved_model my_tensorflow_saved_model /tmp/tfjs_model
+```
+
+Make sure to convert to TF.js [LayersModel](https://www.tensorflow.org/js/guide/models_and_layers) (not GraphModel, as the latter are inferene only, so can not be trained).
+
+Following the `tensorflowjs_converter` command, you will recover two files : a .json describing your model architecture, and a collection of .bin files describing your model weights, which are ready to be uploaded on DisCo. In order to do so, refer to our documentation [here](/TASK.md)
+Note that the following conversion is only possible in cases of models for which TensorFlowJS possesses the [corresponding modules](https://js.tensorflow.org/api/latest/).
+
+

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,29 +28,6 @@ which should output something similar to `arm64`. Then, `npm i @tensorflow/tfjs`
 
 4. Execute `npm run dev` and you are done!
 
-### Problem: Importing models or weights from Pytorch to TensorflowJS
-
-### Solution:
-
-
-There exist several libraries that try to perform automatic conversion between frameworks, which we do not recommend as most of the tools have compatibility issues if the model contains components which differ strongly in implementation between the two frameworks.
-The simplest way to obtain a TensorflowJS model is to first obtain a Tensorflow/Keras model, stored as a .h5 file, and then convert it using TensorflowJS's converter tool, which transforms a Tensorflow/Keras model to TensorflowJS. To obtain the Keras/Tensorflow model from we strongly recommend to directly develop the model in Keras : most of Pytorch components have their equivalent counterpart in Tensorflow/Keras, and translating model architectures between these two frameworks can be done in a straightforward way. One caveat is that, weights currently cannot be converted from the Pytorch `.pth` format to the Keras `.h5` format, so the model must be retrained.
-
-Given your keras model file, to convert it to a TensorFlowJS model:
-```bash
-$ tensorflowjs_converter --input_format=keras my_model_name.h5 /tfjs_model
-```
-
-Side Note : If you already have a TensorFlow saved model, the conversion to TensorFlowJS is straightforward with the following command :
-```bash
-$ tensorflowjs_converter --input_format=tf_saved_model my_tensorflow_saved_model /tmp/tfjs_model
-```
-
-Make sure to convert to TF.js [LayersModel](https://www.tensorflow.org/js/guide/models_and_layers) (not GraphModel, as the latter are inference only, so can not be trained).
-
-Following the `tensorflowjs_converter` command, you will recover two files : a .json describing your model architecture, and a collection of .bin files describing your model weights, which are ready to be uploaded on DisCo. In order to do so, refer to our documentation [here](/TASK.md)
-Note that the following conversion is only possible in cases of models for which TensorFlowJS possesses the [corresponding modules](https://js.tensorflow.org/api/latest/).
-
 
 
 

--- a/docs/TASK.md
+++ b/docs/TASK.md
@@ -14,31 +14,10 @@ To use an existing model in Disco, we first need to convert the model to a Tenso
 
 ### My model is a PyTorch model, I want to bring it to Disco
 
-TensorFlowJS provide a [simple conversion API](https://www.tensorflow.org/js/guide/conversion) to bring your PyTorch model to TensorFlowJS. You first need to convert your Pytorch model into a Keras model, which is a file stored as an HDF5 model with an .h5 extension, using the [following Pytorch-to-Keras model conversion tool](https://github.com/gmalivenko/pytorch2keras). To do so,
-```python
-from pytorch2keras.converter import pytorch_to_keras
-my_pytorch_model = create_my_model()
-keras_model = pytorch_to_keras(my_pytorch_model, dummy_input_of_correct_size, verbose=True)
-keras_model.save("my_model_name.h5")
-```
-Then, given your keras model file, to convert it to a TensorFlowJS model:
-```bash
-$ tensorflowjs_converter --input_format=keras my_model_name.h5 /tfjs_model
-```
-
-Side Note : If you already have a TensorFlow saved model, the conversion to TensorFlowJS is straightforward with the following command :
-```bash
-$ tensorflowjs_converter --input_format=tf_saved_model my_tensorflow_saved_model /tmp/tfjs_model
-```
-
-Make sure to convert to TF.js [LayersModel](https://www.tensorflow.org/js/guide/models_and_layers) (not GraphModel, as the latter are inferene only, so can not be trained).
-
-Following the `tensorflowjs_converter` command, you will recover two files : a .json describing your model architecture, and a collection of .bin files describing your model weights, which are ready to be uploaded on DisCo.
-Note that the following conversion is only possible in cases of models for which TensorFlowJS possesses the [corresponding modules](https://js.tensorflow.org/api/latest/).
 
 
 
-## 2) Simple use case: Using the user interface directly for creating a new task
+## 1) Simple use case: Using the user interface directly for creating a new task
 I am a user who wants to define my custom task and bring my model to Disco, without doing any programming. For this use case, the `.bin` weight file is mandatory.
  - Through the Disco user interface, click on the *create* button on "Add your own model to be trained in a DISCOllaborative"
  - Fill in all the relevant information for your task and model
@@ -46,7 +25,7 @@ I am a user who wants to define my custom task and bring my model to Disco, with
  Your task has been successfully instantiated.
 
 
-## 3) Procedure for adding a custom task
+## 2) Procedure for adding a custom task
 
 In order to add a new custom task to Disco.js, we need to have defined a `TaskProvider` which need to implement two methods:
    * `getTask` which returns a `Task` as defined [here](../discojs/discojs-core/src/task/task.ts), the `Task` contains all the crucial information from training to the mode

--- a/docs/TASK.md
+++ b/docs/TASK.md
@@ -9,11 +9,7 @@ Disco.js currently allows learning of arbitrary machine learning tasks, where ta
 
 ## Bringing your ML model to Disco
 
-To use an existing model in Disco, we first need to convert the model to a TensorFlowJS format, consisting of a TensorFlowJS model file in a JSON format for the neural network architecture, and an optional weight file in .bin format if you want to start from a particular initialization or a pretrained model.
-
-
-### My model is a PyTorch model, I want to bring it to Disco
-
+To use an existing model in Disco, we first need to convert the model to a TensorFlowJS format, consisting of a TensorFlowJS model file in a JSON format for the neural network architecture, and an optional weight file in .bin format if you want to start from a particular initialization or a pretrained model. If your model is from another framework than TensorflowJS, like Pytorch or Tensorflow/Keras, but you still want to bring it to DisCo, please refer to [this problem in the FAQ](/FAQ.md).
 
 
 

--- a/docs/TASK.md
+++ b/docs/TASK.md
@@ -21,7 +21,7 @@ Given your keras model file, to convert it to a TensorFlowJS model:
 $ tensorflowjs_converter --input_format=keras my_model_name.h5 /tfjs_model
 ```
 
-Side Note: If you already have a TensorFlow(Python) saved model ([LayersModel](https://www.tensorflow.org/js/guide/models_and_layers)), then the conversion to TensorFlowJS is straightforward with the following command:
+Side Note: If you already have a TensorFlow (Python) saved model ([LayersModel](https://www.tensorflow.org/js/guide/models_and_layers)), then the conversion to TensorFlowJS is straightforward with the following command:
 ```bash
 $ tensorflowjs_converter --input_format=tf_saved_model my_tensorflow_saved_model /tmp/tfjs_model
 ```

--- a/docs/TASK.md
+++ b/docs/TASK.md
@@ -9,20 +9,19 @@ Disco.js currently allows learning of arbitrary machine learning tasks, where ta
 
 ## Bringing your ML model to Disco
 
-To use an existing model in Disco, we first need to convert the model to a TensorFlowJS format, consisting of a TensorFlowJS model file in a JSON format for the neural network architecture, and an optional weight file in .bin format if you want to start from a particular initialization or a pretrained model. If your model is from another framework than TensorflowJS, like Pytorch or Tensorflow/Keras, but you still want to bring it to DisCo, we indicate the appropriate procedure as follows.
+To use an existing model in Disco, we first need to convert the model to TensorFlowJS format, consisting of a TensorFlowJS model file in a JSON format for the neural network architecture, and an optional weight file in .bin format if you want to start from a particular initialization or a pretrained model. If your model comes from another framework than TensorflowJS, like Pytorch or Tensorflow/Keras, but you still want to bring it to DisCo, we indicate the appropriate procedure as follows.
 
 
-### Importing models or weights from Pytorch to TensorflowJS
+### Importing models or weights from PyTorch to TensorflowJS
 
-
-The simplest way to obtain a TensorflowJS model is to first obtain a Tensorflow/Keras model, stored as a .h5 file, and then convert it using TensorflowJS's converter tool, which transforms a Tensorflow/Keras model to TensorflowJS. To obtain the Keras/Tensorflow model from we strongly recommend to directly develop the model in Keras : most of Pytorch components have their equivalent counterpart in Tensorflow/Keras, and translating model architectures between these two frameworks can be done in a straightforward way. One caveat is that, weights currently cannot be converted from the Pytorch `.pth` format to the Keras `.h5` format, so the model must be retrained.
+The simplest way to obtain a TensorflowJS model is to first obtain a Python Tensorflow/Keras model, stored as a .h5 file, and then convert it using TensorflowJS's converter tool, which transforms any Tensorflow/Keras model to TensorflowJS. One recommended way to obtain a Python Tensorflow/Keras model it to directly develop the model in Keras: most of PyTorch components have their equivalent counterpart in Tensorflow/Keras, and translating model architectures between these two frameworks can be done in a straightforward way. One caveat is that for more complex models, pretrained weights can currently not automatically be converted from the Python `.pth` format to the Keras `.h5` format. If you plan to retrain the model from scratch in Disco, this is no problem. On the other hand if you want to import pretrained Python model weights you currently have to first obtain corresponding Keras weights, from which you can then TF.js weights.
 
 Given your keras model file, to convert it to a TensorFlowJS model:
 ```bash
 $ tensorflowjs_converter --input_format=keras my_model_name.h5 /tfjs_model
 ```
 
-Side Note : If you already have a TensorFlow saved model, the conversion to TensorFlowJS is straightforward with the following command :
+Side Note: If you already have a TensorFlow(Python) saved model ([LayersModel](https://www.tensorflow.org/js/guide/models_and_layers)), then the conversion to TensorFlowJS is straightforward with the following command:
 ```bash
 $ tensorflowjs_converter --input_format=tf_saved_model my_tensorflow_saved_model /tmp/tfjs_model
 ```
@@ -38,9 +37,8 @@ Note that the following conversion is only possible in cases of models for which
 
 
 
-
 ## 1) Simple use case: Using the user interface directly for creating a new task
-I am a user who wants to define my custom task and bring my model to Disco, without doing any programming. For this use case, the `.bin` weight file is mandatory.
+I am a user who wants to define my custom task and bring my model to Disco, without doing any programming. In this case, you use our existing supported data modalities and preprocessing (such as tabular, images, text etc). For this use case, an initial `.bin` weight file of your TF.js model is mandatory.
  - Through the Disco user interface, click on the *create* button on "Add your own model to be trained in a DISCOllaborative"
  - Fill in all the relevant information for your task and model
  - Upload the .json + .bin model in the *Model Files* box.
@@ -48,8 +46,7 @@ I am a user who wants to define my custom task and bring my model to Disco, with
 
 
 ## 2) Procedure for adding a custom task
-
-In order to add a new custom task to Disco.js, we need to have defined a `TaskProvider` which need to implement two methods:
+In order to add a completely new custom task to Disco.js using our own code (such as for data loading, preprocessing etc), we need to defined a `TaskProvider` which need to implement two methods:
    * `getTask` which returns a `Task` as defined [here](../discojs/discojs-core/src/task/task.ts), the `Task` contains all the crucial information from training to the mode
    * `getModel` which returns a `Promise<tf.LayersModel>` specifying a model architecture for the task
 
@@ -57,9 +54,9 @@ You can find examples of `TaskProvider` currently used in our Disco server in `d
 
 ### Task
 
-For the task creation, we consider the main use case which does not go through the user interface :
+For the task creation of new custom tasks, if you can not go through the user interface, we recommend the following guidance:
 
-**I am a developper who wants to define my own task**
+**I am a developper who wants to define my own custom task**
 
 If you want to add a new task to our production DISCO server you have two possibilities:
   * using the user interface as described above (no coding required)


### PR DESCRIPTION
Fixes issue @480 in the following sense : 

This PR is not meant to be merged on develop, but essentially brings the DeepBreath model to JS. In more details : 
  - The converted DeepBreath model in JS  is in /tfjs_model
  -  The Tensorflow saved_model is in /saved_model
  - Three Python scripts were written, the first one called convertDB.py is a conversion from Pytorch to ONNX, a second one called onnx2TensorFlow.py is a rewritting from the ONNX format to tensorflow/TensorflowJS, but by comparing it to the original Pytorch model, some layers had to be dropped due to incompatibilites between Pytorch and ONNX. The third script is an accurate rewritting from the Pytorch model to Tensorflow/TFJS, called torchToTFModel.py. Torch is not used in it, inside we write a TF/Keras model and then save it.

A few notes : When converting from Pytorch to Tensorflow/TFJS, unless the model is trivial, we should not rely on automatic conversion tools like pytorch2keras, or onnx2keras, as these libraries are out of date and don't support many layers/essential functionalities. Redevelopping the model manually on Tensorflow is the best way to go for these kind of tasks.