### PR TITLE
Refactoring created mismatched function calls

### DIFF
--- a/web-client/src/components/testing/Tester.vue
+++ b/web-client/src/components/testing/Tester.vue
@@ -335,7 +335,7 @@ async function predictUsingModel (): Promise<void> {
 }
 
 async function assessModel (): Promise<void> {
-  if (props.datasetBuilder?.size() === 0) {
+  if (props.datasetBuilder?.size === 0) {
     return toaster.error('No file was given')
   }
 

--- a/web-client/src/components/training/Trainer.vue
+++ b/web-client/src/components/training/Trainer.vue
@@ -141,7 +141,7 @@ export default defineComponent({
     async startTraining (distributedTraining: boolean): Promise<void> {
       this.distributedTraining = distributedTraining
 
-      if (!this.datasetBuilder.isBuilt()) {
+      if (!this.datasetBuilder.built) {
         try {
           this.dataset = await this.datasetBuilder.build()
         } catch (e) {
@@ -157,7 +157,7 @@ export default defineComponent({
         await this.disco.fit(this.dataset)
         this.startedTraining = false
       } catch (e) {
-        this.$toast.error('An error occured during training')
+        this.$toast.error('An error occurred during training')
         console.error(e)
         this.cleanState()
       }


### PR DESCRIPTION
After [this commit](https://github.com/epfml/disco/commit/6e85f6f1f8b772e15c5e03cb5b55ef4030db1894#diff-04761da9988636b38bf48b80fb0fcab0a5b47c7bba0254dc48233159441c8613) changed the method `isBuilt()` to be the getter `get built()`, the front end was raising the error `datasetBuilder.isBuilt() is not a function`.

I changed the getter call from `datasetBuilder.isBuilt()` to `datasetBuilder.built` ([getters are called without parentheses](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)

Same thing for `get size()`