### PR TITLE
docker: freeze node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20
+# waiting for nodejs/docker-node#2081
+FROM node:20.12
 
 COPY package*.json .
 COPY isomorphic-wrtc/package.json isomorphic-wrtc/


### PR DESCRIPTION
we're are currently building of latest LTS nodejs container. look like it's [broken for the moment](https://github.com/nodejs/docker-node/issues/2081). freezing version until upstream move.