### PR TITLE
Task creation form privacy parameters default

### DIFF
--- a/web-client/src/task_creation_form.ts
+++ b/web-client/src/task_creation_form.ts
@@ -415,7 +415,7 @@ export const privacyParameters: FormSection = {
       yup: yup.number().positive(),
       as: 'input',
       type: 'number',
-      default: '1.0'
+      default: '40.0'
     },
     {
       id: 'decentralizedSecure',

--- a/web-client/src/task_creation_form.ts
+++ b/web-client/src/task_creation_form.ts
@@ -405,7 +405,8 @@ export const privacyParameters: FormSection = {
       description: 'Differential Privacy: Noise Scale',
       yup: yup.number().positive(),
       as: 'input',
-      type: 'number'
+      type: 'number',
+      default: '0.1'
     },
     {
       id: 'clippingRadius',
@@ -413,7 +414,8 @@ export const privacyParameters: FormSection = {
       description: 'Differential Privacy: Clipping Radius',
       yup: yup.number().positive(),
       as: 'input',
-      type: 'number'
+      type: 'number',
+      default: '1.0'
     },
     {
       id: 'decentralizedSecure',


### PR DESCRIPTION
Adding a default value for the Privacy Parameters form section, for the web-based Disco. 
noiseScale to 0.1 and for the clippingRadius to 40.0
The noiseScale is chosen according to baseline values commonly used in other DP implementations in FL (https://arxiv.org/abs/1912.07902) 
The clipping radius is harder to determine as a default value, as it depends on the data and other factors and is hard to optimize. We took a default value according to (https://arxiv.org/pdf/2106.07094.pdf)

Note that, the task creator can still decide to overwrite the values with their own privacy parameters, and that the defaults serve as a common baseline.  
