### PR TITLE
Display landing page before server boots

### DIFF
--- a/webapp/cypress/e2e/library.cy.ts
+++ b/webapp/cypress/e2e/library.cy.ts
@@ -93,6 +93,8 @@ describe("model library", () => {
 
   it("store trained model", () => {
     setupForTask(defaultTasks.titanic);
+    // Wait for tasks to load
+    cy.visit("/#/list").contains("button", "participate", { timeout: 5000 })
 
     cy.visit("/#/titanic");
     cy.contains("button", "next").click();

--- a/webapp/cypress/e2e/tasks.cy.ts
+++ b/webapp/cypress/e2e/tasks.cy.ts
@@ -8,7 +8,7 @@ describe("tasks page", () => {
       defaultTasks.lusCovid.getTask(),
       defaultTasks.wikitext.getTask(),
     ]);
-    cy.visit("/#/list");
+    cy.visit("/#/list").contains("button", "participate");
 
     // Length 5 = 4 tasks and 1 div for text description
     cy.get('div[id="tasks"]').children().should("have.length", 5);
@@ -18,7 +18,7 @@ describe("tasks page", () => {
     cy.intercept({ hostname: "server", pathname: "tasks" }, [
       defaultTasks.titanic.getTask(),
     ]);
-    cy.visit("/#/list");
+    cy.visit("/#/list").contains("button", "participate");
 
     cy.get(`div[id="titanic"]`).find("button").click();
     cy.url().should("eq", `${Cypress.config().baseUrl}#/titanic`);

--- a/webapp/src/assets/gif/DiscoGIF.vue
+++ b/webapp/src/assets/gif/DiscoGIF.vue
@@ -1,6 +1,6 @@
 <template>
   <img 
-    style="max-height:500px; max-width:500px; height:auto; width:auto;"
+    style="height:100%; width:100%;"
     src="https://storage.googleapis.com/deai-313515.appspot.com/gifs/disco_middle.gif" 
   />
 </template>

--- a/webapp/src/components/App.vue
+++ b/webapp/src/components/App.vue
@@ -1,13 +1,5 @@
 <template>
-  <div v-if="loading">
-    <div class="flex flex-col h-screen w-screen justify-center items-center">
-      <VueSpinner size="50" color="#6096BA"/>
-      <div class="mt-10">
-        <p class="text-disco-blue">Loading DISCO</p>
-      </div>
-    </div>
-  </div>
-  <div v-else>
+  <div>
     <!-- Global container for the screen -->
     <div
       class="
@@ -65,15 +57,11 @@ import { useTasksStore } from '@/store/tasks'
 import { useMemoryStore } from '@/store/memory'
 import BaseLayout from './containers/BaseLayout.vue'
 import SideBar from '@/components/sidebar/SideBar.vue'
-import { VueSpinner } from 'vue3-spinners';
 
 const tasksStore = useTasksStore()
 const memoryStore = useMemoryStore()
 
-const loading = ref(true)
-tasksStore.initTasks()
-  .then(() => { loading.value = false }) // Remove the loading indicator if even if it failed
-  .catch(console.error)
+tasksStore.initTasks().catch(console.error)
 
 onMounted(() => {
   memoryStore.setIndexedDB(!!window.indexedDB)

--- a/webapp/src/components/App.vue
+++ b/webapp/src/components/App.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue'
+import { onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 
 import { useTasksStore } from '@/store/tasks'

--- a/webapp/src/components/home/Home.vue
+++ b/webapp/src/components/home/Home.vue
@@ -15,9 +15,11 @@
       </a>
   </div>
     <!-- Disco logo -->
-    <div class="flex flex-col justify-center mb-8 space-y-4">
-      <DiscoGIF class="mx-auto" />
-      <span class="text-xl text-center text-slate-600">
+    <div class="flex flex-col justify-center items-center mb-8 space-y-4">
+      <div class="md:max-w-md lg:max-w-lg">
+        <DiscoGIF class="mx-auto" />
+      </div>
+      <span class="text-lg md:text-3xl text-center text-slate-600">
         <span class="font-disco text-disco-cyan font-semibold">DIS</span
         >tributed
         <span class="font-disco text-disco-blue font-semibold">CO</span

--- a/webapp/src/components/home/Home.vue
+++ b/webapp/src/components/home/Home.vue
@@ -17,9 +17,9 @@
     <!-- Disco logo -->
     <div class="flex flex-col justify-center items-center mb-8 space-y-4">
       <div class="md:max-w-md lg:max-w-lg">
-        <DiscoGIF class="mx-auto" />
+        <DiscoGIF/>
       </div>
-      <span class="text-lg md:text-3xl text-center text-slate-600">
+      <span class="text-lg md:text-2xl lg:text-3xl text-center text-slate-600">
         <span class="font-disco text-disco-cyan font-semibold">DIS</span
         >tributed
         <span class="font-disco text-disco-blue font-semibold">CO</span

--- a/webapp/src/components/pages/TaskList.vue
+++ b/webapp/src/components/pages/TaskList.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col gap-4">
       <!-- In case no tasks were retrieved, suggest reloading the page -->
       <ButtonsCard
-        v-if="tasks.size === 0"
+        v-if="taskStore.loadingAlreadyFailed"
         :buttons="List.of(['reload page', () => router.go(0)])"
         class="mx-auto"
       >
@@ -37,7 +37,18 @@
           <br/><br/> <b>The data you connect is only used locally and is never uploaded or shared with anyone. Data always stays on your device.</b>
           </template>
         </IconCard>
+        <div 
+          v-if="taskStore.loading"
+          class="my-10 flex flex-col justify-center items-center"
+        >
+          <VueSpinner size="50" color="#6096BA"/>
+          <div class="mt-10 flex flex-col justify-center items-center">
+            <p class="text-disco-blue">Loading <DISCOllaboratives /></p>
+            <p class="text-disco-blue text-xs">This can take a few seconds</p>
+          </div>
+        </div>
         <div
+          v-else
           v-for="task in sortedTasks"
           :id="task.id"
           :key="task.id"
@@ -72,6 +83,7 @@
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
+import { VueSpinner } from 'vue3-spinners';
 
 import { List } from "immutable";
 
@@ -88,7 +100,8 @@ import DISCOllaboratives from '@/components/simple/DISCOllaboratives.vue'
 
 const router = useRouter()
 const trainingStore = useTrainingStore()
-const { tasks } = storeToRefs(useTasksStore())
+const taskStore = useTasksStore()
+const { tasks } = storeToRefs(taskStore)
 
 const sortedTasks = computed(() => [...tasks.value.values()].sort(
   (task1, task2) => task1.displayInformation.taskTitle.localeCompare(task2.displayInformation.taskTitle)

--- a/webapp/src/components/testing/Testing.vue
+++ b/webapp/src/components/testing/Testing.vue
@@ -1,83 +1,93 @@
 <template>
-  <div>
-    <div v-show="validationStore.step === 0">
-      <div class="flex flex-col gap-8">
-        <div v-if="memoryStore.models.size > 0">
-          <IconCard title-placement="center">
-            <template #title>
-              Model Library — <span class="italic">Locally Available and Ready to Test</span>
-            </template>
-            <template #content>
-              Test any model below against a validation dataset.
-              The models listed were downloaded from the remote server.
-              Perhaps you even contributed to their training!
-              Note that these models are currently stored within your browser's memory.
-              <div class="grid gris-cols-1 md:grid-cols-2 lg:grid-cols-3 items-stretch gap-8 mt-8">
-                <div
-                  v-for="[path, metadata] in memoryStore.models"
-                  :key="path"
-                  class="contents"
+  <div v-show="validationStore.step === 0">
+    <div class="flex flex-col gap-8">
+      <div v-if="memoryStore.models.size > 0">
+        <IconCard title-placement="center">
+          <template #title>
+            Model Library — <span class="italic">Locally Available and Ready to Test</span>
+          </template>
+          <template #content>
+            Test any model below against a validation dataset.
+            The models listed were downloaded from the remote server.
+            Perhaps you even contributed to their training!
+            Note that these models are currently stored within your browser's memory.
+            <div class="grid gris-cols-1 md:grid-cols-2 lg:grid-cols-3 items-stretch gap-8 mt-8">
+              <div
+                v-for="[path, metadata] in memoryStore.models"
+                :key="path"
+                class="contents"
+              >
+                <ButtonsCard
+                  :buttons="List.of(
+                    ['test', () => selectModel(path, false)],
+                    ['predict', () => selectModel(path, true)],
+                  )"
+                  class="shadow shadow-disco-cyan"
                 >
-                  <ButtonsCard
-                    :buttons="List.of(
-                      ['test', () => selectModel(path, false)],
-                      ['predict', () => selectModel(path, true)],
-                    )"
-                    class="shadow shadow-disco-cyan"
-                  >
-                    <template #title>
-                      {{ taskTitle(metadata.taskID) }}
-                    </template>
+                  <template #title>
+                    {{ taskTitle(metadata.taskID) }}
+                  </template>
 
-                    <div class="grid grid-cols-2 justify-items-between">
-                      <p class="contents">
-                        <span>Model:</span>
-                        <span>
-                          {{ metadata.name.slice(0, 20) }}
-                          <span v-if="metadata.version !== undefined && metadata.version !== 0">
-                            ({{ metadata.version }})
-                          </span>
+                  <div class="grid grid-cols-2 justify-items-between">
+                    <p class="contents">
+                      <span>Model:</span>
+                      <span>
+                        {{ metadata.name.slice(0, 20) }}
+                        <span v-if="metadata.version !== undefined && metadata.version !== 0">
+                          ({{ metadata.version }})
                         </span>
-                      </p>
-                      <p class="contents">
-                        <span>Date:</span>
-                        <span>{{ metadata.date }} at {{ metadata.hours }}</span>
-                      </p>
-                      <p class="contents">
-                        <span>Size:</span><span>{{ metadata.fileSize }} kB</span>
-                      </p>
-                      <p class="contents">
-                        <span>Type:</span><span>{{ metadata.type === 'saved' ? 'Saved' : 'Cached' }}</span>
-                      </p>
-                    </div>
-                  </ButtonsCard>
-                </div>
+                      </span>
+                    </p>
+                    <p class="contents">
+                      <span>Date:</span>
+                      <span>{{ metadata.date }} at {{ metadata.hours }}</span>
+                    </p>
+                    <p class="contents">
+                      <span>Size:</span><span>{{ metadata.fileSize }} kB</span>
+                    </p>
+                    <p class="contents">
+                      <span>Type:</span><span>{{ metadata.type === 'saved' ? 'Saved' : 'Cached' }}</span>
+                    </p>
+                  </div>
+                </ButtonsCard>
               </div>
-            </template>
-          </IconCard>
-        </div>
-        <div v-else>
-          <IconCard>
-            <template #title>
-              Empty Model Library
-            </template>
-            <template #content>
-              Disco failed to find any model stored locally. Please go to the 
-              <RouterLink
-                class="underline text-blue-400"
-                to="/list"
-              >training page</RouterLink>
-              or directly download a model below, from the Disco repository.
-            </template>
-          </IconCard>
-        </div>
-        <div v-if="federatedTasks.size > 0">
-          <IconCard title-placement="center">
-            <template #title>
-              <DISCO />
-              Model Repository — <span class="italic">Download and Test</span>
-            </template>
-            <template #content>
+            </div>
+          </template>
+        </IconCard>
+      </div>
+      <div v-else>
+        <IconCard>
+          <template #title>
+            Empty Model Library
+          </template>
+          <template #content>
+            Disco failed to find any model stored locally. Please go to the 
+            <RouterLink
+              class="underline text-blue-400"
+              to="/list"
+            >training page</RouterLink>
+            or directly download a model below, from the Disco repository.
+          </template>
+        </IconCard>
+      </div>
+      <div>
+        <IconCard title-placement="center">
+          <template #title>
+            <DISCO />
+            Model Repository — <span class="italic">Download and Test</span>
+          </template>
+          <template #content>
+            <div 
+              v-if="tasksStore.loading"
+              class="my-10 flex flex-col justify-center items-center"
+            >
+              <VueSpinner size="50" color="#6096BA"/>
+              <div class="mt-10 flex flex-col justify-center items-center">
+                <p class="text-disco-blue">Loading <DISCOllaboratives/></p>
+                <p class="text-disco-blue text-xs">This can take a few seconds</p>
+              </div>
+            </div>
+            <div v-else-if="federatedTasks.size > 0">
               Select any model below to download it. For federated tasks only.
               The models listed are not currently stored in your browser's memory,
               but are available and downloadable from the remote Disco server.
@@ -99,59 +109,52 @@
                   </ButtonsCard>
                 </div>
               </div>
-            </template>
-          </IconCard>
-        </div>
-        <div v-else>
-          <IconCard>
-            <template #title>
-              No Remote Models
-            </template>
-            <template #content>
-              Disco failed to fetch any model from the remote server. Is the Disco server running?
-            </template>
-          </IconCard>
-        </div>
+            </div>
+          <div v-else>
+            A problem occurred while fetching <DISCOllaboratives/>
+          </div>
+          </template>
+        </IconCard>
       </div>
     </div>
-    <div v-if="currentTask !== undefined">
-      <!-- Information specific to the validation panel -->
-      <IconCard
-        v-if="!validationStore.isOnlyPrediction"
-        v-show="validationStore.step === 1"
-        class="mb-4 md:mb-8"
-      >
-        <template #title>
-          Model Validation
-        </template>
-        <template #content>
-          It is very important that your model is tested against <b class="uppercase">unseen data</b>.
-          As such, please ensure your dataset of choice was not used during the training phase of your model.
-        </template>
-      </IconCard>
-      <!-- Language model prompting is currently unavailable   -->
-      <div 
-        v-if="currentTask.trainingInformation.dataType === 'text' && validationStore.isOnlyPrediction"
-        v-show="validationStore.step !== 0"
-      >
-        <div class="flex justify-center items-center mb-4">
-          <span class="shrink-0 py-4 px-4 bg-orange-100 rounded-md">
-            <p class="text-slate-600 text-xs">Prompting a language model will be available soon!</p>
-          </span>
-        </div>
+  </div>
+  <div v-if="currentTask !== undefined">
+    <!-- Information specific to the validation panel -->
+    <IconCard
+      v-if="!validationStore.isOnlyPrediction"
+      v-show="validationStore.step === 1"
+      class="mb-4 md:mb-8"
+    >
+      <template #title>
+        Model Validation
+      </template>
+      <template #content>
+        It is very important that your model is tested against <b class="uppercase">unseen data</b>.
+        As such, please ensure your dataset of choice was not used during the training phase of your model.
+      </template>
+    </IconCard>
+    <!-- Language model prompting is currently unavailable   -->
+    <div 
+      v-if="currentTask.trainingInformation.dataType === 'text' && validationStore.isOnlyPrediction"
+      v-show="validationStore.step !== 0"
+    >
+      <div class="flex justify-center items-center mb-4">
+        <span class="shrink-0 py-4 px-4 bg-orange-100 rounded-md">
+          <p class="text-slate-600 text-xs">Prompting a language model will be available soon!</p>
+        </span>
       </div>
-      <KeepAlive>
-        <component
-          :is="currentComponent[0]"
-          v-if="currentComponent !== undefined"
-          :key="validationStore.model + currentComponent[1]"
-          :task="currentTask"
-          :dataset-builder="datasetBuilder"
-          :ground-truth="!validationStore.isOnlyPrediction"
-          :is-only-prediction="validationStore.isOnlyPrediction"
-        />
-      </KeepAlive>
     </div>
+    <KeepAlive>
+      <component
+        :is="currentComponent[0]"
+        v-if="currentComponent !== undefined"
+        :key="validationStore.model + currentComponent[1]"
+        :task="currentTask"
+        :dataset-builder="datasetBuilder"
+        :ground-truth="!validationStore.isOnlyPrediction"
+        :is-only-prediction="validationStore.isOnlyPrediction"
+      />
+    </KeepAlive>
   </div>
 </template>
 <script lang="ts" setup>
@@ -160,6 +163,7 @@ import { watch, computed, shallowRef, onActivated, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { List } from 'immutable'
+import { VueSpinner } from 'vue3-spinners';
 
 import type { Path, Task } from '@epfml/discojs'
 import { EmptyMemory, Memory, data, client as clients, aggregator } from '@epfml/discojs'
@@ -174,6 +178,7 @@ import DISCO from "@/components/simple/DISCO.vue";
 import Tester from '@/components/testing/Tester.vue'
 import ButtonsCard from '@/components/containers/ButtonsCard.vue'
 import IconCard from '@/components/containers/IconCard.vue'
+import DISCOllaboratives from '@/components/simple/DISCOllaboratives.vue'
 import { useToaster } from '@/composables/toaster'
 
 const validationStore = useValidationStore()
@@ -196,7 +201,7 @@ const { step: stepRef, state: stateRef } = storeToRefs(validationStore)
 const currentTask = shallowRef<Task | undefined>(undefined)
 
 const federatedTasks = computed<List<Task>>(() =>
-  tasksStore.tasks.filter((t) => t.trainingInformation.scheme === 'federated').toList())
+  tasksStore.tasks?.filter((t) => t.trainingInformation.scheme === 'federated').toList())
 
 const memory = computed<Memory>(() =>
   memoryStore.useIndexedDB ? new IndexedDB() : new EmptyMemory())
@@ -289,11 +294,14 @@ const selectModel = (path: Path, isOnlyPrediction: boolean): void => {
 }
 
 const taskTitle = (taskID: string): string | undefined => {
-  const titled = tasksStore.tasks.get(taskID)
-  if (titled !== undefined) {
-    return titled.displayInformation.taskTitle
-  } else {
-    throw new Error('Task title not found for task id: ' + taskID)
+  if (!tasksStore.loading && !tasksStore.loadingAlreadyFailed) {
+    const titled = tasksStore.tasks.get(taskID)
+    if (titled !== undefined) {
+      return titled.displayInformation.taskTitle
+    } else {
+      throw new Error('Task title not found for task id: ' + taskID)
+    }
   }
+  return undefined
 }
 </script>

--- a/webapp/src/components/training/Trainer.vue
+++ b/webapp/src/components/training/Trainer.vue
@@ -15,7 +15,13 @@
             <CustomButton @click="startTraining(false)">
               train alone
             </CustomButton>
-            <CustomButton @click="startTraining(true)">
+            <CustomButton 
+              v-tippy="{
+                content: 'Note that if you are the only participant the training will not be collaborative. You can open multiple tabs to emulate different participants by yourself.',
+                placement: 'right'
+              }"
+              @click="startTraining(true)"
+            >
               train collaboratively
             </CustomButton>
           </div>

--- a/webapp/src/store/tasks.ts
+++ b/webapp/src/store/tasks.ts
@@ -13,8 +13,10 @@ export const useTasksStore = defineStore('tasks', () => {
   const trainingStore = useTrainingStore()
 
   const tasks = shallowRef<Map<TaskID, Task>>(Map())
-
-  // Used to not display duplicate toaster messages
+  
+  // used to display loading indicator in the webapp when loading tasks
+  const loading = ref(false)
+  // used to not display duplicate toaster messages
   const loadingAlreadyFailed = ref(false)
 
   function addTask (task: Task): void {
@@ -27,7 +29,10 @@ export const useTasksStore = defineStore('tasks', () => {
 
   async function initTasks (): Promise<void> {
     try {
+      loading.value = true
+      await new Promise((res,_) => setTimeout(res, 7000))
       const tasks = (await fetchTasks(CONFIG.serverUrl)).filter((t: Task) => !TASKS_TO_FILTER_OUT.includes(t.id))
+
       tasks.forEach(addTask)
       loadingAlreadyFailed.value = false
     } catch (e) {
@@ -39,8 +44,10 @@ export const useTasksStore = defineStore('tasks', () => {
         toaster.error('The server is unreachable.\nPlease try again later or reach out on slack.')
         loadingAlreadyFailed.value = true
       }
+    } finally {
+      loading.value = false
     }
   }
 
-  return { tasks, initTasks, addTask }
+  return { tasks, initTasks, addTask, loading, loadingAlreadyFailed }
 })

--- a/webapp/src/store/tasks.ts
+++ b/webapp/src/store/tasks.ts
@@ -30,7 +30,6 @@ export const useTasksStore = defineStore('tasks', () => {
   async function initTasks (): Promise<void> {
     try {
       loading.value = true
-      await new Promise((res,_) => setTimeout(res, 7000))
       const tasks = (await fetchTasks(CONFIG.serverUrl)).filter((t: Task) => !TASKS_TO_FILTER_OUT.includes(t.id))
 
       tasks.forEach(addTask)


### PR DESCRIPTION
* Rather than blocking the website to load until the server booted and pushed the discollaboratives, I'm moving the loading indicator to where the discollaboratives are actually needed: the task list page and the testing page (which list models to download)
![Screenshot 2024-07-23 at 13 36 03](https://github.com/user-attachments/assets/ca6630cb-8f07-4aa7-96c5-88c9ddfc44b1)
![Screenshot 2024-07-23 at 13 36 33](https://github.com/user-attachments/assets/7c8d1aa0-f6e9-45d7-90f6-7856c4658528)
* Make the DISCO GIF responsive (currently larger than the screen on small devices)
* Add a note on the collaborative button to explain how collaborative training behaves if there is a single participant.
![Screenshot 2024-07-23 at 18 21 13](https://github.com/user-attachments/assets/fb765afc-c55c-4c7d-96d6-353b834fabdd)
