### PR TITLE
dependabot: fix for monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    # support monorepo dependabot/dependabot-core#4993
+    directory: /
+    schedule:
+      interval: weekly
+    versioning-strategy: increase


### PR DESCRIPTION
default dependabot configs [wrongly ask to update non-existing package-lock in workspaces](https://github.com/dependabot/dependabot-core/issues/4993). implementing workaround.