### PR TITLE
add auto-release

### DIFF
--- a/.github/workflows/publish-deploy.yml
+++ b/.github/workflows/publish-deploy.yml
@@ -2,6 +2,7 @@ name: publish-deploy
 on:
   push:
     branches: [develop]
+    tags: [v*]
 
 jobs:
   publish-npm:
@@ -18,12 +19,14 @@ jobs:
           scope: "@epfml"
       - run: npm ci
       - run: npm --workspace=discojs{,-node,-web} version prerelease --preid=p`date +%Y%m%d%H%M%S`
+        if: github.ref_type == 'branch'
       - run: npm --workspace=discojs{,-node,-web} run build
       - run: npm --workspace=discojs{,-node,-web} publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build-webapp:
+    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,6 +43,7 @@ jobs:
           path: webapp/dist
   deploy-pages:
     needs: build-webapp
+    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -68,6 +72,9 @@ jobs:
         id: meta
         with:
           images: ghcr.io/epfml/disco
+          tags: |
+            type=semver,pattern={{version}}
+            type=edge
       - uses: docker/build-push-action@v5
         id: build
         with:
@@ -77,6 +84,7 @@ jobs:
 
   deploy-server:
     needs: [publish-github-container]
+    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,23 +1,46 @@
+# Releases
+
+This automation happens via [a workflow of our CI](../.github/workflows/publish-deploy.yml).
+
+## Normal development
+
+Every merge to the default branch (`develop`) releases
+a patch version of the NPM packages (`discojs`, `discojs-node` & `discojs-web`).
+
+It will also create a
+[container image](<https://en.wikipedia.org/wiki/Containerization_(computing)>)
+using the repo's [Dockerfile](https://docs.docker.com/reference/dockerfile/)
+which gets pushed to [GitHub Packages](https://docs.github.com/en/packages)
+under the [`edge`](https://github.com/epfml/disco/pkgs/container/disco/edge) tag.
+
+The webapp is first built using a classic `npm -ws run build`
+which gets deployed to GitHub Pages, with a
+[custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site).
+
+## Release
+
+When tagging a commit with a "v" prefix, more is happening.
+
+- NPM packages get released without a patch postfix
+- a container is built for that version and gets released under that tag,
+  minus the "v" prefix
+
+When you want to do a release, be sure that the commit that you're tagging
+is the one changing version number in the various "package.json".
+
+If you want to add release notes, take a look in
+[the dedicated GitHub page](https://github.com/epfml/disco/releases)
+after pushing the tag.
+
 # Deployment
 
-We are maintaining two services, the [webapp](https://discolab.ai/) and the [server](https://disco-zbkj3i466a-oa.a.run.app/).
-Both are automatically deployed when pushing to the default branch (`develop`) via [a workflow of our CI](../.github/workflows/publish-deploy.yml).
+We are maintaining two services, the [webapp](https://discolab.ai/)
+and the [server](https://disco-zbkj3i466a-oa.a.run.app/).
 
-## webapp
+The server is using the previously built container deployed on
+[Google Cloud via Cloud Run](https://cloud.google.com/run).
 
-It is first built using a classic `npm -ws run build`.
-Then is gets deployed to GitHub Pages,
-with a [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site).
-
-## server
-
-First, a [container image](<https://en.wikipedia.org/wiki/Containerization_(computing)>) is built
-using the repo's [Dockerfile](https://docs.docker.com/reference/dockerfile/).
-It gets pushed to [GitHub Packages](https://docs.github.com/en/packages).
-
-It is then deployed to [Google Cloud via Cloud Run](https://cloud.google.com/run).
-
-### Google Cloud specifics
+## Google Cloud specifics
 
 The GitHub Action runner is authenticated via a
 [Direct Workload Identity Federation](https://github.com/google-github-actions/auth?tab=readme-ov-file#preferred-direct-workload-identity-federation)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12380,7 +12380,6 @@
       }
     },
     "server": {
-      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@epfml/discojs-node": "*",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "server",
   "private": true,
-  "version": "2.1.1",
   "type": "module",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
tried out releasing v2.2.0 & v2.2.1 and it seems to be working.
* container image published with tag 2.2.0 & 2.2.1, "develop" image is now called edge
* npm packages have two new version 2.2.0 & 2.2.1
* we can easily [write a new relase](https://github.com/epfml/disco/releases/new) based on theses tag

so when pushing a commit and tag with npm version bumps for main packages, it works. we can release v3.0.0 anytime.