### PR TITLE
LUS COVID demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # dependencies
 /node_modules/
-
+# disco models
+**/models
 # built
 dist/
 

--- a/cli/src/args.ts
+++ b/cli/src/args.ts
@@ -42,6 +42,7 @@ let supportedTasks: Map<string, Task> = Map()
 supportedTasks = supportedTasks.set(defaultTasks.simpleFace.getTask().id, defaultTasks.simpleFace.getTask())
 supportedTasks = supportedTasks.set(defaultTasks.titanic.getTask().id, defaultTasks.titanic.getTask())
 supportedTasks = supportedTasks.set(defaultTasks.cifar10.getTask().id, defaultTasks.cifar10.getTask())
+supportedTasks = supportedTasks.set(defaultTasks.lusCovid.getTask().id, defaultTasks.lusCovid.getTask())
 
 const task = supportedTasks.get(unsafeArgs.task)
 if (task === undefined) {
@@ -56,6 +57,8 @@ if (task.trainingInformation !== undefined) {
   // For DP
   // TASK.trainingInformation.clippingRadius = 10000000
   // TASK.trainingInformation.noiseScale = 0
+} else {
+  throw new Error("Task training information is undefined")
 }
 
 export const args: BenchmarkArguments = { ...unsafeArgs, task }

--- a/cli/src/args.ts
+++ b/cli/src/args.ts
@@ -24,7 +24,7 @@ const argExample = 'e.g. npm start -- -u 2 -e 3 # runs 2 users for 3 epochs'
 
 const unsafeArgs = parse<BenchmarkUnsafeArguments>(
   {
-    task: { type: String, alias: 't', description: 'Task: titanic, simple_face or cifar10', defaultValue: 'simple_face' },
+    task: { type: String, alias: 't', description: 'Task: titanic, simple_face, cifar10 or lus_covid', defaultValue: 'simple_face' },
     numberOfUsers: { type: Number, alias: 'u', description: 'Number of users', defaultValue: 1 },
     epochs: { type: Number, alias: 'e', description: 'Number of epochs', defaultValue: 10 },
     roundDuration: { type: Number, alias: 'r', description: 'Round duration', defaultValue: 10 },

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -31,10 +31,11 @@ async function runUser(
 
 async function main (task: Task, numberOfUsers: number): Promise<void> {
   console.log(`Started federated training of ${task.id}`)
-
+  console.log({ args })
   const [server, url] = await startServer()
 
   const data = await getTaskData(task)
+
   const logs = await Promise.all(
     Range(0, numberOfUsers).map(async (_) => await runUser(task, url, data)).toArray()
   )

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -31,12 +31,10 @@ async function runUser(
 
 async function main (task: Task, numberOfUsers: number): Promise<void> {
   console.log(`Started federated training of ${task.id}`)
-  console.log(args)
 
   const [server, url] = await startServer()
 
   const data = await getTaskData(task)
-
   const logs = await Promise.all(
     Range(0, numberOfUsers).map(async (_) => await runUser(task, url, data)).toArray()
   )

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -31,7 +31,7 @@ async function runUser(
 
 async function main (task: Task, numberOfUsers: number): Promise<void> {
   console.log(`Started federated training of ${task.id}`)
-  console.log({ args })
+  console.log(args)
 
   const [server, url] = await startServer()
 

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -42,8 +42,24 @@ async function cifar10Data (cifar10: Task): Promise<data.DataSplit> {
   const dir = '../datasets/CIFAR10/'
   const files = (await fs_promises.readdir(dir)).map((file) => path.join(dir, file))
   const labels = Range(0, 24).map((label) => (label % 10).toString()).toArray()
-
   return await new NodeImageLoader(cifar10).loadAll(files, { labels })
+}
+
+async function lusCovidData (lusCovid: Task): Promise<data.DataSplit> {
+  const dir = '../datasets/lus_covid/'
+  const covid_pos = dir + 'COVID+'
+  const covid_neg = dir + 'COVID-'
+  const files_pos = (await fs_promises.readdir(covid_pos)).map(file => path.join(covid_pos, file))
+  const label_pos = Range(0, files_pos.length).map(_ => 'COVID-Positive')
+
+  const files_neg = (await fs_promises.readdir(covid_neg)).map(file => path.join(covid_neg, file))
+  const label_neg = Range(0, files_neg.length).map(_ => 'COVID-Negative')
+  
+  const files = files_pos.concat(files_neg)
+  const labels = label_pos.concat(label_neg).toArray()
+
+  const dataConfig = { labels, shuffle: true, validationSplit: 0.1, channels: 3 }
+  return await new NodeImageLoader(lusCovid).loadAll(files, dataConfig)
 }
 
 async function titanicData (titanic: Task): Promise<data.DataSplit> {
@@ -68,6 +84,8 @@ export async function getTaskData (task: Task): Promise<data.DataSplit> {
       return await titanicData(task)
     case 'cifar10':
       return await cifar10Data(task)
+    case 'lus_covid':
+      return await lusCovidData(task)
     case 'YOUR CUSTOM TASK HERE':
       throw new Error('YOUR CUSTOM FUNCTION HERE')
     default:

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -16,26 +16,17 @@ async function simplefaceData (task: Task): Promise<data.DataSplit> {
   const youngFolders = ['child']
   const oldFolders = ['adult']
 
-  // const dir = '../../face_age/'
-  // const youngFolders = ['007', '008', '009', '010', '011', '012', '013', '014']
-  // const oldFolders = ['021', '022', '023', '024', '025', '026']
-
-  // TODO: we just keep x% of data for faster training, e.g., for each folder, we keep 0.1 fraction of images
   const fractionToKeep = 1
-  const youngFiles = youngFolders.flatMap(folder => {
-    return filesFromFolder(dir, folder, fractionToKeep)
-  })
+  const youngFiles = youngFolders.flatMap(folder => filesFromFolder(dir, folder, fractionToKeep))
+  const adultFiles = oldFolders.flatMap(folder => filesFromFolder(dir, folder, fractionToKeep))
+  const images = youngFiles.concat(adultFiles)
 
-  const oldFiles = oldFolders.flatMap(folder => {
-    return filesFromFolder(dir, folder, fractionToKeep)
-  })
+  const youngLabels = youngFiles.map(_ => 'child')
+  const oldLabels = adultFiles.map(_ => 'adult')
+  const labels = youngLabels.concat(oldLabels)
+  console.log(labels)
 
-  const filesPerFolder = [youngFiles, oldFiles]
-
-  const labels = filesPerFolder.flatMap((files, index) => Array<string>(files.length).fill(`${index}`))
-  const files = filesPerFolder.flat()
-
-  return await new NodeImageLoader(task).loadAll(files, { labels })
+  return await new NodeImageLoader(task).loadAll(images, { labels })
 }
 
 async function cifar10Data (cifar10: Task): Promise<data.DataSplit> {

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -24,8 +24,6 @@ async function simplefaceData (task: Task): Promise<data.DataSplit> {
   const youngLabels = youngFiles.map(_ => 'child')
   const oldLabels = adultFiles.map(_ => 'adult')
   const labels = youngLabels.concat(oldLabels)
-  console.log(labels)
-
   return await new NodeImageLoader(task).loadAll(images, { labels })
 }
 

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -1,24 +1,17 @@
 import { Range } from 'immutable'
-import fs from 'node:fs'
-import fs_promises from 'fs/promises'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import type { Task, data } from '@epfml/discojs-core'
 import { NodeImageLoader, NodeTabularLoader } from '@epfml/discojs-node'
 
-function filesFromFolder (dir: string, folder: string, fractionToKeep: number): string[] {
-  const f = fs.readdirSync(dir + folder)
-  return f.slice(0, Math.round(f.length * fractionToKeep)).map(file => dir + folder + '/' + file)
-}
-
 async function simplefaceData (task: Task): Promise<data.DataSplit> {
   const dir = '../datasets/simple_face/'
-  const youngFolders = ['child']
-  const oldFolders = ['adult']
+  const youngFolder = dir + 'child/'
+  const adultFolder = dir + 'adult/'
 
-  const fractionToKeep = 1
-  const youngFiles = youngFolders.flatMap(folder => filesFromFolder(dir, folder, fractionToKeep))
-  const adultFiles = oldFolders.flatMap(folder => filesFromFolder(dir, folder, fractionToKeep))
+  const youngFiles = (await fs.readdir(youngFolder)).map(file => path.join(youngFolder, file))
+  const adultFiles = (await fs.readdir(adultFolder)).map(file => path.join(adultFolder, file))
   const images = youngFiles.concat(adultFiles)
 
   const youngLabels = youngFiles.map(_ => 'child')
@@ -29,7 +22,7 @@ async function simplefaceData (task: Task): Promise<data.DataSplit> {
 
 async function cifar10Data (cifar10: Task): Promise<data.DataSplit> {
   const dir = '../datasets/CIFAR10/'
-  const files = (await fs_promises.readdir(dir)).map((file) => path.join(dir, file))
+  const files = (await fs.readdir(dir)).map((file) => path.join(dir, file))
   const labels = Range(0, 24).map((label) => (label % 10).toString()).toArray()
   return await new NodeImageLoader(cifar10).loadAll(files, { labels })
 }
@@ -38,10 +31,10 @@ async function lusCovidData (lusCovid: Task): Promise<data.DataSplit> {
   const dir = '../datasets/lus_covid/'
   const covid_pos = dir + 'COVID+'
   const covid_neg = dir + 'COVID-'
-  const files_pos = (await fs_promises.readdir(covid_pos)).map(file => path.join(covid_pos, file))
+  const files_pos = (await fs.readdir(covid_pos)).map(file => path.join(covid_pos, file))
   const label_pos = Range(0, files_pos.length).map(_ => 'COVID-Positive')
 
-  const files_neg = (await fs_promises.readdir(covid_neg)).map(file => path.join(covid_neg, file))
+  const files_neg = (await fs.readdir(covid_neg)).map(file => path.join(covid_neg, file))
   const label_neg = Range(0, files_neg.length).map(_ => 'COVID-Negative')
   
   const files = files_pos.concat(files_neg)

--- a/datasets/.gitignore
+++ b/datasets/.gitignore
@@ -12,9 +12,6 @@
 /titanic_wrong_number_columns.csv
 /titanic_wrong_passengerID.csv
 
-# lungs ultrasound
-/lus_covid/
-
 # wikitext
 /wikitext/
 

--- a/datasets/.gitignore
+++ b/datasets/.gitignore
@@ -14,3 +14,6 @@
 
 # wikitext
 /wikitext/
+
+# LUS Covid
+/lus_covid/

--- a/datasets/.gitignore
+++ b/datasets/.gitignore
@@ -12,6 +12,9 @@
 /titanic_wrong_number_columns.csv
 /titanic_wrong_passengerID.csv
 
+# lungs ultrasound
+/lus_covid/
+
 # wikitext
 /wikitext/
 

--- a/datasets/populate
+++ b/datasets/populate
@@ -13,9 +13,3 @@ mkdir -p wikitext
 cd wikitext
 curl 'https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.tar.gz' |
 	tar --extract --gzip --strip-components=1
-
-# lus_covid
-mkdir -p lus_covid
-cd lus_covid
-curl https://drive.switch.ch/index.php/s/zM5ZrUWK3taaIly/download |
-	tar --extract --gzip --strip-components=1

--- a/datasets/populate
+++ b/datasets/populate
@@ -8,8 +8,16 @@ cd "$(dirname "$0")"
 curl 'http://deai-313515.appspot.com.storage.googleapis.com/example_training_data.tar.gz' |
 	tar --extract --strip-components=1
 
+# lungs ultrasound
+curl 'https://drive.switch.ch/index.php/s/zM5ZrUWK3taaIly/download' > archive.zip
+unzip -u archive.zip
+rm -rf 'lungs ultrasound'
+mv DeAI-testimages 'lus_covid'
+rm archive.zip
+
 # wikitext
 mkdir -p wikitext
 cd wikitext
 curl 'https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.tar.gz' |
 	tar --extract --gzip --strip-components=1
+cd ..

--- a/datasets/populate
+++ b/datasets/populate
@@ -18,4 +18,4 @@ curl 'https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.ta
 mkdir -p lus_covid
 cd lus_covid
 curl https://drive.switch.ch/index.php/s/zM5ZrUWK3taaIly/download |
-        tar --extract --gzip --strip-components=1
+	tar --extract --gzip --strip-components=1

--- a/datasets/populate
+++ b/datasets/populate
@@ -13,3 +13,9 @@ mkdir -p wikitext
 cd wikitext
 curl 'https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.tar.gz' |
 	tar --extract --gzip --strip-components=1
+
+# lus_covid
+mkdir -p lus_covid
+cd lus_covid
+curl https://drive.switch.ch/index.php/s/zM5ZrUWK3taaIly/download |
+        tar --extract --gzip --strip-components=1

--- a/discojs/discojs-core/src/client/event_connection.ts
+++ b/discojs/discojs-core/src/client/event_connection.ts
@@ -1,4 +1,4 @@
-import isomorphic from 'isomorphic-ws'
+import WebSocket from 'isomorphic-ws'
 import type { Peer, SignalData } from './decentralized/peer.js'
 import { type NodeID } from './types.js'
 import msgpack from 'msgpack-lite'
@@ -82,19 +82,19 @@ export class PeerConnection extends EventEmitter<{ [K in type]: NarrowMessage<K>
 
 export class WebSocketServer extends EventEmitter<{ [K in type]: NarrowMessage<K> }> implements EventConnection {
   private constructor (
-    private readonly socket: isomorphic.WebSocket,
+    private readonly socket: WebSocket.WebSocket,
     private readonly validateSent?: (msg: Message) => boolean
   ) { super() }
 
   static async connect (url: URL,
     validateReceived: (msg: unknown) => msg is Message,
     validateSent: (msg: Message) => boolean): Promise<WebSocketServer> {
-    const ws = new isomorphic.WebSocket(url)
+    const ws = new WebSocket(url)
     ws.binaryType = 'arraybuffer'
 
     const server: WebSocketServer = new WebSocketServer(ws, validateSent)
 
-    ws.onmessage = (event: isomorphic.MessageEvent) => {
+    ws.onmessage = (event: WebSocket.MessageEvent) => {
       if (!(event.data instanceof ArrayBuffer)) {
         throw new Error('server did not send an ArrayBuffer')
       }
@@ -110,7 +110,7 @@ export class WebSocketServer extends EventEmitter<{ [K in type]: NarrowMessage<K
     }
 
     return await new Promise((resolve, reject) => {
-      ws.onerror = (err: isomorphic.ErrorEvent) => {
+      ws.onerror = (err: WebSocket.ErrorEvent) => {
         reject(new Error(`Server unreachable: ${err.message}`))
       }
       ws.onopen = () => { resolve(server) }

--- a/discojs/discojs-core/src/dataset/data/image_data.ts
+++ b/discojs/discojs-core/src/dataset/data/image_data.ts
@@ -43,12 +43,12 @@ export class ImageData extends Data {
           throw new Error()
         }
       } catch (e) {
-	      let cause
-	      if (e instanceof Error) {
+        let cause
+        if (e instanceof Error) {
           cause = e
-	      } else {
+        } else {
           console.error("got invalid Error type", e)
-	      }
+        }
         throw new Error('Data input format is not compatible with the chosen task', { cause })
       }
     }

--- a/discojs/discojs-core/src/dataset/data/image_data.ts
+++ b/discojs/discojs-core/src/dataset/data/image_data.ts
@@ -43,12 +43,12 @@ export class ImageData extends Data {
           throw new Error()
         }
       } catch (e) {
-	let cause
-	if (e instanceof Error) {
+	      let cause
+	      if (e instanceof Error) {
           cause = e
-	} else {
+	      } else {
           console.error("got invalid Error type", e)
-	}
+	      }
         throw new Error('Data input format is not compatible with the chosen task', { cause })
       }
     }

--- a/discojs/discojs-core/src/dataset/data_loader/data_loader.ts
+++ b/discojs/discojs-core/src/dataset/data_loader/data_loader.ts
@@ -6,6 +6,7 @@ export interface DataConfig {
   shuffle?: boolean,
   validationSplit?: number,
   inference?: boolean,
+  // Mostly used for reading lus_covid images with 3 channels (default is 1 and causes an error)
   channels?:number
 }
 

--- a/discojs/discojs-core/src/dataset/data_loader/data_loader.ts
+++ b/discojs/discojs-core/src/dataset/data_loader/data_loader.ts
@@ -1,6 +1,13 @@
 import type { DataSplit, Dataset } from '../index.js'
 
-export interface DataConfig { features?: string[], labels?: string[], shuffle?: boolean, validationSplit?: number, inference?: boolean }
+export interface DataConfig {
+  features?: string[],
+  labels?: string[],
+  shuffle?: boolean,
+  validationSplit?: number,
+  inference?: boolean,
+  channels?:number
+}
 
 export abstract class DataLoader<Source> {
   abstract load (source: Source, config: DataConfig): Promise<Dataset>

--- a/discojs/discojs-core/src/dataset/data_loader/image_loader.ts
+++ b/discojs/discojs-core/src/dataset/data_loader/image_loader.ts
@@ -69,13 +69,13 @@ export abstract class ImageLoader<Source> extends DataLoader<Source> {
 
     const indices = Range(0, images.length).toArray()
     if (config?.labels !== undefined) {
-      const label_list = this.task.trainingInformation?.LABEL_LIST
-      if (label_list === undefined || !Array.isArray(label_list)) {
+      const labelList = this.task.trainingInformation?.LABEL_LIST
+      if (labelList === undefined || !Array.isArray(labelList)) {
         throw new Error('LABEL_LIST should be specified in the task training information')
       }
-      const numberOfClasses = label_list.length
+      const numberOfClasses = labelList.length
       // Map label strings to integer
-      const label_to_int = new Map(label_list.map((label_name, idx) => [label_name, idx]))
+      const label_to_int = new Map(labelList.map((label_name, idx) => [label_name, idx]))
       if (label_to_int.size != numberOfClasses) {
         throw new Error("Input labels aren't matching the task LABEL_LIST")
       }

--- a/discojs/discojs-core/src/dataset/data_loader/image_loader.ts
+++ b/discojs/discojs-core/src/dataset/data_loader/image_loader.ts
@@ -42,6 +42,7 @@ export abstract class ImageLoader<Source> extends DataLoader<Source> {
 
   private async buildDataset (images: Source[], labels: number[], indices: number[], config?: DataConfig): Promise<Data> {
     // Can't use arrow function for generator and need access to 'this'
+    // eslint-disable-next-line
     const self = this
     async function * dataGenerator (): AsyncGenerator<tf.TensorContainer> {
       const withLabels = config?.labels !== undefined

--- a/discojs/discojs-core/src/dataset/dataset_builder.ts
+++ b/discojs/discojs-core/src/dataset/dataset_builder.ts
@@ -128,7 +128,7 @@ export class DatasetBuilder<Source> {
         shuffle: false
       }
       const sources = this.labelledSources.valueSeq().toArray().flat()
-      dataTuple = await this.dataLoader.loadAll(sources, defaultConfig)
+      dataTuple = await this.dataLoader.loadAll(sources, { ...defaultConfig, ...config })
     }
     // TODO @s314cy: Support .csv labels for image datasets (supervised training or testing)
     this._built = true

--- a/discojs/discojs-core/src/dataset/dataset_builder.ts
+++ b/discojs/discojs-core/src/dataset/dataset_builder.ts
@@ -21,7 +21,7 @@ export class DatasetBuilder<Source> {
   /**
    * Whether a dataset was already produced.
    */
-  // TODO useless, responsiblity on callers
+  // TODO useless, responsibility on callers
   private _built: boolean
 
   constructor (
@@ -84,12 +84,12 @@ export class DatasetBuilder<Source> {
   }
 
   private getLabels (): string[] {
-    // We need to duplicate the labels as we need one for each soure.
+    // We need to duplicate the labels as we need one for each source.
     // Say for label A we have sources [img1, img2, img3], then we
     // need labels [A, A, A].
     let labels: string[][] = []
-    this.labelledSources.valueSeq().forEach((sources, index) => {
-      const sourcesLabels = Array.from({ length: sources.length }, (_) => index.toString())
+    this.labelledSources.forEach((sources, label) => {
+      const sourcesLabels = Array.from({ length: sources.length }, (_) => label)
       labels = labels.concat(sourcesLabels)
     })
     return labels.flat()

--- a/discojs/discojs-core/src/default_tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/default_tasks/lus_covid.ts
@@ -21,9 +21,9 @@ export const lusCovid: TaskProvider = {
       },
       trainingInformation: {
         modelID: 'lus-covid-model',
-        epochs: 10,
+        epochs: 50,
         roundDuration: 2,
-        validationSplit: 0.2,
+        validationSplit: 0,
         batchSize: 5,
         IMAGE_H: 100,
         IMAGE_W: 100,

--- a/discojs/discojs-core/src/default_tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/default_tasks/lus_covid.ts
@@ -21,7 +21,7 @@ export const lusCovid: TaskProvider = {
       },
       trainingInformation: {
         modelID: 'lus-covid-model',
-        epochs: 10,
+        epochs: 50,
         roundDuration: 2,
         validationSplit: 0.2,
         batchSize: 5,

--- a/discojs/discojs-core/src/default_tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/default_tasks/lus_covid.ts
@@ -21,10 +21,10 @@ export const lusCovid: TaskProvider = {
       },
       trainingInformation: {
         modelID: 'lus-covid-model',
-        epochs: 15,
+        epochs: 10,
         roundDuration: 10,
         validationSplit: 0.2,
-        batchSize: 2,
+        batchSize: 5,
         IMAGE_H: 100,
         IMAGE_W: 100,
         preprocessingFunctions: [data.ImagePreprocessing.Resize],
@@ -40,7 +40,7 @@ export const lusCovid: TaskProvider = {
     }
   },
 
-  // Model architecture from tensorflow js docs: 
+  // Model architecture from tensorflow.js docs: 
   // https://codelabs.developers.google.com/codelabs/tfjs-training-classfication/index.html#4
   async getModel (): Promise<Model> {
     const imageHeight = 100
@@ -92,7 +92,7 @@ export const lusCovid: TaskProvider = {
     }))
 
     model.compile({
-      optimizer: tf.train.adam(0.0001), // lus_covid performance are very sensitive to the learning rate
+      optimizer: tf.train.adam(), // lus_covid performance are very sensitive to the learning rate
       loss: 'binaryCrossentropy',
       metrics: ['accuracy']
     })

--- a/discojs/discojs-core/src/default_tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/default_tasks/lus_covid.ts
@@ -30,11 +30,11 @@ export const lusCovid: TaskProvider = {
         preprocessingFunctions: [data.ImagePreprocessing.Resize, data.ImagePreprocessing.Normalize],
         LABEL_LIST: ['COVID-Positive', 'COVID-Negative'],
         dataType: 'image',
-        scheme: 'decentralized',
+        scheme: 'federated',
         noiseScale: undefined,
         clippingRadius: 20,
         decentralizedSecure: true,
-        minimumReadyPeers: 3,
+        minimumReadyPeers: 2,
         maxShareValue: 100
       }
     }

--- a/discojs/discojs-core/src/default_tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/default_tasks/lus_covid.ts
@@ -21,16 +21,16 @@ export const lusCovid: TaskProvider = {
       },
       trainingInformation: {
         modelID: 'lus-covid-model',
-        epochs: 10,
+        epochs: 15,
         roundDuration: 10,
         validationSplit: 0.2,
         batchSize: 5,
         IMAGE_H: 100,
         IMAGE_W: 100,
-        preprocessingFunctions: [data.ImagePreprocessing.Resize],
+        preprocessingFunctions: [data.ImagePreprocessing.Resize, data.ImagePreprocessing.Normalize],
         LABEL_LIST: ['COVID-Positive', 'COVID-Negative'],
         dataType: 'image',
-        scheme: 'federated',
+        scheme: 'decentralized',
         noiseScale: undefined,
         clippingRadius: 20,
         decentralizedSecure: true,
@@ -65,18 +65,16 @@ export const lusCovid: TaskProvider = {
     // in a region instead of averaging.
     model.add(tf.layers.maxPooling2d({ poolSize: [2, 2], strides: [2, 2] }))
 
-    // Repeat 3 conv2d + maxPooling blocks.
+    // Repeat the conv2d + maxPooling block.
     // Note that we have more filters in the convolution.
-    for (let i = 0; i < 3; i++) {
-      model.add(tf.layers.conv2d({
-        kernelSize: 5,
-        filters: 16,
-        strides: 1,
-        activation: 'relu',
-        kernelInitializer: 'varianceScaling'
-      }))
-      model.add(tf.layers.maxPooling2d({ poolSize: [2, 2], strides: [2, 2] }))
-    }
+    model.add(tf.layers.conv2d({
+      kernelSize: 5,
+      filters: 16,
+      strides: 1,
+      activation: 'relu',
+      kernelInitializer: 'varianceScaling'
+    }))
+    model.add(tf.layers.maxPooling2d({ poolSize: [2, 2], strides: [2, 2] }))
 
     // Now we flatten the output from the 2D filters into a 1D vector to prepare
     // it for input into our last layer. This is common practice when feeding
@@ -92,7 +90,7 @@ export const lusCovid: TaskProvider = {
     }))
 
     model.compile({
-      optimizer: tf.train.adam(), // lus_covid performance are very sensitive to the learning rate
+      optimizer: 'sgd',
       loss: 'binaryCrossentropy',
       metrics: ['accuracy']
     })

--- a/discojs/discojs-core/src/default_tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/default_tasks/lus_covid.ts
@@ -21,7 +21,7 @@ export const lusCovid: TaskProvider = {
       },
       trainingInformation: {
         modelID: 'lus-covid-model',
-        epochs: 50,
+        epochs: 10,
         roundDuration: 2,
         validationSplit: 0.2,
         batchSize: 5,

--- a/discojs/discojs-core/src/default_tasks/lus_covid.ts
+++ b/discojs/discojs-core/src/default_tasks/lus_covid.ts
@@ -21,8 +21,8 @@ export const lusCovid: TaskProvider = {
       },
       trainingInformation: {
         modelID: 'lus-covid-model',
-        epochs: 15,
-        roundDuration: 10,
+        epochs: 10,
+        roundDuration: 2,
         validationSplit: 0.2,
         batchSize: 5,
         IMAGE_H: 100,

--- a/discojs/discojs-core/src/serialization/weights.ts
+++ b/discojs/discojs-core/src/serialization/weights.ts
@@ -12,10 +12,8 @@ function isSerialized (raw: unknown): raw is Serialized {
   if (typeof raw !== 'object' || raw === null) {
     return false
   }
-  if (!('shape' in raw && 'data' in raw)) {
-    return false
-  }
-  const { shape, data } = raw as Record<'shape' | 'data', unknown>
+
+  const { shape, data }: Partial<Record<'shape' | 'data', unknown>> = raw
 
   if (
     !(Array.isArray(shape) && shape.every((e) => typeof e === 'number')) ||
@@ -24,7 +22,10 @@ function isSerialized (raw: unknown): raw is Serialized {
     return false
   }
 
-  const _: Serialized = {shape, data}
+  const _: Serialized = {
+    shape: shape as number[],
+    data: data as number[],
+  }
 
   return true
 }

--- a/discojs/discojs-core/src/training/disco.ts
+++ b/discojs/discojs-core/src/training/disco.ts
@@ -84,7 +84,8 @@ export class Disco {
    * Starts a training instance for the Disco object's task on the provided data tuple.
    * @param dataTuple The data tuple
    */
-  async *fit(dataTuple: data.DataSplit): AsyncGenerator<RoundLogs> {
+  // TODO RoundLogs should contain number of participants but Trainer doesn't need client
+  async *fit(dataTuple: data.DataSplit): AsyncGenerator<RoundLogs & { participants: number }> {
     this.logger.success("Training started.");
 
     const trainData = dataTuple.train.preprocess().batch();
@@ -108,7 +109,10 @@ export class Disco {
       }
       this.logger.success(msg)
 
-      yield roundLogs
+      yield {
+        ...roundLogs,
+        participants: this.client.nodes.size + 1 // add ourself
+      }
     }
 
     this.logger.success("Training finished.");

--- a/discojs/discojs-core/src/training/trainer/trainer_builder.ts
+++ b/discojs/discojs-core/src/training/trainer/trainer_builder.ts
@@ -1,6 +1,6 @@
 import type { client as clients, Model, Task, ModelInfo, Memory } from '../../index.js'
 import { ModelType } from '../../index.js'
-
+import * as tf from '@tensorflow/tfjs'
 import { DistributedTrainer } from './distributed_trainer.js'
 import { LocalTrainer } from './local_trainer.js'
 import type { Trainer } from './trainer.js'
@@ -40,7 +40,7 @@ export class TrainerBuilder {
   }
 
   /**
-   * If a model exists in memory, laod it, otherwise load model from server
+   * If a model exists in memory, load it, otherwise load model from server
    * @returns
    */
   private async getModel (client: clients.Client): Promise<Model> {
@@ -54,7 +54,7 @@ export class TrainerBuilder {
     const model = await (
       await this.memory.contains(info) ? this.memory.getModel(info) : client.getLatestModel()
     )
-
+    console.log("Model weights: ", await model.weights.weights.at(0)?.data<'float32'>())
     return model
   }
 }

--- a/discojs/discojs-core/src/training/trainer/trainer_builder.ts
+++ b/discojs/discojs-core/src/training/trainer/trainer_builder.ts
@@ -1,6 +1,5 @@
 import type { client as clients, Model, Task, ModelInfo, Memory } from '../../index.js'
 import { ModelType } from '../../index.js'
-import * as tf from '@tensorflow/tfjs'
 import { DistributedTrainer } from './distributed_trainer.js'
 import { LocalTrainer } from './local_trainer.js'
 import type { Trainer } from './trainer.js'

--- a/discojs/discojs-core/src/training/trainer/trainer_builder.ts
+++ b/discojs/discojs-core/src/training/trainer/trainer_builder.ts
@@ -53,7 +53,6 @@ export class TrainerBuilder {
     const model = await (
       await this.memory.contains(info) ? this.memory.getModel(info) : client.getLatestModel()
     )
-    console.log("Model weights: ", await model.weights.weights.at(0)?.data<'float32'>())
     return model
   }
 }

--- a/discojs/discojs-node/src/data/image_loader.spec.ts
+++ b/discojs/discojs-node/src/data/image_loader.spec.ts
@@ -1,19 +1,13 @@
 import { assert, expect } from 'chai'
-import { List, Map, Range } from 'immutable'
-import fs from 'fs'
+import { List, Range } from 'immutable'
+import fs from 'node:fs/promises'
 import * as tf from '@tensorflow/tfjs'
 import { node as tfNode } from '@tensorflow/tfjs-node'
 
 import type { Task } from '@epfml/discojs-core'
+import { data } from '@epfml/discojs-core'
 
 import { ImageLoader } from './image_loader.js'
-
-const readFilesFromDir = (dir: string): string[] =>
-  fs.readdirSync(dir).map((file: string) => dir + file)
-
-const DIRS = {
-  CIFAR10: '../../datasets/CIFAR10/'
-}
 
 const cifar10Mock: Task = {
   id: 'cifar10',
@@ -49,36 +43,87 @@ const mnistMock: Task = {
   }
 }
 
+const lusCovidMock: Task = {
+  id: 'lus-covid',
+  displayInformation: {},
+  trainingInformation: {
+      modelID: 'lus-covid-model',
+      epochs: 1,
+      roundDuration: 1,
+      validationSplit: 0.2,
+      batchSize: 1,
+      IMAGE_H: 100,
+      IMAGE_W: 100,
+      preprocessingFunctions: [data.ImagePreprocessing.Resize],
+      LABEL_LIST: ['COVID-Positive', 'COVID-Negative'],
+      dataType: 'image',
+      scheme: 'federated',
+    }
+}
+
+const DIRS = {
+  CIFAR10: '../../datasets/CIFAR10/',
+  LUS_COVID: '../../datasets/lus_covid/COVID+/'
+}
+
+async function readFilesFromDir(dir: string): Promise<string[]>{
+  return (await fs.readdir(dir)).map((file: string) => dir + file)
+}
+
+const FILES = {
+  CIFAR10: await readFilesFromDir(DIRS.CIFAR10),
+  LUS_COVID: await readFilesFromDir(DIRS.LUS_COVID),
+}
+
 const LOADERS = {
   CIFAR10: new ImageLoader(cifar10Mock),
-  MNIST: new ImageLoader(mnistMock)
+  MNIST: new ImageLoader(mnistMock),
+  LUS_COVID: new ImageLoader(lusCovidMock),
 }
-const FILES = Map(DIRS).map((readFilesFromDir)).toObject()
 
-describe('image loader', () => {
+async function readImageTensor(source: string, channels?: number) {
+  return tfNode.decodeImage(await fs.readFile(source), channels) as tf.Tensor3D
+}
+
+const imagesCIFAR10 = await Promise.all(FILES.CIFAR10.map(source => readImageTensor(source)))
+
+describe('image loader', async () => {
   it('loads single sample without label', async () => {
-    const file = '../../datasets/9-mnist-example.png'
-    const singletonDataset = await LOADERS.MNIST.load(file)
-    const imageContent = tfNode.decodeImage(fs.readFileSync(file))
+    const source = '../../datasets/9-mnist-example.png'
+    const singletonDataset = await LOADERS.MNIST.load(source)
+    const imageContent = await readImageTensor(source)
+
     await Promise.all((await singletonDataset.toArrayForTest()).map(async (entry) => {
       expect(await imageContent.bytes()).eql(await (entry as tf.Tensor).bytes())
     }))
   })
 
+  it('loads lus images with 3 channels', async () => {
+    const channels = 3 
+    const imagesContent = FILES.LUS_COVID.map(source => readImageTensor(source, channels))
+    const datasetContent = await (await LOADERS.LUS_COVID
+      .loadAll(FILES.LUS_COVID, { shuffle: false, channels }))
+      .train.dataset.toArray()
+    
+    expect(datasetContent.length).equal(imagesContent.length)
+    expect((datasetContent[0] as tf.Tensor3D).shape[2]).equals(3)
+    expect((datasetContent[0] as tf.Tensor3D).shape).eql((await imagesContent[0]).shape)
+  })
+
+
   it('loads multiple samples without labels', async () => {
-    const imagesContent = FILES.CIFAR10.map((file) => tfNode.decodeImage(fs.readFileSync(file)))
     const datasetContent = await (await LOADERS.CIFAR10
       .loadAll(FILES.CIFAR10, { shuffle: false }))
       .train.dataset.toArray()
-    expect(datasetContent.length).equal(imagesContent.length)
-    expect((datasetContent[0] as tf.Tensor3D).shape).eql(imagesContent[0].shape)
+    expect(datasetContent.length).equal(imagesCIFAR10.length)
+    expect((datasetContent[0] as tf.Tensor3D).shape).eql((imagesCIFAR10[0]).shape)
   })
 
   it('loads single sample with label', async () => {
-    const path = DIRS.CIFAR10 + '0.png'
-    const imageContent = tfNode.decodeImage(fs.readFileSync(path))
+    const source = DIRS.CIFAR10 + '0.png'
+    const imageContent = await readImageTensor(source)
     const datasetContent = await (await LOADERS.CIFAR10
-      .load(path, { labels: ['example'] })).toArray() as Array<Record<'xs' | 'ys', tf.Tensor>>
+      .load(source, { labels: ['example'] })).toArray() as Array<Record<'xs' | 'ys', tf.Tensor>>
     expect(datasetContent[0].xs.shape).eql(imageContent.shape)
     expect(datasetContent[0].ys).eql('example')
   })
@@ -88,13 +133,12 @@ describe('image loader', () => {
     const stringLabels = labels.map((label) => label.toString())
     const oneHotLabels = List(tf.oneHot(labels.toArray(), 10).arraySync() as number[])
 
-    const imagesContent = List(FILES.CIFAR10.map((file) => tfNode.decodeImage(fs.readFileSync(file))))
     const datasetContent = List(await (await LOADERS.CIFAR10
       .loadAll(FILES.CIFAR10, { labels: stringLabels.toArray(), shuffle: false }))
       .train.dataset.toArray())
 
-    expect(datasetContent.size).equal(imagesContent.size)
-    datasetContent.zip(imagesContent).zip(oneHotLabels).forEach(([[actual, sample], label]) => {
+    expect(datasetContent.size).equal(imagesCIFAR10.length)
+    datasetContent.zip(List(imagesCIFAR10)).zip(oneHotLabels).forEach(([[actual, sample], label]) => {
       if (!(
         typeof actual === 'object' && actual !== null &&
         'xs' in actual && 'ys' in actual
@@ -143,15 +187,14 @@ describe('image loader', () => {
   })
   it('validation split', async () => {
     const validationSplit = 0.2
-    const imagesContent = FILES.CIFAR10.map((file) => tfNode.decodeImage(fs.readFileSync(file)))
     const datasetContent = await new ImageLoader(cifar10Mock)
       .loadAll(FILES.CIFAR10, { shuffle: false, validationSplit })
 
-    const trainSize = Math.floor(imagesContent.length * (1 - validationSplit))
+    const trainSize = Math.floor(imagesCIFAR10.length * (1 - validationSplit))
     expect((await datasetContent.train.dataset.toArray()).length).equal(trainSize)
     if (datasetContent.validation === undefined) {
       assert(false)
     }
-    expect((await datasetContent.validation.dataset.toArray()).length).equal(imagesContent.length - trainSize)
+    expect((await datasetContent.validation.dataset.toArray()).length).equal(imagesCIFAR10.length - trainSize)
   })
 })

--- a/discojs/discojs-node/src/data/image_loader.spec.ts
+++ b/discojs/discojs-node/src/data/image_loader.spec.ts
@@ -107,23 +107,21 @@ describe('image loader', () => {
   })
 
   it('loads samples in order', async () => {
-    const loader = new ImageLoader(defaultTasks.mnist.getTask())
-    const dataset = await ((await loader.loadAll(FILES.CIFAR10, { shuffle: false })).train.dataset).toArray()
+    const dataset = await ((await LOADERS.CIFAR10.loadAll(FILES.CIFAR10, { shuffle: false })).train.dataset).toArray()
 
     List(dataset).zip(List(FILES.CIFAR10))
       .forEach(async ([s, f]) => {
-        const sample = (await (await loader.load(f)).toArray())[0]
+        const sample = (await (await LOADERS.CIFAR10.load(f)).toArray())[0]
         assert.deepEqual((await tf.equal(s as tf.Tensor, sample as tf.Tensor).all().array()), [1])
       })
     assert(true)
   })
 
   it('shuffles list', () => {
-    const loader = new ImageLoader(defaultTasks.mnist.getTask())
     const list = Range(0, 100_000).toArray()
     const shuffled = [...list]
 
-    loader.shuffle(shuffled)
+    LOADERS.CIFAR10.shuffle(shuffled)
     expect(list).to.not.eql(shuffled)
 
     shuffled.sort((a, b) => a - b)
@@ -131,9 +129,8 @@ describe('image loader', () => {
   })
 
   it('shuffles samples', async () => {
-    const loader = new ImageLoader(defaultTasks.mnist.getTask())
-    const dataset = await (await loader.loadAll(FILES.CIFAR10, { shuffle: false })).train.dataset.toArray()
-    const shuffled = await (await loader.loadAll(FILES.CIFAR10, { shuffle: true })).train.dataset.toArray()
+    const dataset = await (await LOADERS.CIFAR10.loadAll(FILES.CIFAR10, { shuffle: false })).train.dataset.toArray()
+    const shuffled = await (await LOADERS.CIFAR10.loadAll(FILES.CIFAR10, { shuffle: true })).train.dataset.toArray()
 
     const misses = List(dataset).zip(List(shuffled)).map(([d, s]) =>
       tf.notEqual(d as tf.Tensor, s as tf.Tensor).any().dataSync()[0]
@@ -142,8 +139,7 @@ describe('image loader', () => {
   })
   it('validation split', async () => {
     const validationSplit = 0.2
-    const datasetContent = await new ImageLoader(defaultTasks.mnist.getTask())
-      .loadAll(FILES.CIFAR10, { shuffle: false, validationSplit })
+    const datasetContent = await LOADERS.CIFAR10.loadAll(FILES.CIFAR10, { shuffle: false, validationSplit })
 
     const trainSize = Math.floor(imagesCIFAR10.length * (1 - validationSplit))
     expect((await datasetContent.train.dataset.toArray()).length).equal(trainSize)

--- a/discojs/discojs-node/src/data/image_loader.spec.ts
+++ b/discojs/discojs-node/src/data/image_loader.spec.ts
@@ -99,17 +99,18 @@ describe('image loader', () => {
     }))
   })
 
-  it('loads lus images with 3 channels', async () => {
-    const channels = 3 
-    const imagesContent = FILES.LUS_COVID.map(source => readImageTensor(source, channels))
-    const datasetContent = await (await LOADERS.LUS_COVID
-      .loadAll(FILES.LUS_COVID, { shuffle: false, channels }))
-      .train.dataset.toArray()
+  // TODO uncomment once lus images are downloaded by the datasets/populate script
+  // it('loads lus images with 3 channels', async () => {
+  //   const channels = 3 
+  //   const imagesContent = FILES.LUS_COVID.map(source => readImageTensor(source, channels))
+  //   const datasetContent = await (await LOADERS.LUS_COVID
+  //     .loadAll(FILES.LUS_COVID, { shuffle: false, channels }))
+  //     .train.dataset.toArray()
     
-    expect(datasetContent.length).equal(imagesContent.length)
-    expect((datasetContent[0] as tf.Tensor3D).shape[2]).equals(3)
-    expect((datasetContent[0] as tf.Tensor3D).shape).eql((await imagesContent[0]).shape)
-  })
+  //   expect(datasetContent.length).equal(imagesContent.length)
+  //   expect((datasetContent[0] as tf.Tensor3D).shape[2]).equals(3)
+  //   expect((datasetContent[0] as tf.Tensor3D).shape).eql((await imagesContent[0]).shape)
+  // })
 
 
   it('loads multiple samples without labels', async () => {

--- a/discojs/discojs-node/src/data/image_loader.spec.ts
+++ b/discojs/discojs-node/src/data/image_loader.spec.ts
@@ -99,18 +99,17 @@ describe('image loader', () => {
     }))
   })
 
-  // TODO uncomment once lus images are downloaded by the datasets/populate script
-  // it('loads lus images with 3 channels', async () => {
-  //   const channels = 3 
-  //   const imagesContent = FILES.LUS_COVID.map(source => readImageTensor(source, channels))
-  //   const datasetContent = await (await LOADERS.LUS_COVID
-  //     .loadAll(FILES.LUS_COVID, { shuffle: false, channels }))
-  //     .train.dataset.toArray()
+  it('loads lus images with 3 channels', async () => {
+    const channels = 3 
+    const imagesContent = FILES.LUS_COVID.map(source => readImageTensor(source, channels))
+    const datasetContent = await (await LOADERS.LUS_COVID
+      .loadAll(FILES.LUS_COVID, { shuffle: false, channels }))
+      .train.dataset.toArray()
     
-  //   expect(datasetContent.length).equal(imagesContent.length)
-  //   expect((datasetContent[0] as tf.Tensor3D).shape[2]).equals(3)
-  //   expect((datasetContent[0] as tf.Tensor3D).shape).eql((await imagesContent[0]).shape)
-  // })
+    expect(datasetContent.length).equal(imagesContent.length)
+    expect((datasetContent[0] as tf.Tensor3D).shape[2]).equals(3)
+    expect((datasetContent[0] as tf.Tensor3D).shape).eql((await imagesContent[0]).shape)
+  })
 
 
   it('loads multiple samples without labels', async () => {

--- a/discojs/discojs-node/src/data/image_loader.spec.ts
+++ b/discojs/discojs-node/src/data/image_loader.spec.ts
@@ -87,13 +87,14 @@ async function readImageTensor(source: string, channels?: number) {
 
 const imagesCIFAR10 = await Promise.all(FILES.CIFAR10.map(source => readImageTensor(source)))
 
-describe('image loader', async () => {
+describe('image loader', () => {
   it('loads single sample without label', async () => {
     const source = '../../datasets/9-mnist-example.png'
     const singletonDataset = await LOADERS.MNIST.load(source)
     const imageContent = await readImageTensor(source)
 
-    await Promise.all((await singletonDataset.toArrayForTest()).map(async (entry) => {
+    const datasetArr = await singletonDataset.toArrayForTest()
+    await Promise.all(datasetArr.map(async (entry) => {
       expect(await imageContent.bytes()).eql(await (entry as tf.Tensor).bytes())
     }))
   })

--- a/discojs/discojs-node/src/data/image_loader.ts
+++ b/discojs/discojs-node/src/data/image_loader.ts
@@ -1,11 +1,14 @@
 import fs from 'node:fs/promises'
 import type tf from '@tensorflow/tfjs'
-import { node } from '@tensorflow/tfjs-node'
+import { node as tfNode } from '@tensorflow/tfjs-node'
 
 import { data } from '@epfml/discojs-core'
 
 export class ImageLoader extends data.ImageLoader<string> {
-  async readImageFrom (source: string): Promise<tf.Tensor3D> {
-    return node.decodeImage(await fs.readFile(source)) as tf.Tensor3D
+  async readImageFrom(source: string, channels?: number): Promise<tf.Tensor3D> {
+    // We allow specifying the number of channels because the default number of channels
+    // differs between web and node for the same image 
+    // E.g. lus covid images have 1 channel with fs.readFile but 3 when loaded with discojs-web
+    return tfNode.decodeImage(await fs.readFile(source), channels) as tf.Tensor3D
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "ws": "8"
       },
       "devDependencies": {
-        "@tensorflow/tfjs-node": "^4.17.0",
+        "@tensorflow/tfjs-node": "4",
         "@types/chai": "4",
         "@types/mocha": "10",
         "@types/simple-peer": "9",
@@ -774,12 +774,12 @@
       "dev": true
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.12.0.tgz",
-      "integrity": "sha512-6EnWQXHnCh2bMiXT5N/IWwkcYQXjmF8nnEZ3YhTm23h1ZfOylz83D7pJYhcU8CsTiEdgbGiNdqyZPKwrHw03Ng==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.13.1.tgz",
+      "integrity": "sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==",
       "dependencies": {
-        "@intlify/message-compiler": "9.12.0",
-        "@intlify/shared": "9.12.0"
+        "@intlify/message-compiler": "9.13.1",
+        "@intlify/shared": "9.13.1"
       },
       "engines": {
         "node": ">= 16"
@@ -789,11 +789,11 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.12.0.tgz",
-      "integrity": "sha512-2c6VwhvVJ1nur+2cN2NjdrmrV6vXjvyxYVvtUYMXKsWSUwoNURHGds0xJVJmWxbF8qV9oGepcVV6xl9bvadEIg==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.13.1.tgz",
+      "integrity": "sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==",
       "dependencies": {
-        "@intlify/shared": "9.12.0",
+        "@intlify/shared": "9.13.1",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.12.0.tgz",
-      "integrity": "sha512-uBcH55x5CfZynnerWHQxrXbT6yD6j6T7Nt+R2+dHAOAneoMd6BoGvfEzfYscE94rgmjoDqdr+PdGDBLk5I5EjA==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.13.1.tgz",
+      "integrity": "sha512-u3b6BKGhE6j/JeRU6C/RL2FgyJfy6LakbtfeVF8fJXURpZZTzfh3e05J0bu0XPw447Q6/WUp3C4ajv4TMS4YsQ==",
       "engines": {
         "node": ">= 16"
       },
@@ -1147,200 +1147,257 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.2.tgz",
-      "integrity": "sha512-ahxSgCkAEk+P/AVO0vYr7DxOD3CwAQrT0Go9BJyGQ9Ef0QxVOfjDZMiF4Y2s3mLyPrjonchIMH/tbWHucJMykQ==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.16.4.tgz",
+      "integrity": "sha512-GkhjAaQ8oUTOKE4g4gsZ0u8K/IHU1+2WQSgS1TwTcYvL+sjbaQjNHFXbOJ6kgqGHIO1DfUhI/Sphi9GkRT9K+Q==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.2.tgz",
-      "integrity": "sha512-lAarIdxZWbFSHFSDao9+I/F5jDaKyCqAPMq5HqnfpBw8dKDiCaaqM0lq5h1pQTLeIqueeay4PieGR5jGZMWprw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.16.4.tgz",
+      "integrity": "sha512-Bvm6D+NPbGMQOcxvS1zUl8H7DWlywSXsphAeOnVeiZLQ+0J6Is8T7SrjGTH29KtYkiY9vld8ZnpV3G2EPbom+w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.2.tgz",
-      "integrity": "sha512-SWsr8zEUk82KSqquIMgZEg2GE5mCSfr9sE/thDROkX6pb3QQWPp8Vw8zOq2GyxZ2t0XoSIUlvHDkrf5Gmf7x3Q==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.16.4.tgz",
+      "integrity": "sha512-i5d64MlnYBO9EkCOGe5vPR/EeDwjnKOGGdd7zKFhU5y8haKhQZTN2DgVtpODDMxUr4t2K90wTUJg7ilgND6bXw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.2.tgz",
-      "integrity": "sha512-o/HAIrQq0jIxJAhgtIvV5FWviYK4WB0WwV91SLUnsliw1lSAoLsmgEEgRWzDguAFeUEUUoIWXiJrPqU7vGiVkA==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.16.4.tgz",
+      "integrity": "sha512-WZupV1+CdUYehaZqjaFTClJI72fjJEgTXdf4NbW69I9XyvdmztUExBtcI2yIIU6hJtYvtwS6pkTkHJz+k08mAQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.2.tgz",
-      "integrity": "sha512-nwlJ65UY9eGq91cBi6VyDfArUJSKOYt5dJQBq8xyLhvS23qO+4Nr/RreibFHjP6t+5ap2ohZrUJcHv5zk5ju/g==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.16.4.tgz",
+      "integrity": "sha512-ADm/xt86JUnmAfA9mBqFcRp//RVRt1ohGOYF6yL+IFCYqOBNwy5lbEK05xTsEoJq+/tJzg8ICUtS82WinJRuIw==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.16.4.tgz",
+      "integrity": "sha512-tJfJaXPiFAG+Jn3cutp7mCs1ePltuAgRqdDZrzb1aeE3TktWWJ+g7xK9SNlaSUFw6IU4QgOxAY4rA+wZUT5Wfg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.2.tgz",
-      "integrity": "sha512-Pg5TxxO2IVlMj79+c/9G0LREC9SY3HM+pfAwX7zj5/cAuwrbfj2Wv9JbMHIdPCfQpYsI4g9mE+2Bw/3aeSs2rQ==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.16.4.tgz",
+      "integrity": "sha512-7dy1BzQkgYlUTapDTvK997cgi0Orh5Iu7JlZVBy1MBURk7/HSbHkzRnXZa19ozy+wwD8/SlpJnOOckuNZtJR9w==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.2.tgz",
-      "integrity": "sha512-cAOTjGNm84gc6tS02D1EXtG7tDRsVSDTBVXOLbj31DkwfZwgTPYZ6aafSU7rD/4R2a34JOwlF9fQayuTSkoclA==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.16.4.tgz",
+      "integrity": "sha512-zsFwdUw5XLD1gQe0aoU2HVceI6NEW7q7m05wA46eUAyrkeNYExObfRFQcvA6zw8lfRc5BHtan3tBpo+kqEOxmg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.2.tgz",
-      "integrity": "sha512-4RyT6v1kXb7C0fn6zV33rvaX05P0zHoNzaXI/5oFHklfKm602j+N4mn2YvoezQViRLPnxP8M1NaY4s/5kXO5cw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.16.4.tgz",
+      "integrity": "sha512-p8C3NnxXooRdNrdv6dBmRTddEapfESEUflpICDNKXpHvTjRRq1J82CbU5G3XfebIZyI3B0s074JHMWD36qOW6w==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.2.tgz",
-      "integrity": "sha512-KNUH6jC/vRGAKSorySTyc/yRYlCwN/5pnMjXylfBniwtJx5O7X17KG/0efj8XM3TZU7raYRXJFFReOzNmL1n1w==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.16.4.tgz",
+      "integrity": "sha512-Lh/8ckoar4s4Id2foY7jNgitTOUQczwMWNYi+Mjt0eQ9LKhr6sK477REqQkmy8YHY3Ca3A2JJVdXnfb3Rrwkng==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.2.tgz",
-      "integrity": "sha512-xPV4y73IBEXToNPa3h5lbgXOi/v0NcvKxU0xejiFw6DtIYQqOTMhZ2DN18/HrrP0PmiL3rGtRG9gz1QE8vFKXQ==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.16.4.tgz",
+      "integrity": "sha512-1xwwn9ZCQYuqGmulGsTZoKrrn0z2fAur2ujE60QgyDpHmBbXbxLaQiEvzJWDrscRq43c8DnuHx3QorhMTZgisQ==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.2.tgz",
-      "integrity": "sha512-QBhtr07iFGmF9egrPOWyO5wciwgtzKkYPNLVCFZTmr4TWmY0oY2Dm/bmhHjKRwZoGiaKdNcKhFtUMBKvlchH+Q==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.16.4.tgz",
+      "integrity": "sha512-LuOGGKAJ7dfRtxVnO1i3qWc6N9sh0Em/8aZ3CezixSTM+E9Oq3OvTsvC4sm6wWjzpsIlOCnZjdluINKESflJLA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.2.tgz",
-      "integrity": "sha512-8zfsQRQGH23O6qazZSFY5jP5gt4cFvRuKTpuBsC1ZnSWxV8ZKQpPqOZIUtdfMOugCcBvFGRa1pDC/tkf19EgBw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.16.4.tgz",
+      "integrity": "sha512-ch86i7KkJKkLybDP2AtySFTRi5fM3KXp0PnHocHuJMdZwu7BuyIKi35BE9guMlmTpwwBTB3ljHj9IQXnTCD0vA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.2.tgz",
-      "integrity": "sha512-H4s8UjgkPnlChl6JF5empNvFHp77Jx+Wfy2EtmYPe9G22XV+PMuCinZVHurNe8ggtwoaohxARJZbaH/3xjB/FA==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.16.4.tgz",
+      "integrity": "sha512-Ma4PwyLfOWZWayfEsNQzTDBVW8PZ6TUUN1uFTBQbF2Chv/+sjenE86lpiEwj2FiviSmSZ4Ap4MaAfl1ciF4aSA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.2.tgz",
-      "integrity": "sha512-djqpAjm/i8erWYF0K6UY4kRO3X5+T4TypIqw60Q8MTqSBaQNpNXDhxdjpZ3ikgb+wn99svA7jxcXpiyg9MUsdw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.16.4.tgz",
+      "integrity": "sha512-9m/ZDrQsdo/c06uOlP3W9G2ENRVzgzbSXmXHT4hwVaDQhYcRpi9bgBT0FTG9OhESxwK0WjQxYOSfv40cU+T69w==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.2.tgz",
-      "integrity": "sha512-teAqzLT0yTYZa8ZP7zhFKEx4cotS8Tkk5XiqNMJhD4CpaWB1BHARE4Qy+RzwnXvSAYv+Q3jAqCVBS+PS+Yee8Q==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.16.4.tgz",
+      "integrity": "sha512-YunpoOAyGLDseanENHmbFvQSfVL5BxW3k7hhy0eN4rb3gS/ct75dVD0EXOWIqFT/nE8XYW6LP6vz6ctKRi0k9A==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -1370,16 +1427,16 @@
       "dev": true
     },
     "node_modules/@tensorflow/tfjs": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-4.17.0.tgz",
-      "integrity": "sha512-yXRBhpM3frlNA/YaPp6HNk9EfIi8han5RYeQA3R8OCa0Od+AfoG1PUmlxV8fE2wCorlGVyHsgpiJ6M9YZPB56w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-4.18.0.tgz",
+      "integrity": "sha512-MjA2M91wSkTkpFSuyQAuZm+DT9Y7DFu3rsTaO1BjCbf1S7o8DgJPKMmh6hk6uEn6/SBBbZVXPu+ZTQ/SyrP2Pw==",
       "dependencies": {
-        "@tensorflow/tfjs-backend-cpu": "4.17.0",
-        "@tensorflow/tfjs-backend-webgl": "4.17.0",
-        "@tensorflow/tfjs-converter": "4.17.0",
-        "@tensorflow/tfjs-core": "4.17.0",
-        "@tensorflow/tfjs-data": "4.17.0",
-        "@tensorflow/tfjs-layers": "4.17.0",
+        "@tensorflow/tfjs-backend-cpu": "4.18.0",
+        "@tensorflow/tfjs-backend-webgl": "4.18.0",
+        "@tensorflow/tfjs-converter": "4.18.0",
+        "@tensorflow/tfjs-core": "4.18.0",
+        "@tensorflow/tfjs-data": "4.18.0",
+        "@tensorflow/tfjs-layers": "4.18.0",
         "argparse": "^1.0.10",
         "chalk": "^4.1.0",
         "core-js": "3.29.1",
@@ -1391,9 +1448,9 @@
       }
     },
     "node_modules/@tensorflow/tfjs-backend-cpu": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-4.17.0.tgz",
-      "integrity": "sha512-2VSCHnX9qhYTjw9HiVwTBSnRVlntKXeBlK7aSVsmZfHGwWE2faErTtO7bWmqNqw0U7gyznJbVAjlow/p+0RNGw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-4.18.0.tgz",
+      "integrity": "sha512-zk6NyGGsv0mCDnc5xWxLB5Zi8GaHVI2gg7KC0FSw/r5wW9SfA3ZIqUHVZhbIVhNqZSWy6L/+EIJa7l6q1XCkrg==",
       "dependencies": {
         "@types/seedrandom": "^2.4.28",
         "seedrandom": "^3.0.5"
@@ -1402,15 +1459,15 @@
         "yarn": ">= 1.3.2"
       },
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "4.17.0"
+        "@tensorflow/tfjs-core": "4.18.0"
       }
     },
     "node_modules/@tensorflow/tfjs-backend-webgl": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-4.17.0.tgz",
-      "integrity": "sha512-CC5GsGECCd7eYAUaKq0XJ48FjEZdgXZWPxgUYx4djvfUx5fQPp35hCSP9w/k463jllBMbjl2tKRg8u7Ia/LYzg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-4.18.0.tgz",
+      "integrity": "sha512-ZLQ8MnWnIttMDqHepEzPL0Y4HkTePl8+AaYm9AcNnDUK7VF2jn+BXcTHCUOGfiwKu/OMwRc6osDrjxr0cCqNrA==",
       "dependencies": {
-        "@tensorflow/tfjs-backend-cpu": "4.17.0",
+        "@tensorflow/tfjs-backend-cpu": "4.18.0",
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "^2.4.28",
         "seedrandom": "^3.0.5"
@@ -1419,21 +1476,21 @@
         "yarn": ">= 1.3.2"
       },
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "4.17.0"
+        "@tensorflow/tfjs-core": "4.18.0"
       }
     },
     "node_modules/@tensorflow/tfjs-converter": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.17.0.tgz",
-      "integrity": "sha512-qFxIjPfomCuTrYxsFjtKbi3QfdmTTCWo+RvqD64oCMS0sjp7sUDNhJyKDoLx6LZhXlwXpHIVDJctLMRMwet0Zw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.18.0.tgz",
+      "integrity": "sha512-b7utNMvmI986OPaQvDyHoiHKiIyip7ubSjG4KzTcFOWEKTsirtHxRp/6QKY/XSuH3AJK9Switu1/B5QC7xR2Zg==",
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "4.17.0"
+        "@tensorflow/tfjs-core": "4.18.0"
       }
     },
     "node_modules/@tensorflow/tfjs-core": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-4.17.0.tgz",
-      "integrity": "sha512-v9Q5430EnRpyhWNd9LVgXadciKvxLiq+sTrLKRowh26BHyAsams4tZIgX3lFKjB7b90p+FYifVMcqLTTHgjGpQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-4.18.0.tgz",
+      "integrity": "sha512-wjyq+F8AZJjhtr5xUBAON4VrNBXr9Poows/LnRh1K7wS+w41sCk0EQfeo6NfgUZXbHE/jgcqU6+fZDUKt3qRrg==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "@types/offscreencanvas": "~2019.7.0",
@@ -1491,16 +1548,16 @@
       }
     },
     "node_modules/@tensorflow/tfjs-data": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-4.17.0.tgz",
-      "integrity": "sha512-aPKrDFip+gXicWOFALeNT7KKQjRXFkHd/hNe/zs4mCFcIN00hy1PkZ6xkYsgrsdLDQMBSGeS4B4ZM0k5Cs88QA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-4.18.0.tgz",
+      "integrity": "sha512-JGfEwq8a0nEXwwU04/PW7O6kZ3FdqAd6ofMboM9qwGTv47QdeO/G1657sy4N21Q/qiz5qFDbGLhim3Nq9gZm9g==",
       "dependencies": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.6.1",
         "string_decoder": "^1.3.0"
       },
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "4.17.0",
+        "@tensorflow/tfjs-core": "4.18.0",
         "seedrandom": "^3.0.5"
       }
     },
@@ -1543,21 +1600,21 @@
       }
     },
     "node_modules/@tensorflow/tfjs-layers": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.17.0.tgz",
-      "integrity": "sha512-DEE0zRKvf3LJ0EcvG5XouJYOgFGWYAneZ0K1d23969z7LfSyqVmBdLC6BTwdLKuJk3ouUJIKXU1TcpFmjDuh7g==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.18.0.tgz",
+      "integrity": "sha512-9AyxUdvjMDbDOkNzdkMRToJZF/le5ia8X3lVfGRGxzsuyoWDBGlV9V1ICufD+Z8sODXVyu+cgE8kAMtVK4aHFA==",
       "peerDependencies": {
-        "@tensorflow/tfjs-core": "4.17.0"
+        "@tensorflow/tfjs-core": "4.18.0"
       }
     },
     "node_modules/@tensorflow/tfjs-node": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-4.17.0.tgz",
-      "integrity": "sha512-lRe5XPwLzVgpLoxgKWWlqCX9uYybklMai3npgVcvniLQnd6JjkGx+RY2D+7jyQmdo1zJUACfxw3conP88OcBug==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-4.18.0.tgz",
+      "integrity": "sha512-jat7J/K8OEKyO/w20PXN8OBQMwdUMQxfPpNGsyS21lq93dr6g+z4vVH0RT+soPsVX2NvdIrAxHT3RWkinSCikw==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "1.0.9",
-        "@tensorflow/tfjs": "4.17.0",
+        "@tensorflow/tfjs": "4.18.0",
         "adm-zip": "^0.5.2",
         "google-protobuf": "^3.9.2",
         "https-proxy-agent": "^2.2.1",
@@ -2063,8 +2120,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -2179,9 +2235,9 @@
       "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q=="
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -2272,16 +2328,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.6.0.tgz",
-      "integrity": "sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.7.1.tgz",
+      "integrity": "sha512-KwfdWXJBOviaBVhxO3p5TJiLpNuh2iyXyjmWN0f1nU87pwyvfS0EmjC6ukQVYVFJd/K1+0NWGPDXiyEyQorn0Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/type-utils": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/scope-manager": "7.7.1",
+        "@typescript-eslint/type-utils": "7.7.1",
+        "@typescript-eslint/utils": "7.7.1",
+        "@typescript-eslint/visitor-keys": "7.7.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
@@ -2307,15 +2363,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha512-usPMPHcwX3ZoPWnBnhhorc14NJw9J4HpSXQX4urF2TPKG0au0XhJoZyX62fmvdHONUkmyUe74Hzm1//XA+BoYg==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.7.1.tgz",
+      "integrity": "sha512-vmPzBOOtz48F6JAGVS/kZYk4EkXao6iGrD838sp1w3NQQC0W8ry/q641KU4PrG7AKNAf56NOcR8GOpH8l9FPCw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/scope-manager": "7.7.1",
+        "@typescript-eslint/types": "7.7.1",
+        "@typescript-eslint/typescript-estree": "7.7.1",
+        "@typescript-eslint/visitor-keys": "7.7.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2335,13 +2391,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.6.0.tgz",
-      "integrity": "sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.7.1.tgz",
+      "integrity": "sha512-PytBif2SF+9SpEUKynYn5g1RHFddJUcyynGpztX3l/ik7KmZEv19WCMhUBkHXPU9es/VWGD3/zg3wg90+Dh2rA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0"
+        "@typescript-eslint/types": "7.7.1",
+        "@typescript-eslint/visitor-keys": "7.7.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -2352,13 +2408,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.6.0.tgz",
-      "integrity": "sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.7.1.tgz",
+      "integrity": "sha512-ZksJLW3WF7o75zaBPScdW1Gbkwhd/lyeXGf1kQCxJaOeITscoSl0MjynVvCzuV5boUz/3fOI06Lz8La55mu29Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0",
+        "@typescript-eslint/typescript-estree": "7.7.1",
+        "@typescript-eslint/utils": "7.7.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -2379,9 +2435,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.6.0.tgz",
-      "integrity": "sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.7.1.tgz",
+      "integrity": "sha512-AmPmnGW1ZLTpWa+/2omPrPfR7BcbUU4oha5VIbSbS1a1Tv966bklvLNXxp3mrbc+P2j4MNOTfDffNsk4o0c6/w==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -2392,13 +2448,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.6.0.tgz",
-      "integrity": "sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.7.1.tgz",
+      "integrity": "sha512-CXe0JHCXru8Fa36dteXqmH2YxngKJjkQLjxzoj6LYwzZ7qZvgsLSc+eqItCrqIop8Vl2UKoAi0StVWu97FQZIQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/visitor-keys": "7.6.0",
+        "@typescript-eslint/types": "7.7.1",
+        "@typescript-eslint/visitor-keys": "7.7.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2420,17 +2476,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.6.0.tgz",
-      "integrity": "sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.7.1.tgz",
+      "integrity": "sha512-QUvBxPEaBXf41ZBbaidKICgVL8Hin0p6prQDu6bbetWo39BKbWJxRsErOzMNT1rXvTll+J7ChrbmMCXM9rsvOQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.15",
         "@types/semver": "^7.5.8",
-        "@typescript-eslint/scope-manager": "7.6.0",
-        "@typescript-eslint/types": "7.6.0",
-        "@typescript-eslint/typescript-estree": "7.6.0",
+        "@typescript-eslint/scope-manager": "7.7.1",
+        "@typescript-eslint/types": "7.7.1",
+        "@typescript-eslint/typescript-estree": "7.7.1",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -2445,12 +2501,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.6.0.tgz",
-      "integrity": "sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.7.1.tgz",
+      "integrity": "sha512-gBL3Eq25uADw1LQ9kVpf3hRM+DWzs0uZknHYK3hq4jcTPqVCClHGDnB6UUUV2SFeBeA4KWHWbbLqmbGcZ4FYbw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.6.0",
+        "@typescript-eslint/types": "7.7.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -2481,13 +2537,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.5.0.tgz",
-      "integrity": "sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.5.1.tgz",
+      "integrity": "sha512-w3Bn+VUMqku+oWmxvPhTE86uMTbfmBl35aGaIPlwVW7Q89ZREC/icfo2HBsEZ3AAW6YR9lObfZKPEzstw9tJOQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.5.0",
-        "@vitest/utils": "1.5.0",
+        "@vitest/spy": "1.5.1",
+        "@vitest/utils": "1.5.1",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -2564,12 +2620,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.5.0.tgz",
-      "integrity": "sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.5.1.tgz",
+      "integrity": "sha512-mt372zsz0vFR7L1xF/ert4t+teD66oSuXoTyaZbl0eJgilvyzCKP1tJ21gVa8cDklkBOM3DLnkE1ljj/BskyEw==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.5.0",
+        "@vitest/utils": "1.5.1",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -2605,9 +2661,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.5.0.tgz",
-      "integrity": "sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.5.1.tgz",
+      "integrity": "sha512-h/1SGaZYXmjn6hULRBOlqam2z4oTlEe6WwARRzLErAPBqljAs6eX7tfdyN0K+MpipIwSZ5sZsubDWkCPAiVXZQ==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -2619,9 +2675,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.5.0.tgz",
-      "integrity": "sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.5.1.tgz",
+      "integrity": "sha512-vsqczk6uPJjmPLy6AEtqfbFqgLYcGBe9BTY+XL8L6y8vrGOhyE23CJN9P/hPimKXnScbqiZ/r/UtUSOQ2jIDGg==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -2631,9 +2687,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.5.0.tgz",
-      "integrity": "sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.5.1.tgz",
+      "integrity": "sha512-92pE17bBXUxA0Y7goPcvnATMCuq4NQLOmqsG0e2BtzRi7KLwZB5jpiELi/8ybY8IQNWemKjSD5rMoO7xTdv8ug==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -2643,6 +2699,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@vitest/utils/node_modules/loupe": {
@@ -2655,87 +2720,77 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.2.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.2.0-alpha.7.tgz",
-      "integrity": "sha512-igpp+nTkyl8faVzRJMpSCeA4XlBJ5UVSyc/WGyksmUmP10YbfufbcQCFlxEXv2uMBV+a3L4JVCj+Vju+08FOSA==",
+      "version": "2.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.2.0-alpha.10.tgz",
+      "integrity": "sha512-njVJLtpu0zMvDaEk7K5q4BRpOgbyEUljU++un9TfJoJNhxG0z/hWwpwgTRImO42EKvwIxF3XUzeMk+qatAFy7Q==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "2.2.0-alpha.7"
+        "@volar/source-map": "2.2.0-alpha.10"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.2.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.2.0-alpha.7.tgz",
-      "integrity": "sha512-iIZM2EovdEnr6mMwlsnt4ciix4xz7HSGHyUSviRaY5cii5PMXGHeUU9UDeb+xzLCx8kdk3L5J4z+ts50AhkYcg==",
+      "version": "2.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.2.0-alpha.10.tgz",
+      "integrity": "sha512-nrdWApVkP5cksAnDEyy1JD9rKdwOJsEq1B+seWO4vNXmZNcxQQCx4DULLBvKt7AzRUAQiAuw5aQkb9RBaSqdVA==",
       "dev": true,
       "dependencies": {
         "muggle-string": "^0.4.0"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "2.2.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.2.0-alpha.7.tgz",
-      "integrity": "sha512-qy04/hx4UbW1BdPlzaxlH60D4plubcyqdbYM6Y5vZiascZxFowtd6vE39Td9FYzDxwcKgzb/Crvf/ABhdHnuBA==",
+      "version": "2.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.2.0-alpha.10.tgz",
+      "integrity": "sha512-GCa0vTVVdA9ULUsu2Rx7jwsIuyZQPvPVT9o3NrANTbYv+523Ao1gv3glC5vzNSDPM6bUl37r94HbCj7KINQr+g==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "2.2.0-alpha.7",
+        "@volar/language-core": "2.2.0-alpha.10",
         "path-browserify": "^1.0.1"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
-      "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.25.tgz",
+      "integrity": "sha512-Y2pLLopaElgWnMNolgG8w3C5nNUVev80L7hdQ5iIKPtMJvhVpG0zhnBG/g3UajJmZdvW0fktyZTotEHD1Srhbg==",
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.4",
+        "@vue/shared": "3.4.25",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
-    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
-      "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.25.tgz",
+      "integrity": "sha512-Ugz5DusW57+HjllAugLci19NsDK+VyjGvmbB2TXaTcSlQxwL++2PETHx/+Qv6qFwNLzSt7HKepPe4DcTE3pBWg==",
       "dependencies": {
-        "@vue/compiler-core": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-core": "3.4.25",
+        "@vue/shared": "3.4.25"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
-      "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.25.tgz",
+      "integrity": "sha512-m7rryuqzIoQpOBZ18wKyq05IwL6qEpZxFZfRxlNYuIPDqywrXQxgUwLXIvoU72gs6cRdY6wHD0WVZIFE4OEaAQ==",
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/compiler-core": "3.4.21",
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.4",
+        "@vue/compiler-core": "3.4.25",
+        "@vue/compiler-dom": "3.4.25",
+        "@vue/compiler-ssr": "3.4.25",
+        "@vue/shared": "3.4.25",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.7",
-        "postcss": "^8.4.35",
-        "source-map-js": "^1.0.2"
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
-      "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.25.tgz",
+      "integrity": "sha512-H2ohvM/Pf6LelGxDBnfbbXFPyM4NE3hrw0e/EpwuSiYu8c819wx+SVGdJ65p/sFrYDd6OnSDxN1MB2mN07hRSQ==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-dom": "3.4.25",
+        "@vue/shared": "3.4.25"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -2782,12 +2837,12 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.0.12.tgz",
-      "integrity": "sha512-aIStDPt69SHOpiIckGTIIjEz/sXc6ZfCMS5uWYL1AcbcRMhzFCLZscGAVte1+ad+RRFepSpKBjGttyPcgKJ7ww==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.0.14.tgz",
+      "integrity": "sha512-3q8mHSNcGTR7sfp2X6jZdcb4yt8AjBXAfKk0qkZIh7GAJxOnoZ10h5HToZglw4ToFvAnq+xu/Z2FFbglh9Icag==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "2.2.0-alpha.7",
+        "@volar/language-core": "2.2.0-alpha.10",
         "@vue/compiler-dom": "^3.4.0",
         "@vue/shared": "^3.4.0",
         "computeds": "^0.0.1",
@@ -2805,48 +2860,48 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
-      "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.25.tgz",
+      "integrity": "sha512-mKbEtKr1iTxZkAG3vm3BtKHAOhuI4zzsVcN0epDldU/THsrvfXRKzq+lZnjczZGnTdh3ojd86/WrP+u9M51pWQ==",
       "dependencies": {
-        "@vue/shared": "3.4.21"
+        "@vue/shared": "3.4.25"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
-      "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.25.tgz",
+      "integrity": "sha512-3qhsTqbEh8BMH3pXf009epCI5E7bKu28fJLi9O6W+ZGt/6xgSfMuGPqa5HRbUxLoehTNp5uWvzCr60KuiRIL0Q==",
       "dependencies": {
-        "@vue/reactivity": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/reactivity": "3.4.25",
+        "@vue/shared": "3.4.25"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
-      "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.25.tgz",
+      "integrity": "sha512-ode0sj77kuwXwSc+2Yhk8JMHZh1sZp9F/51wdBiz3KGaWltbKtdihlJFhQG4H6AY+A06zzeMLkq6qu8uDSsaoA==",
       "dependencies": {
-        "@vue/runtime-core": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@vue/runtime-core": "3.4.25",
+        "@vue/shared": "3.4.25",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
-      "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.25.tgz",
+      "integrity": "sha512-8VTwq0Zcu3K4dWV0jOwIVINESE/gha3ifYCOKEhxOj6MEl5K5y8J8clQncTcDhKF+9U765nRw4UdUEXvrGhyVQ==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-ssr": "3.4.25",
+        "@vue/shared": "3.4.25"
       },
       "peerDependencies": {
-        "vue": "3.4.21"
+        "vue": "3.4.25"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
-      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g=="
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.25.tgz",
+      "integrity": "sha512-k0yappJ77g2+KNrIaF0FFnzwLvUBLUYr8VOwz+/6vLsmItFp51AcxLL7Ey3iPd7BIRyWPOcqUjMnm7OkahXllA=="
     },
     "node_modules/@vue/test-utils": {
       "version": "2.4.5",
@@ -2870,9 +2925,9 @@
       "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA=="
     },
     "node_modules/@xenova/transformers": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.0.tgz",
-      "integrity": "sha512-usmDut7hwnrc4EqP59cboYqE6C8up63SqMy3E9RjG9nCsOhrsLndEU7DMu+bZ9R+HcAI8jRGabTIxH+B6agBVA==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.1.tgz",
+      "integrity": "sha512-zo702tQAFZXhzeD2GCYUNUqeqkoueOdiSbQWa4s0q7ZE4z8WBIwIsMMPGobpgdqjQ2u0Qulo08wuqVEUrBXjkQ==",
       "dependencies": {
         "@huggingface/jinja": "^0.2.2",
         "onnxruntime-web": "1.14.0",
@@ -3056,9 +3111,9 @@
       }
     },
     "node_modules/apexcharts": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.48.0.tgz",
-      "integrity": "sha512-Lhpj1Ij6lKlrUke8gf+P+SE6uGUn+Pe1TnCJ+zqrY0YMvbqM3LMb1lY+eybbTczUyk0RmMZomlTa2NgX2EUs4Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.49.0.tgz",
+      "integrity": "sha512-2T9HnbQFLCuYRPndQLmh+bEQFoz0meUbvASaGgiSKDuYhWcLBodJtIpKql2aOtMx4B/sHrWW0dm90HsW4+h2PQ==",
       "dependencies": {
         "@yr/monotone-cubic-spline": "^1.0.3",
         "svg.draggable.js": "^2.2.2",
@@ -3148,6 +3203,36 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3228,6 +3313,21 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -3268,20 +3368,20 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.3.tgz",
-      "integrity": "sha512-amG72llr9pstfXOBOHve1WjiuKKAMnebcmMbPWDZ7BCevAoJLpugjuAPRsDINEyjT0a6tbaVx3DctkXIRbLuJw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
+      "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.0.0",
         "bare-path": "^2.0.0",
-        "streamx": "^2.13.0"
+        "bare-stream": "^1.0.0"
       }
     },
     "node_modules/bare-os": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.1.tgz",
-      "integrity": "sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
+      "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
       "optional": true
     },
     "node_modules/bare-path": {
@@ -3291,6 +3391,15 @@
       "optional": true,
       "dependencies": {
         "bare-os": "^2.1.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
+      "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.16.1"
       }
     },
     "node_modules/base64-js": {
@@ -3351,6 +3460,12 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -3441,11 +3556,139 @@
         "node": ">=8"
       }
     },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
+    },
+    "node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.5",
+        "hash-base": "~3.0",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.7",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.23.0",
@@ -3509,6 +3752,18 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3584,9 +3839,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001609",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001609.tgz",
-      "integrity": "sha512-JFPQs34lHKx1B5t1EpQpWH4c+29zIyn/haGsbpfq3suuV9v56enjFt23zqijxGTMwy1p/4H2tjnQMY+p1WoAyA==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "dev": true,
       "funding": [
         {
@@ -3715,6 +3970,16 @@
       ],
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/clean-stack": {
@@ -3990,6 +4255,12 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/confbox": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
+      "integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==",
+      "dev": true
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -4006,10 +4277,22 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -4070,6 +4353,49 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -4087,6 +4413,28 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cssesc": {
@@ -4119,9 +4467,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "13.7.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.3.tgz",
-      "integrity": "sha512-uoecY6FTCAuIEqLUYkTrxamDBjMHTYak/1O7jtgwboHiTnS1NaMOoR08KcTrbRZFCBvYOiS4tEkQRmsV+xcrag==",
+      "version": "13.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.8.1.tgz",
+      "integrity": "sha512-Uk6ovhRbTg6FmXjeZW/TkbRM07KPtvM5gah1BIMp4Y2s+i/NMxgaLw0+PbYTOdw1+egE0FP3mWRiGcRkjjmhzA==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
@@ -4738,6 +5086,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -4779,6 +5137,23 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4807,6 +5182,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/domain-browser": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
+      "integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/domexception": {
@@ -4888,9 +5275,30 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.735",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.735.tgz",
-      "integrity": "sha512-pkYpvwg8VyOTQAeBqZ7jsmpCjko1Qc6We1ZtZCjRyYbT5v4AIUKDy5cQTRotQlSSZmMr8jqpEt6JtOj5k7lR7A==",
+      "version": "1.4.748",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.748.tgz",
+      "integrity": "sha512-VWqjOlPZn70UZ8FTKUOkUvBLeTQ0xpty66qV0yJcAGY2/CthI4xyW9aEozRVtuwv3Kpf5xTesmJUcPwuJmgP4A==",
+      "dev": true
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
+      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -5118,9 +5526,9 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.15.1.tgz",
-      "integrity": "sha512-eLHLWP5Q+I4j2AWepYq0PgFEei9/s5LvjuSqWrxurkg1YZ8ltxdvMNmdSf0drnsNo57CTgYY/NIHHLRSWejR7w==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.15.2.tgz",
+      "integrity": "sha512-CtcFEQTDKyftpI22FVGpx8bkpKyYXBlNge6zSo0pl5/qJvBAnzaD76Vu2AsP16d6mTj478Ldn2mhgrWV+Xr0vQ==",
       "dev": true,
       "dependencies": {
         "globals": "^13.20.0"
@@ -5160,9 +5568,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.24.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.24.1.tgz",
-      "integrity": "sha512-wk3SuwmS1pZdcuJlokGYEi/buDOwD6KltvhIZyOnpJ/378dcQ4zchu9PAMbbLAaydCz1iYc5AozszcOOgZIIOg==",
+      "version": "9.25.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.25.0.tgz",
+      "integrity": "sha512-tDWlx14bVe6Bs+Nnh3IGrD+hb11kf2nukfm6jLsmJIhmiRQ1SUaksvwY9U5MvPB0pcrg0QK0xapQkfITs3RKOA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -5283,13 +5691,9 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -5332,6 +5736,25 @@
       "version": "6.4.7",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
       "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg=="
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "node_modules/execa": {
       "version": "4.1.0",
@@ -5739,6 +6162,15 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -5873,7 +6305,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -6158,10 +6589,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -6181,6 +6650,17 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hosted-git-info": {
@@ -6252,6 +6732,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -6407,6 +6893,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -6422,6 +6924,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ci": {
@@ -6463,6 +6977,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6488,6 +7017,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -6533,6 +7078,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -6563,6 +7123,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isomorphic-timers-promises": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
+      "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/isomorphic-wrtc": {
       "resolved": "isomorphic-wrtc",
@@ -6609,9 +7178,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.12.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.3.tgz",
-      "integrity": "sha512-2RRziagf555owrm9IRVtdKynOBeITiDpuZqIpgwqXShPncPKNiRQoiGsl/T8SQdq+8ugRzH2LqY67irr2y/d+g==",
+      "version": "17.13.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.0.tgz",
+      "integrity": "sha512-9qcrTyoBmFZRNHeVP4edKqIUEgFzq7MHvTNSDuHSqkpOPtiBkgNgcmTSqmiw1kw9tdKaiddvIDv/eCJDxmqWCA==",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -6839,12 +7408,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-    },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -7108,14 +7671,11 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
-      "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -7151,6 +7711,17 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
       "dev": true
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -7200,6 +7771,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -7248,6 +7838,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "9.0.4",
@@ -7505,9 +8107,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.57.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.57.0.tgz",
-      "integrity": "sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==",
+      "version": "3.62.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
+      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7665,14 +8267,15 @@
       }
     },
     "node_modules/node-datachannel": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.6.0.tgz",
-      "integrity": "sha512-4T483RZmPCdMT9eTCHsRHiZM3NRwG+bFwaFohE/H22bs7p5N0uYUFgwTT2ldYWExqOJrgF10j6hE/yyl/78+/g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.8.0.tgz",
+      "integrity": "sha512-05vYthhjESfO5qumWRbqHI1PN71rc19DJjc14ofOLapJrTCnmhx0JYw0G5wcL56b57uHQP9WjEak3+XklrB+Og==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
         "node-domexception": "^2.0.1",
-        "prebuild-install": "^7.0.1"
+        "prebuild-install": "^7.0.1",
+        "rollup": "^4.14.1"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -7739,6 +8342,50 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
+    },
+    "node_modules/node-stdlib-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.2.0.tgz",
+      "integrity": "sha512-VSjFxUhRhkyed8AtLwSCkMrJRfQ3e2lGtG3sP6FEgaLKBBbxM/dLfjRe1+iLhjvyLFW3tBQ8+c0pcOtXGbAZJg==",
+      "dev": true,
+      "dependencies": {
+        "assert": "^2.0.0",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^5.7.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "create-require": "^1.1.1",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^4.22.0",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "isomorphic-timers-promises": "^1.0.1",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.1",
+        "pkg-dir": "^5.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.4.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.1",
+        "url": "^0.11.0",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-stdlib-browser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
     },
     "node_modules/nodemon": {
@@ -7907,9 +8554,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.9.tgz",
+      "integrity": "sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -7933,6 +8580,22 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8052,6 +8715,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true
+    },
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -8112,6 +8781,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8122,6 +8797,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+      "dev": true,
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "hash-base": "~3.0",
+        "pbkdf2": "^3.1.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/parse-json": {
@@ -8254,6 +8946,22 @@
         "through": "~2.3"
       }
     },
+    "node_modules/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8342,21 +9050,42 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
-      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+    "node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
       "dev": true,
       "dependencies": {
-        "jsonc-parser": "^3.2.0",
-        "mlly": "^1.2.0",
-        "pathe": "^1.1.0"
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.1.0.tgz",
+      "integrity": "sha512-/RpmvKdxKf8uILTtoOhAgf30wYbP2Qw+L9p3Rvshx1JZVX+XQNZQFjlbmGHEGIm4CkVPlSn+NXmIM8+9oWQaSA==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.1.7",
+        "mlly": "^1.6.1",
+        "pathe": "^1.1.2"
       }
     },
     "node_modules/platform": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.38",
@@ -8613,6 +9342,12 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8700,6 +9435,26 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -8729,6 +9484,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/querystringify": {
@@ -8765,6 +9529,16 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
     },
@@ -9035,16 +9809,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.2.tgz",
-      "integrity": "sha512-WkeoTWvuBoFjFAhsEOHKRoZ3r9GfTyhh7Vff1zwebEFLEFjT1lG3784xEgKiTa7E+e70vsC81roVL2MP4tgEEQ==",
-      "dev": true,
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.16.4.tgz",
+      "integrity": "sha512-kuaTJSUbz+Wsb2ATGvEknkI12XV40vIiHmLuFlejoo7HtDok/O5eDDD0UpCVY5bBX5U5RYo8wWP83H7ZsqVEnA==",
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -9056,21 +9839,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.2",
-        "@rollup/rollup-android-arm64": "4.14.2",
-        "@rollup/rollup-darwin-arm64": "4.14.2",
-        "@rollup/rollup-darwin-x64": "4.14.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.2",
-        "@rollup/rollup-linux-arm64-musl": "4.14.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.2",
-        "@rollup/rollup-linux-x64-gnu": "4.14.2",
-        "@rollup/rollup-linux-x64-musl": "4.14.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.2",
-        "@rollup/rollup-win32-x64-msvc": "4.14.2",
+        "@rollup/rollup-android-arm-eabi": "4.16.4",
+        "@rollup/rollup-android-arm64": "4.16.4",
+        "@rollup/rollup-darwin-arm64": "4.16.4",
+        "@rollup/rollup-darwin-x64": "4.16.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.16.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.16.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.16.4",
+        "@rollup/rollup-linux-arm64-musl": "4.16.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.16.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.16.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.16.4",
+        "@rollup/rollup-linux-x64-gnu": "4.16.4",
+        "@rollup/rollup-linux-x64-musl": "4.16.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.16.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.16.4",
+        "@rollup/rollup-win32-x64-msvc": "4.16.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -9256,10 +10040,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -9659,6 +10462,16 @@
       "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
       "dev": true
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
     "node_modules/stream-combiner": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -9666,6 +10479,18 @@
       "dev": true,
       "dependencies": {
         "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
       }
     },
     "node_modules/streamx": {
@@ -10135,21 +10960,33 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "node_modules/timers-browserify": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+      "dev": true,
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tiny-case": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
     },
     "node_modules/tinybench": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.6.0.tgz",
-      "integrity": "sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
+      "integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
       "dev": true
     },
     "node_modules/tinypool": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.3.tgz",
-      "integrity": "sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -10362,6 +11199,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10437,14 +11280,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.6.0.tgz",
-      "integrity": "sha512-LY6vH6F1l5jpGqRtU+uK4+mOecIb4Cd4kaz1hAiJrgnNiHUA8wiw8BkJyYS+MRLM69F1QuSKwtGlQqnGl1Rc6w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.7.1.tgz",
+      "integrity": "sha512-ykEBfa3xx3odjZy6GRED4SCPrjo0rgHwstLlEgLX4EMEuv7QeIDSmfV+S6Kk+XkbsYn4BDEcPvsci1X26lRpMQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.6.0",
-        "@typescript-eslint/parser": "7.6.0",
-        "@typescript-eslint/utils": "7.6.0"
+        "@typescript-eslint/eslint-plugin": "7.7.1",
+        "@typescript-eslint/parser": "7.7.1",
+        "@typescript-eslint/utils": "7.7.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -10551,6 +11394,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -10558,6 +11411,40 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true
+    },
+    "node_modules/url/node_modules/qs": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -10621,9 +11508,9 @@
       }
     },
     "node_modules/vee-validate/node_modules/type-fest": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
-      "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.17.0.tgz",
+      "integrity": "sha512-9flrz1zkfLRH3jO3bLflmTxryzKMxVa7841VeMgBaNQGY6vH4RCcpN/sQLB7mQQYh1GZ5utT2deypMuCy4yicw==",
       "engines": {
         "node": ">=16"
       },
@@ -10645,9 +11532,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
-      "integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.10.tgz",
+      "integrity": "sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.20.1",
@@ -10700,9 +11587,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.5.0.tgz",
-      "integrity": "sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.5.1.tgz",
+      "integrity": "sha512-HNpfV7BrAsjkYVNWIcPleJwvJmydJqqJRrRbpoQ/U7QDwJKyEzNa4g5aYg8MjXJyKsk29IUCcMLFRcsEvqUIsA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -10721,17 +11608,33 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vitest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.5.0.tgz",
-      "integrity": "sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==",
+    "node_modules/vite-plugin-node-polyfills": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.21.0.tgz",
+      "integrity": "sha512-Sk4DiKnmxN8E0vhgEhzLudfJQfaT8k4/gJ25xvUPG54KjLJ6HAmDKbr4rzDD/QWEY+Lwg80KE85fGYBQihEPQA==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.5.0",
-        "@vitest/runner": "1.5.0",
-        "@vitest/snapshot": "1.5.0",
-        "@vitest/spy": "1.5.0",
-        "@vitest/utils": "1.5.0",
+        "@rollup/plugin-inject": "^5.0.5",
+        "node-stdlib-browser": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/davidmyersdev"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.5.1.tgz",
+      "integrity": "sha512-3GvBMpoRnUNbZRX1L3mJCv3Ou3NAobb4dM48y8k9ZGwDofePpclTOyO+lqJFKSQpubH1V8tEcAEw/Y3mJKGJQQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "1.5.1",
+        "@vitest/runner": "1.5.1",
+        "@vitest/snapshot": "1.5.1",
+        "@vitest/spy": "1.5.1",
+        "@vitest/utils": "1.5.1",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -10745,7 +11648,7 @@
         "tinybench": "^2.5.1",
         "tinypool": "^0.8.3",
         "vite": "^5.0.0",
-        "vite-node": "1.5.0",
+        "vite-node": "1.5.1",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -10760,8 +11663,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.5.0",
-        "@vitest/ui": "1.5.0",
+        "@vitest/browser": "1.5.1",
+        "@vitest/ui": "1.5.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -10989,16 +11892,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
     "node_modules/vue": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
-      "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.25.tgz",
+      "integrity": "sha512-HWyDqoBHMgav/OKiYA2ZQg+kjfMgLt/T0vg4cbIF7JbXAjDexRf5JRg+PWAfrAkSmTd2I8aPSXtooBFWHB98cg==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-sfc": "3.4.21",
-        "@vue/runtime-dom": "3.4.21",
-        "@vue/server-renderer": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-dom": "3.4.25",
+        "@vue/compiler-sfc": "3.4.25",
+        "@vue/runtime-dom": "3.4.25",
+        "@vue/server-renderer": "3.4.25",
+        "@vue/shared": "3.4.25"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -11010,9 +11919,9 @@
       }
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.0.12.tgz",
-      "integrity": "sha512-iVJugClQdu3ZyF0N4CF3Egi+gWYfnxlIPPGtFXZG29rF3kQIuziP+k7rVGCCHiibIOQ1SlspKjrh+LRYzMpwTA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.0.14.tgz",
+      "integrity": "sha512-DInfgOyXlMyliyqAAD9frK28tTfch0+tMi4qoWJcZlRxUf+NFAtraJBnAsKLep+FOyLMiajkhfyEb3xLK08i7w==",
       "dev": true
     },
     "node_modules/vue-demi": {
@@ -11065,12 +11974,12 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.12.0.tgz",
-      "integrity": "sha512-rUxCKTws8NH3XP98W71GA7btAQdAuO7j6BC5y5s1bTNQYo/CIgZQf+p7d1Zo5bo/3v8TIq9aSUMDjpfgKsC3Uw==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.13.1.tgz",
+      "integrity": "sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==",
       "dependencies": {
-        "@intlify/core-base": "9.12.0",
-        "@intlify/shared": "9.12.0",
+        "@intlify/core-base": "9.13.1",
+        "@intlify/shared": "9.13.1",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -11084,9 +11993,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.0.tgz",
-      "integrity": "sha512-dqUcs8tUeG+ssgWhcPbjHvazML16Oga5w34uCUmsk7i0BcnskoLGwjpa15fqMr2Fa5JgVBrdL2MEgqz6XZ/6IQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.2.tgz",
+      "integrity": "sha512-hKQJ1vDAZ5LVkKEnHhmm1f9pMiWIBNGF5AwU67PdH7TyXCj/a4hTccuUuYCAMgJK6rO/NVYtQIEN3yL8CECa7Q==",
       "dependencies": {
         "@vue/devtools-api": "^6.5.1"
       },
@@ -11119,13 +12028,13 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.0.12.tgz",
-      "integrity": "sha512-thlBBWlPYrNdba535oDdxz7PRUufZgRZRVP5Aql5wBVpGSWSeqou4EzFXeKVoZr59lp9hJROubDVzlhACmcEhg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.0.14.tgz",
+      "integrity": "sha512-DgAO3U1cnCHOUO7yB35LENbkapeRsBZ7Ugq5hGz/QOHny0+1VQN8eSwSBjYbjLVPfvfw6EY7sNPjbuHHUhckcg==",
       "dev": true,
       "dependencies": {
-        "@volar/typescript": "2.2.0-alpha.7",
-        "@vue/language-core": "2.0.12",
+        "@volar/typescript": "2.2.0-alpha.10",
+        "@vue/language-core": "2.0.14",
         "semver": "^7.5.4"
       },
       "bin": {
@@ -11251,6 +12160,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ=="
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.2.2",
@@ -11378,6 +12306,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -11565,6 +12502,7 @@
         "tailwindcss": "3",
         "typescript": "5",
         "vite": "5",
+        "vite-plugin-node-polyfills": "0.21",
         "vitest": "1",
         "vue-tsc": "2"
       }

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,0 @@
-# saved models
-/models/

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -38,36 +38,33 @@ export class TasksAndModels {
     const modelPath = `./models/${discoTask.id}/`
     try {
       const content = await fs.readFile(`${modelPath}/model.json`)
-      console.log("Loading local model for task", discoTask.id)
       return await serialization.model.decode(content)
     } catch {
-      throw new Error("No local model found")
       // unable to read file, continuing
     }
-    // console.log("Instantiating a new model", discoTask.id)
     
-    // if (isTask(task)) {
-    //   throw new Error('saved model not found and no way to get it')
-    // } else {
-    //   model = await task.getModel()
-    // }
-    // console.log('Saving model to disk')
-    // await fs.mkdir(modelPath, { recursive: true })
-    // const encoded = await serialization.model.encode(model)
-    // await fs.writeFile(`${modelPath}/model.json`, encoded)
+    if (isTask(task)) {
+      throw new Error('saved model not found and no way to get it')
+    } else {
+      model = await task.getModel()
+    }
+    console.log('Saving model to disk')
+    await fs.mkdir(modelPath, { recursive: true })
+    const encoded = await serialization.model.encode(model)
+    await fs.writeFile(`${modelPath}/model.json`, encoded)
     
-    // // Check digest if provided
-    // if (discoTask.digest !== undefined) {
-    //   try {
-    //     await this.checkDigest(discoTask.digest, modelPath)
-    //   } catch (e) {
-    //     console.warn('removing model files at', modelPath)
-    //     await fs.rm(modelPath, { recursive: true, force: true })
-    //     throw e
-    //   }
-    // }
+    // Check digest if provided
+    if (discoTask.digest !== undefined) {
+      try {
+        await this.checkDigest(discoTask.digest, modelPath)
+      } catch (e) {
+        console.warn('removing model files at', modelPath)
+        await fs.rm(modelPath, { recursive: true, force: true })
+        throw e
+      }
+    }
     
-    // return model
+    return model
   }
 
   private async checkDigest (digest: Digest, modelPath: Path): Promise<void> {

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -31,40 +31,43 @@ export class TasksAndModels {
   }
 
   // Returns already saved model in priority, then the model from the task definition
-  private async loadModelFromTask (task: Task | TaskProvider): Promise<Model> {
+  private async loadModelFromTask(task: Task | TaskProvider): Promise<Model> {
     const discoTask = isTask(task) ? task : task.getTask()
     let model: Model | undefined
-
+    
     const modelPath = `./models/${discoTask.id}/`
     try {
       const content = await fs.readFile(`${modelPath}/model.json`)
+      console.log("Loading local model for task", discoTask.id)
       return await serialization.model.decode(content)
     } catch {
+      throw new Error("No local model found")
       // unable to read file, continuing
     }
-
-    if (isTask(task)) {
-      throw new Error('saved model not found and no way to get it')
-    } else {
-      model = await task.getModel()
-    }
-
-    await fs.mkdir(modelPath, { recursive: true })
-    const encoded = await serialization.model.encode(model)
-    await fs.writeFile(`${modelPath}/model.json`, encoded)
-
-    // Check digest if provided
-    if (discoTask.digest !== undefined) {
-      try {
-        await this.checkDigest(discoTask.digest, modelPath)
-      } catch (e) {
-        console.warn('removing nodel files at', modelPath)
-        await fs.rm(modelPath, { recursive: true, force: true })
-        throw e
-      }
-    }
-
-    return model
+    // console.log("Instantiating a new model", discoTask.id)
+    
+    // if (isTask(task)) {
+    //   throw new Error('saved model not found and no way to get it')
+    // } else {
+    //   model = await task.getModel()
+    // }
+    // console.log('Saving model to disk')
+    // await fs.mkdir(modelPath, { recursive: true })
+    // const encoded = await serialization.model.encode(model)
+    // await fs.writeFile(`${modelPath}/model.json`, encoded)
+    
+    // // Check digest if provided
+    // if (discoTask.digest !== undefined) {
+    //   try {
+    //     await this.checkDigest(discoTask.digest, modelPath)
+    //   } catch (e) {
+    //     console.warn('removing model files at', modelPath)
+    //     await fs.rm(modelPath, { recursive: true, force: true })
+    //     throw e
+    //   }
+    // }
+    
+    // return model
   }
 
   private async checkDigest (digest: Digest, modelPath: Path): Promise<void> {
@@ -92,7 +95,7 @@ export class TasksAndModels {
       Array.isArray(weightsFiles) &&
       typeof weightsFiles[0] === 'string'
     )) {
-      throw new Error("invalud weights files")
+      throw new Error("invalid weights files")
     }
     await Promise.all(weightsFiles.map(async (file: string) => {
       const data = await fs.readFile(`${modelPath}/${file}`)

--- a/server/src/tasks.ts
+++ b/server/src/tasks.ts
@@ -48,7 +48,7 @@ export class TasksAndModels {
     } else {
       model = await task.getModel()
     }
-    console.log('Saving model to disk')
+
     await fs.mkdir(modelPath, { recursive: true })
     const encoded = await serialization.model.encode(model)
     await fs.writeFile(`${modelPath}/model.json`, encoded)

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -4,7 +4,6 @@ import { runDefaultServer } from './get_server.js'
 
 export async function startServer (): Promise<[Server, URL]> {
   const server = await runDefaultServer()
-
   await new Promise((resolve, reject) => {
     server.once('listening', resolve)
     server.once('error', reject)

--- a/server/tests/e2e/federated.spec.ts
+++ b/server/tests/e2e/federated.spec.ts
@@ -156,7 +156,7 @@ describe("end-to-end federated", function () {
     assert.isTrue(m1.equals(m2))
   });
   it("two lus_covid users reach consensus", async function () {
-    this.timeout(30_000);
+    this.timeout('3m');
 
     const [m1, m2] = await Promise.all([lusCovidUser(), lusCovidUser()]);
     assert.isTrue(m1.equals(m2))

--- a/server/tests/e2e/federated.spec.ts
+++ b/server/tests/e2e/federated.spec.ts
@@ -142,11 +142,11 @@ describe("end-to-end federated", function () {
     return aggregator.model.weights
   }
 
-  it("two cifar10 users reach consensus", async function () {
+  it("three cifar10 users reach consensus", async function () {
     this.timeout(90_000);
 
-    const [m1, m2] = await Promise.all([cifar10user(), cifar10user()]);
-    assert.isTrue(m1.equals(m2))
+    const [m1, m2, m3] = await Promise.all([cifar10user(), cifar10user(), cifar10user()]);
+    assert.isTrue(m1.equals(m2) && m2.equals(m3))
   });
 
   it("two titanic users reach consensus", async function () {

--- a/server/tests/e2e/federated.spec.ts
+++ b/server/tests/e2e/federated.spec.ts
@@ -120,6 +120,7 @@ describe("end-to-end federated", function () {
     const negativeLabels = files[1].map(_ => 'COVID-Negative')
     const labels = positiveLabels.concat(negativeLabels)
     const lusCovidTask = defaultTasks.lusCovid.getTask()
+    lusCovidTask.trainingInformation.epochs = 15
 
     const data = await new NodeImageLoader(lusCovidTask)
       .loadAll(files.flat(), { labels, channels: 3 })

--- a/server/tests/e2e/federated.spec.ts
+++ b/server/tests/e2e/federated.spec.ts
@@ -138,7 +138,7 @@ describe("end-to-end federated", function () {
       throw new Error('model was not set')
     }
     const validationLogs = logs.last()?.epochs.last()?.validation
-    expect(validationLogs?.accuracy).to.be.greaterThan(0.8)
+    expect(validationLogs?.accuracy).to.be.greaterThan(0.6)
     return aggregator.model.weights
   }
 

--- a/server/tests/e2e/federated.spec.ts
+++ b/server/tests/e2e/federated.spec.ts
@@ -24,8 +24,10 @@ describe("end-to-end federated", function () {
     server?.close();
   });
 
+  const DATASET_DIR = '../datasets/'
+
   async function cifar10user (): Promise<WeightsContainer> {
-    const dir = '../datasets/CIFAR10/'
+    const dir = DATASET_DIR + 'CIFAR10/'
     const files = (await fs.readdir(dir)).map((file) => path.join(dir, file))
     const labels = Range(0, 24).map((label) => (label % 10).toString()).toArray()
 
@@ -47,7 +49,7 @@ describe("end-to-end federated", function () {
   }
 
   async function titanicUser (): Promise<WeightsContainer> {
-    const files = ['../datasets/titanic_train.csv']
+    const files = [DATASET_DIR + 'titanic_train.csv']
 
     const titanicTask = defaultTasks.titanic.getTask()
     titanicTask.trainingInformation.epochs = 5
@@ -87,8 +89,8 @@ describe("end-to-end federated", function () {
     task.trainingInformation.epochs = 2
     const loader = new NodeTextLoader(task)
     const dataSplit: data.DataSplit = {
-      train: await data.TextData.init((await loader.load('../datasets/wikitext/wiki.train.tokens')), task),
-      validation: await data.TextData.init(await loader.load('../datasets/wikitext/wiki.valid.tokens'), task)
+      train: await data.TextData.init((await loader.load(DATASET_DIR + 'wikitext/wiki.train.tokens')), task),
+      validation: await data.TextData.init(await loader.load(DATASET_DIR + 'wikitext/wiki.valid.tokens'), task)
     }
 
     const aggregator = new aggregators.MeanAggregator()
@@ -106,18 +108,58 @@ describe("end-to-end federated", function () {
     );
   }
 
+  async function lusCovidUser (): Promise<WeightsContainer> {
+    const dir = DATASET_DIR + 'lus_covid/'
+    const files = await Promise.all(['COVID+/', 'COVID-/'].map(async (subdir: string) => {
+      return (await fs.readdir(dir + subdir))
+        .map((file: string) => dir + subdir + file)
+        .filter((path: string) => path.endsWith('.png'))
+    }))
+
+    const positiveLabels = files[0].map(_ => 'COVID-Positive')
+    const negativeLabels = files[1].map(_ => 'COVID-Negative')
+    const labels = positiveLabels.concat(negativeLabels)
+    const lusCovidTask = defaultTasks.lusCovid.getTask()
+
+    const data = await new NodeImageLoader(lusCovidTask)
+      .loadAll(files.flat(), { labels, channels: 3 })
+
+    const aggregator = new aggregators.MeanAggregator()
+    const client = new clients.federated.FederatedClient(url, lusCovidTask, aggregator)
+    const disco = new Disco(lusCovidTask, { scheme: 'federated', client })
+
+    let logs = List<RoundLogs>()
+    for await (const round of disco.fit(data)) {
+      logs = logs.push(round)
+    }
+    await disco.close()
+
+    if (aggregator.model === undefined) {
+      throw new Error('model was not set')
+    }
+    const validationLogs = logs.last()?.epochs.last()?.validation
+    expect(validationLogs?.accuracy).to.be.greaterThan(0.8)
+    return aggregator.model.weights
+  }
+
   it("two cifar10 users reach consensus", async function () {
     this.timeout(90_000);
 
     const [m1, m2] = await Promise.all([cifar10user(), cifar10user()]);
-    assert.isTrue(m1.equals(m2));
+    assert.isTrue(m1.equals(m2))
   });
 
   it("two titanic users reach consensus", async function () {
     this.timeout(30_000);
 
     const [m1, m2] = await Promise.all([titanicUser(), titanicUser()]);
-    assert.isTrue(m1.equals(m2));
+    assert.isTrue(m1.equals(m2))
+  });
+  it("two lus_covid users reach consensus", async function () {
+    this.timeout(30_000);
+
+    const [m1, m2] = await Promise.all([lusCovidUser(), lusCovidUser()]);
+    assert.isTrue(m1.equals(m2))
   });
 
   it("trains wikitext", async function () {

--- a/server/tests/validator.spec.ts
+++ b/server/tests/validator.spec.ts
@@ -37,7 +37,10 @@ describe('validator', function () {
     const files: string[][] = ['child/', 'adult/']
       .map((subdir: string) => fs.readdirSync(dir + subdir)
         .map((file: string) => dir + subdir + file))
-    const labels = files.flatMap((files, index) => Array<string>(files.length).fill(`${index}`))
+    // const labels = files.flatMap((files, index) => Array<string>(files.length).fill(`${index}`))
+    const youngLabels = files[0].map(_ => 'child')
+    const oldLabels = files[1].map(_ => 'adult')
+    const labels = youngLabels.concat(oldLabels)
 
     const data = (await new NodeImageLoader(simplefaceMock)
       .loadAll(files.flat(), { labels })).train

--- a/server/tests/validator.spec.ts
+++ b/server/tests/validator.spec.ts
@@ -61,7 +61,7 @@ describe('validator', function () {
       validator.accuracy > 0.3,
       `Expected random weight init accuracy greater than 0.3 but got ${validator.accuracy}`
     )
-  }).timeout(1000)
+  }).timeout(5_000)
 
   it('can read and predict randomly on titanic', async () => {
     const titanicTask = defaultTasks.titanic.getTask()

--- a/server/tests/validator.spec.ts
+++ b/server/tests/validator.spec.ts
@@ -2,27 +2,12 @@ import { assert } from 'chai'
 import fs from 'fs'
 import type { Server } from 'node:http'
 
-import type { Task, data } from '@epfml/discojs-core'
-import { Validator, ConsoleLogger, EmptyMemory, client as clients, aggregator, defaultTasks } from '@epfml/discojs-core'
+import {
+  Validator, ConsoleLogger, EmptyMemory, client as clients,
+  aggregator, defaultTasks, data
+} from '@epfml/discojs-core'
 import { NodeImageLoader, NodeTabularLoader } from '@epfml/discojs-node'
 import { startServer } from '../src/index.js'
-
-const simplefaceMock: Task = {
-  id: 'simple_face',
-  displayInformation: {},
-  trainingInformation: {
-    modelID: 'simple_face-model',
-    epochs: 1,
-    batchSize: 4,
-    roundDuration: 1,
-    validationSplit: 0,
-    scheme: 'federated',
-    dataType: 'image',
-    IMAGE_H: 200,
-    IMAGE_W: 200,
-    LABEL_LIST: ['child', 'adult']
-  }
-}
 
 describe('validator', function () {
   this.timeout(10_000)
@@ -32,28 +17,37 @@ describe('validator', function () {
   beforeEach(async () => { [server, url] = await startServer() })
   afterEach(() => { server?.close() })
 
-  it('simple_face validator', async () => {
+  it('can read and predict randomly on simple_face', async () => {
+    // Load the data
     const dir = '../datasets/simple_face/'
-    const files: string[][] = ['child/', 'adult/']
-      .map((subdir: string) => fs.readdirSync(dir + subdir)
-        .map((file: string) => dir + subdir + file))
-    // const labels = files.flatMap((files, index) => Array<string>(files.length).fill(`${index}`))
-    const youngLabels = files[0].map(_ => 'child')
-    const oldLabels = files[1].map(_ => 'adult')
-    const labels = youngLabels.concat(oldLabels)
+    const files: string[][] = ['child/', 'adult/'].map((subdir: string) => {
+      return fs.readdirSync(dir + subdir)
+        .map((file: string) => dir + subdir + file)
+        .filter((path: string) => path.endsWith('.png'))
+    })
+    
+    const childLabels = files[0].map(_ => 'child')
+    const adultLabels = files[1].map(_ => 'adult')
+    const labels = childLabels.concat(adultLabels)
 
-    const data = (await new NodeImageLoader(simplefaceMock)
-      .loadAll(files.flat(), { labels })).train
+    const simplefaceTask = defaultTasks.simpleFace.getTask()
+
+    const data = (await new NodeImageLoader(simplefaceTask)
+      .loadAll(files.flat(), { labels, channels: undefined })).train
+    
+    // Init a validator instance
     const meanAggregator = new aggregator.MeanAggregator()
-    const client = new clients.Local(url, simplefaceMock, meanAggregator)
+    const client = new clients.Local(url, simplefaceTask, meanAggregator)
     meanAggregator.setModel(await client.getLatestModel())
     const validator = new Validator(
-      simplefaceMock,
+      simplefaceTask,
       new ConsoleLogger(),
       new EmptyMemory(),
       undefined,
       client
     )
+
+    // Read data and predict with an untrained model
     await validator.assess(data)
     const size = data.size ?? -1
     if (size === -1) {
@@ -67,10 +61,9 @@ describe('validator', function () {
       validator.accuracy > 0.3,
       `Expected random weight init accuracy greater than 0.3 but got ${validator.accuracy}`
     )
-    console.table(validator.confusionMatrix)
-  }).timeout(15_000)
+  }).timeout(1000)
 
-  it('titanic validator', async () => {
+  it('can read and predict randomly on titanic', async () => {
     const titanicTask = defaultTasks.titanic.getTask()
     const files = ['../datasets/titanic_train.csv']
     const data: data.Data = (await new NodeTabularLoader(titanicTask, ',').loadAll(files, {
@@ -95,5 +88,53 @@ describe('validator', function () {
       validator.accuracy > 0.3,
       `Expected random weight init accuracy greater than 0.3 but got ${validator.accuracy}`
     )
-  }).timeout(15_000)
+  }).timeout(1000)
+
+  it('can read and predict randomly on lus_covid', async () => {
+    // Load the data
+    const dir = '../datasets/lus_covid/'
+    const files: string[][] = ['COVID+/', 'COVID-/'].map((subdir: string) => {
+      return fs.readdirSync(dir + subdir)
+        .map((file: string) => dir + subdir + file)
+        .filter((path: string) => path.endsWith('.png'))
+    })
+    
+    const positiveLabels = files[0].map(_ => 'COVID-Positive')
+    const negativeLabels = files[1].map(_ => 'COVID-Negative')
+    const labels = positiveLabels.concat(negativeLabels)
+
+    const lusCovidTask = defaultTasks.lusCovid.getTask()
+
+    const data = (await new NodeImageLoader(lusCovidTask)
+      .loadAll(files.flat(), { labels, channels: 3 })).train
+    
+    // Initialize a validator instance
+    const meanAggregator = new aggregator.MeanAggregator()
+    const client = new clients.Local(url, lusCovidTask, meanAggregator)
+    meanAggregator.setModel(await client.getLatestModel())
+
+    const validator = new Validator(
+      lusCovidTask,
+      new ConsoleLogger(),
+      new EmptyMemory(),
+      undefined,
+      client
+    )
+
+    // Assert random initialization metrics
+    await validator.assess(data)
+    const size = data.size ?? -1
+    if (size === -1) {
+      console.log('data.size was undefined')
+    }
+    assert(
+      validator.visitedSamples === data.size,
+      `Expected ${size} visited samples but got ${validator.visitedSamples}`
+    )
+    assert(
+      validator.accuracy > 0.4,
+      `Expected random weight init accuracy greater than 0.4 but got ${validator.accuracy}`
+    )
+  }).timeout(1000)
+
 })

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -46,6 +46,7 @@
     "tailwindcss": "3",
     "typescript": "5",
     "vite": "5",
+    "vite-plugin-node-polyfills": "0.21",
     "vitest": "1",
     "vue-tsc": "2"
   }

--- a/web-client/src/components/training/Trainer.vue
+++ b/web-client/src/components/training/Trainer.vue
@@ -2,17 +2,9 @@
   <div class="space-y-4 md:space-y-8">
     <!-- Train Button -->
     <div class="flex justify-center">
-      <IconCard
-        title-placement="center"
-        class="w-3/5"
-      >
-        <template #title>
-          Control the Training Flow
-        </template>
-        <template
-          v-if="!startedTraining"
-          #content
-        >
+      <IconCard title-placement="center" class="w-3/5">
+        <template #title> Control the Training Flow </template>
+        <template v-if="training === undefined" #content>
           <div class="grid grid-cols-2 gap-8">
             <CustomButton @click="startTraining(false)">
               train alone
@@ -22,14 +14,9 @@
             </CustomButton>
           </div>
         </template>
-        <template
-          v-else
-          #content
-        >
+        <template v-else #content>
           <div class="flex justify-center">
-            <CustomButton @click="pauseTraining()">
-              stop <span v-if="distributedTraining">collaborative training</span><span v-else>training</span>
-            </CustomButton>
+            <CustomButton @click="stopTraining()"> stop training </CustomButton>
           </div>
         </template>
       </IconCard>
@@ -45,141 +32,124 @@
   </div>
 </template>
 
-<script lang="ts">
-import { List } from 'immutable'
-import { mapStores } from 'pinia'
-import { defineComponent } from 'vue'
+<script lang="ts" setup>
+import { List } from "immutable";
+import { ref, computed } from "vue";
 
-import type { RoundLogs, Task } from '@epfml/discojs-core'
-import { data, EmptyMemory, isTask, Disco, Memory, client as clients } from '@epfml/discojs-core'
-import { IndexedDB } from '@epfml/discojs'
+import type { RoundLogs, Task } from "@epfml/discojs-core";
+import {
+  aggregator as aggregators,
+  client as clients,
+  data,
+  EmptyMemory,
+  Disco,
+} from "@epfml/discojs-core";
+import { IndexedDB } from "@epfml/discojs";
 
-import { useMemoryStore } from '@/store/memory'
-// TODO @s314cy: move to discojs-core/src/client/get.ts
-import { getClient } from '@/clients'
-import { useToaster } from '@/composables/toaster'
-import TrainingInformation from '@/components/training/TrainingInformation.vue'
-import CustomButton from '@/components/simple/CustomButton.vue'
-import IconCard from '@/components/containers/IconCard.vue'
+import { CONFIG } from "@/config";
+import { useMemoryStore } from "@/store/memory";
+import { useToaster } from "@/composables/toaster";
+import TrainingInformation from "@/components/training/TrainingInformation.vue";
+import CustomButton from "@/components/simple/CustomButton.vue";
+import IconCard from "@/components/containers/IconCard.vue";
 
-const toaster = useToaster()
+const toaster = useToaster();
+const memoryStore = useMemoryStore();
 
-export default defineComponent({
-  name: 'Trainer',
-  components: {
-    TrainingInformation,
-    CustomButton,
-    IconCard
-  },
-  props: {
-    task: {
-      validator: isTask,
-      default: undefined as Task | undefined
-    },
-    datasetBuilder: data.DatasetBuilder
-  },
-  data (): {
-    distributedTraining: boolean,
-    startedTraining: boolean,
-    logs: List<RoundLogs & { participants: number }>,
-    messages: List<string>,
-    } {
-    return {
-      distributedTraining: false,
-      startedTraining: false,
-      logs: List(),
-      messages: List(),
-    }
-  },
-  computed: {
-    ...mapStores(useMemoryStore),
-    client (): clients.Client {
-      return getClient(this.scheme, this.task)
-    },
-    memory (): Memory {
-      return this.memoryStore.useIndexedDB ? new IndexedDB() : new EmptyMemory()
-    },
-    disco (): Disco {
-      return new Disco(
-        this.task,
-        {
-          logger: {
-            success: (msg: string) => {
-              this.messages = this.messages.push(msg)
-            },
-            error: (msg: string) => {
-              this.messages = this.messages.push(msg)
-            },
-          },
-          memory: this.memory,
-          scheme: this.scheme,
-          client: this.client
-        }
+const props = defineProps<{
+  task: Task;
+  datasetBuilder: data.DatasetBuilder<File>;
+}>();
+
+const training =
+  ref<AsyncGenerator<RoundLogs & { participants: number }, void>>();
+const logs = ref(List<RoundLogs & { participants: number }>());
+const messages = ref(List<string>());
+
+const hasValidationData = computed(
+  () => props.task.trainingInformation.validationSplit > 0,
+);
+
+async function startTraining(distributed: boolean): Promise<void> {
+  let dataset: data.DataSplit;
+  try {
+    dataset = await props.datasetBuilder.build({
+      shuffle: false,
+      validationSplit: props.task.trainingInformation.validationSplit,
+    });
+  } catch (e) {
+    console.error(e);
+    if (
+      e instanceof Error &&
+      e.message.includes(
+        "provided in columnConfigs does not match any of the column names",
       )
-    },
-    scheme (): Task['trainingInformation']['scheme'] {
-      if (this.distributedTraining && this.task.trainingInformation?.scheme !== undefined) {
-        return this.task.trainingInformation?.scheme
-      }
-
-      // default scheme
-      return 'local'
-    },
-    hasValidationData (): boolean {
-      return this.task?.trainingInformation?.validationSplit > 0
-    },
-  },
-  methods: {
-    async startTraining (distributedTraining: boolean): Promise<void> {
-      this.distributedTraining = distributedTraining
-
-      if (this.datasetBuilder === undefined) {
-        throw new Error('no dataset builder')
-      }
-
-      let dataset: data.DataSplit
-      try {
-        dataset = await this.datasetBuilder.build({
-          shuffle: true,
-          validationSplit: this.task.trainingInformation.validationSplit
-        })
-      } catch (e) {
-        console.error(e)
-        if (e instanceof Error && e.message.includes('provided in columnConfigs does not match any of the column names')) {
-          // missing field is specified between two "quotes"
-          const missingFields: String = e.message.split('"')[1].split('"')[0]
-          toaster.error(`The input data is missing the field "${missingFields}"`)
-        } else {
-          toaster.error('Incorrect data format. Please check the expected format at the previous step.')
-        }
-        this.cleanState()
-        return
-      }
-
-      toaster.info('Model training started')
-
-      try {
-        this.startedTraining = true
-        for await (const roundLogs of this.disco.fit(dataset)) {
-          this.logs = this.logs.push(roundLogs)
-        }
-        this.startedTraining = false
-      } catch (e) {
-        toaster.error('An error occurred during training')
-        console.error(e)
-        this.cleanState()
-        return
-      }
-      toaster.success('Training successfully completed')
-    },
-    cleanState (): void {
-      this.distributedTraining = false
-      this.startedTraining = false
-    },
-    async pauseTraining (): Promise<void> {
-      await this.disco.pause()
-      this.startedTraining = false
+    ) {
+      // missing field is specified between two "quotes"
+      const missingFields: String = e.message.split('"')[1].split('"')[0];
+      toaster.error(`The input data is missing the field "${missingFields}"`);
+    } else {
+      toaster.error(
+        "Incorrect data format. Please check the expected format at the previous step.",
+      );
     }
+    return;
   }
-})
+
+  toaster.info("Model training started");
+
+  const scheme = distributed ? props.task.trainingInformation.scheme : "local";
+  const client =
+    scheme === "local"
+      ? new clients.Local(
+          CONFIG.serverUrl,
+          props.task,
+          new aggregators.MeanAggregator(),
+        )
+      : new clients.federated.FederatedClient(
+          CONFIG.serverUrl,
+          props.task,
+          new aggregators.MeanAggregator(),
+        );
+
+  const disco = new Disco(props.task, {
+    logger: {
+      success: (msg: string) => {
+        messages.value = messages.value.push(msg);
+      },
+      error: (msg: string) => {
+        messages.value = messages.value.push(msg);
+      },
+    },
+    memory: memoryStore.useIndexedDB ? new IndexedDB() : new EmptyMemory(),
+    scheme,
+    client,
+  });
+
+  try {
+    training.value = disco.fit(dataset);
+    for await (const roundLogs of training.value)
+      logs.value = logs.value.push(roundLogs);
+
+    if (training.value === undefined) {
+      toaster.success("Training stopped");
+      return;
+    }
+  } catch (e) {
+    toaster.error("An error occurred during training");
+    console.error(e);
+  } finally {
+    training.value = undefined;
+  }
+
+  toaster.success("Training successfully completed");
+}
+
+async function stopTraining(): Promise<void> {
+  const generator = training.value;
+  if (generator === undefined) return;
+
+  training.value = undefined;
+  generator.return();
+}
 </script>

--- a/web-client/src/components/training/Trainer.vue
+++ b/web-client/src/components/training/Trainer.vue
@@ -139,7 +139,10 @@ export default defineComponent({
 
       let dataset: data.DataSplit
       try {
-        dataset = await this.datasetBuilder.build()
+        dataset = await this.datasetBuilder.build({
+          shuffle: true,
+          validationSplit: this.task.trainingInformation.validationSplit
+        })
       } catch (e) {
         console.error(e)
         if (e instanceof Error && e.message.includes('provided in columnConfigs does not match any of the column names')) {

--- a/web-client/src/components/training/Trainer.vue
+++ b/web-client/src/components/training/Trainer.vue
@@ -81,7 +81,7 @@ export default defineComponent({
   data (): {
     distributedTraining: boolean,
     startedTraining: boolean,
-    logs: List<RoundLogs>,
+    logs: List<RoundLogs & { participants: number }>,
     messages: List<string>,
     } {
     return {

--- a/web-client/src/components/training/Trainer.vue
+++ b/web-client/src/components/training/Trainer.vue
@@ -128,6 +128,7 @@ async function startTraining(distributed: boolean): Promise<void> {
 
   try {
     training.value = disco.fit(dataset);
+    logs.value = List<RoundLogs & { participants: number }>();
     for await (const roundLogs of training.value)
       logs.value = logs.value.push(roundLogs);
 

--- a/web-client/src/components/training/Trainer.vue
+++ b/web-client/src/components/training/Trainer.vue
@@ -137,7 +137,7 @@ export default defineComponent({
         throw new Error('no dataset builder')
       }
 
-      let dataset
+      let dataset: data.DataSplit
       try {
         dataset = await this.datasetBuilder.build()
       } catch (e) {
@@ -165,6 +165,7 @@ export default defineComponent({
         toaster.error('An error occurred during training')
         console.error(e)
         this.cleanState()
+        return
       }
       toaster.success('Training successfully completed')
     },

--- a/web-client/src/components/training/TrainingInformation.vue
+++ b/web-client/src/components/training/TrainingInformation.vue
@@ -131,7 +131,7 @@
 
 <script setup lang="ts">
 import { List } from 'immutable'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 // @ts-expect-error waiting for vue3-apexcharts#98
 import ApexChart from "vue3-apexcharts";
 
@@ -145,14 +145,22 @@ import People from '@/assets/svg/People.vue'
 import Contact from '@/assets/svg/Contact.vue'
 
 const props = defineProps<{
-  logs: List<RoundLogs>
+  logs: List<RoundLogs & { participants: number }>
   hasValidationData: boolean // TODO infer from logs
   messages: List<string> // TODO why do we want messages?
 }>()
 
 const options = chartOptions
 
-const participants = ref({ current: 1, average: 1 }) // TODO collect real data
+const participants = computed(() => {
+  const average = props.logs.size > 0
+    ? props.logs.reduce((acc, logs) => acc + logs.participants, 0) / props.logs.size
+    : 0
+  return {
+    current: props.logs.last()?.participants ?? 0,
+    average
+  }
+})
 
 const latestEpoch = computed(() => props.logs.last()?.epochs.last())
 

--- a/web-client/src/components/training/__tests__/TrainingInformation.spec.ts
+++ b/web-client/src/components/training/__tests__/TrainingInformation.spec.ts
@@ -17,7 +17,7 @@ it("shows messages", async () => {
       },
     },
     props: {
-      logs: List<RoundLogs>(),
+      logs: List<RoundLogs & { participants: number }>(),
       messages: List.of<string>("a", "b", "c"),
       hasValidationData: false,
     },

--- a/web-client/src/store/memory.ts
+++ b/web-client/src/store/memory.ts
@@ -7,7 +7,7 @@ import * as tf from '@tensorflow/tfjs'
 import type { ModelInfo, Path } from '@epfml/discojs-core'
 import { ModelType } from '@epfml/discojs-core'
 
-interface ModelMetadata extends ModelInfo {
+export interface ModelMetadata extends ModelInfo {
   date: string
   hours: string
   fileSize: number

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -1,18 +1,25 @@
-import { fileURLToPath, URL } from 'node:url'
+import { fileURLToPath, URL } from "node:url";
 
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import { defineConfig } from "vite";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
+import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   server: { port: 8081 },
-  plugins: [vue()],
+  plugins: [
+    vue(),
+    nodePolyfills({
+      include: ["buffer"],
+      globals: { Buffer: true },
+    }),
+  ],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
       // TODO until simple-peer#883 is fixed
-      'simple-peer': 'simple-peer/simplepeer.min.js',
-    }
+      "simple-peer": "simple-peer/simplepeer.min.js",
+    },
   },
-  cacheDir: '../node_modules/.vite'
-})
+  cacheDir: "../node_modules/.vite",
+});


### PR DESCRIPTION
Bug fixes to set up the LUS COVID demo for next week

- [x] Add test cases lus_covid (image_loader, validator, end to end training)
- [x] Fix node image_loader default channel error (default to 1 while it should be 3)
- [x] Add lus_covid task to CLI
- [x] Fine-tune hyper parameters
- [ ] Image dataset shuffling is done by hand while tfjs already implements it
- [x] Fix label encoding mistake (using tf.oneHot on 'positive' and 'negative' yields the same label for both class)
- [x] "Train Collaboratively" raises an error
- [x] Training loss and other metrics stay constant after the first few epochs
- [x] Model always predicts positive
- [x] ~~Training collaboratively with two web-client results in timeouts (server drop client contributions)~~
    - Addressed by #661 
- [x] ~~UI number of participants doesn't get updated as they join a task~~
    - Addressed by #661 
- [x] web-client training performance stays constant while training via node.js works well

Model used to only predict the majority class (~0.5 accuracy), by normalizing image values from 0-255 to 0-1 the training now yields >0.9 on both training and validation sets