### PR TITLE
Add dark mode feature

### DIFF
--- a/webapp/src/assets/svg/MoonIcon.vue
+++ b/webapp/src/assets/svg/MoonIcon.vue
@@ -5,6 +5,7 @@
     stroke="currentColor"
     :class="customClass"
     :viewBox="viewBox"
+    stroke-width="2" 
   >
     <path
       stroke-linecap="round"
@@ -19,7 +20,7 @@ export default {
   name: 'MoonIcon',
   props: {
     customClass: {
-      default: 'w-6 h-6',
+      default: 'bi bi-info-circle w-7 h-7',
       type: String
     },
     viewBox: { default: '0 0 24 24', type: String }

--- a/webapp/src/assets/svg/SunIcon.vue
+++ b/webapp/src/assets/svg/SunIcon.vue
@@ -1,0 +1,27 @@
+<template>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      stroke="currentColor"
+      :class="customClass"
+      :viewBox="viewBox"
+      stroke-width="2" 
+    >
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <path d="M12 12m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" />
+        <path d="M6 6h3.5l2.5 -2.5l2.5 2.5h3.5v3.5l2.5 2.5l-2.5 2.5v3.5h-3.5l-2.5 2.5l-2.5 -2.5h-3.5v-3.5l-2.5 -2.5l2.5 -2.5z" />
+    </svg>
+  </template>
+  <script lang="ts">
+  export default {
+    name: 'SunIcon',
+    props: {
+      customClass: {
+        default: 'bi bi-info-circle w-8 h-8',
+        type: String
+      },
+      viewBox: { default: '0 0 24 24', type: String }
+    }
+  }
+  </script>
+  

--- a/webapp/src/assets/svg/SunIcon.vue
+++ b/webapp/src/assets/svg/SunIcon.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- This SVG came from https://tablericons.com/, a website that provides open source svg -->
     <svg
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
@@ -17,7 +18,7 @@
     name: 'SunIcon',
     props: {
       customClass: {
-        default: 'bi bi-info-circle w-8 h-8',
+        default: 'w-8 h-8',
         type: String
       },
       viewBox: { default: '0 0 24 24', type: String }

--- a/webapp/src/components/App.vue
+++ b/webapp/src/components/App.vue
@@ -18,6 +18,7 @@
           z-20
           flex flex-shrink-0
           bg-white
+          dark:bg-slate-800
           border-r
           md:static
           focus:outline-none

--- a/webapp/src/components/App.vue
+++ b/webapp/src/components/App.vue
@@ -8,6 +8,8 @@
         antialiased
         text-slate-900
         bg-slate-100
+        dark:bg-slate-900
+        dark:text-slate-100
       "
     >
       <!-- Sidebar -->
@@ -20,6 +22,7 @@
           bg-white
           dark:bg-slate-800
           border-r
+          dark:border-slate-900
           md:static
           focus:outline-none
         "

--- a/webapp/src/components/containers/BaseLayout.vue
+++ b/webapp/src/components/containers/BaseLayout.vue
@@ -4,7 +4,7 @@
       <slot />
     </main>
 
-    <footer class="flex items-center p-4 bg-white border-t text-slate-500">
+    <footer class="flex items-center p-4 bg-white dark:bg-slate-800 border-t dark:border-slate-900 text-slate-500 dark:text-slate-300">
       <div class="flex mx-auto space-x-6 items-center">
         <a
           class="fa-brands fa-github fa-xl"

--- a/webapp/src/components/containers/ButtonsCard.vue
+++ b/webapp/src/components/containers/ButtonsCard.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="flex flex-col p-7 gap-4 bg-white rounded-lg transition duration-200 group hover:-translate-y-1 hover:scale-[101%] hover:outline hover:outline-2 hover:outline-disco-cyan hover:cursor-pointer"
+    class="flex flex-col p-7 gap-4 bg-white dark:bg-slate-950 rounded-lg transition duration-200 group hover:-translate-y-1 hover:scale-[101%] hover:outline hover:outline-2 hover:outline-disco-cyan dark:hover:outline-disco-dark-cyan hover:cursor-pointer"
   >
     <div class="flex flex-row">
       <div
-        class="grow text-xl text-disco-blue group-hover:text-disco-cyan"
+        class="grow text-xl text-disco-blue dark:text-disco-light-blue group-hover:text-disco-cyan dark:group-hover:text-disco-light-cyan"
         :class="`text-${titleAlign}`"
       >
         <slot name="title" />
@@ -13,7 +13,7 @@
       <div><slot name="icon" /></div>
     </div>
 
-    <div class="text-slate-500">
+    <div class="text-slate-500 dark:text-slate-200">
       <slot />
     </div>
 

--- a/webapp/src/components/containers/ButtonsCard.vue
+++ b/webapp/src/components/containers/ButtonsCard.vue
@@ -13,7 +13,7 @@
       <div><slot name="icon" /></div>
     </div>
 
-    <div class="text-slate-500 dark:text-slate-200">
+    <div class="text-slate-500 dark:text-slate-300">
       <slot />
     </div>
 

--- a/webapp/src/components/containers/ButtonsCard.vue
+++ b/webapp/src/components/containers/ButtonsCard.vue
@@ -4,7 +4,7 @@
   >
     <div class="flex flex-row">
       <div
-        class="grow text-xl text-disco-blue dark:text-disco-light-blue group-hover:text-disco-cyan dark:group-hover:text-disco-light-cyan"
+        class="grow text-xl text-disco-blue dark:text-slate-300 group-hover:text-disco-cyan dark:group-hover:text-disco-light-cyan"
         :class="`text-${titleAlign}`"
       >
         <slot name="title" />

--- a/webapp/src/components/containers/Card.vue
+++ b/webapp/src/components/containers/Card.vue
@@ -11,7 +11,7 @@
 export default {
   name: 'CardItem',
   props: {
-    customClass: { default: 'bg-white', type: String }
+    customClass: { default: 'bg-white dark:bg-slate-950', type: String }
   }
 }
 </script>

--- a/webapp/src/components/containers/DropdownCard.vue
+++ b/webapp/src/components/containers/DropdownCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="grid grid-cols-1 space-y-8 lg:gap-8 rounded-xl group/super">
-    <div class="col-span-1 bg-white rounded-xl">
+    <div class="col-span-1 bg-white dark:bg-slate-950 rounded-xl">
       <IconCardHeader>
         <template #title>
           <button class="focus:outline-none" @click="toggle">
@@ -16,7 +16,7 @@
         </template>
       </IconCardHeader>
 
-      <div v-show="opened" class="text-sm text-slate-500 p-8 border-t">
+      <div v-show="opened" class="text-sm text-slate-500 dark:text-slate-300 p-8 border-t">
         <slot />
       </div>
     </div>

--- a/webapp/src/components/containers/IconCard.vue
+++ b/webapp/src/components/containers/IconCard.vue
@@ -3,13 +3,13 @@
     class="grid grid-cols-1 space-y-8 lg:gap-8 rounded-xl group/super"
     :class="fillSpace ? 'min-w-full lg:min-w-[42rem]': ''"
     >
-    <div class="col-span-1 bg-white rounded-xl">
+    <div class="col-span-1 bg-white dark:bg-slate-950 rounded-xl">
       <IconCardHeader :title-placement="titlePlacement">
         <template #title> <slot name="title" /> </template>
         <template #icon> <slot name="icon" /> </template>
       </IconCardHeader>
 
-      <div class="text-sm text-slate-500 p-8 border-t">
+      <div class="text-sm text-slate-500 dark:text-slate-200 p-8 border-t">
         <slot />
       </div>
     </div>

--- a/webapp/src/components/containers/IconCardHeader.vue
+++ b/webapp/src/components/containers/IconCardHeader.vue
@@ -1,7 +1,7 @@
 <template>
       <div class="flex items-center justify-between p-4 md:p-6">
         <h4
-          class="flex w-full text-xl text-disco-blue group-hover/super:text-disco-cyan"
+          class="flex w-full text-xl text-disco-blue dark:text-disco-light-blue group-hover/super:text-disco-cyan"
           :class="`justify-${titlePlacement} text-${titlePlacement}`"
         >
           <slot name="title" />

--- a/webapp/src/components/containers/IconCardSmall.vue
+++ b/webapp/src/components/containers/IconCardSmall.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="flex items-center justify-between p-4 bg-white rounded-md"
+    class="flex items-center justify-between p-4 bg-white dark:bg-slate-950 rounded-md"
   >
     <div>
       <h6
-        class="text-xs font-medium leading-none tracking-wider text-gray-500 uppercase"
+        class="text-xs font-medium leading-none tracking-wider text-gray-500 dark:text-gray-300 uppercase"
       >
         {{ header }}
       </h6>

--- a/webapp/src/components/containers/ImageCard.vue
+++ b/webapp/src/components/containers/ImageCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid grid-cols-1 w-full bg-white aspect-square rounded-xl drop-shadow-md hover:drop-shadow-xl transition duration-500 hover:scale-105 opacity-70 hover:opacity-100 shadow hover:shadow-lg"
+    class="grid grid-cols-1 w-full bg-white dark:bg-slate-800 aspect-square rounded-xl drop-shadow-md hover:drop-shadow-xl transition duration-500 hover:scale-105 opacity-70 hover:opacity-100 shadow hover:shadow-lg"
   >
     <div class="grid grid-cols-1 gap-1 text-center content-center p-2 h-16">
       <slot name="title" />

--- a/webapp/src/components/dataset_input/FileSelection.vue
+++ b/webapp/src/components/dataset_input/FileSelection.vue
@@ -1,7 +1,7 @@
 <template>
   <article
     aria-label="File Upload Model"
-    class="h-full flex flex-col bg-white rounded-lg"
+    class="h-full flex flex-col bg-white dark:bg-slate-950 rounded-lg"
     @drop.prevent
     @dragover.prevent
     @dragenter.prevent
@@ -18,12 +18,12 @@
         @dragleave="onDragLeave"
         @drop="async (e: DragEvent) => await dragFiles(e)"
       >
-        <p class="p-4 text-lg text-disco-blue flex-wrap justify-center">
+        <p class="p-4 text-lg text-disco-blue dark:text-disco-light-blue flex-wrap justify-center">
           <span>Drag and drop the {{ fileType }} or</span>
         </p>
         <label class="mb-6">
           <span
-            class="px-4 py-2 min-w-[8rem] text-lg uppercase text-white bg-disco-cyan rounded duration-200 hover:bg-white hover:outline hover:outline-disco-cyan hover:outline-2 hover:text-disco-cyan hover:cursor-pointer"
+            class="px-4 py-2 min-w-[8rem] text-lg uppercase text-white bg-disco-cyan rounded duration-200 hover:bg-white hover:dark:bg-slate-950 hover:outline hover:outline-disco-cyan hover:outline-2 hover:text-disco-cyan hover:cursor-pointer"
           >
             select {{ fileType }}
           </span>

--- a/webapp/src/components/dataset_input/FileSelection.vue
+++ b/webapp/src/components/dataset_input/FileSelection.vue
@@ -57,7 +57,7 @@
         v-if="$slots.default && files === undefined"
         class="flex justify-center mt-5"
       >
-        <p class="text-slate-500 text-sm">
+        <p class="text-slate-500 dark:text-slate-300 text-sm">
           <span><slot /></span>
         </p>
       </div>
@@ -68,7 +68,7 @@
         class="pt-4 flex flex-col items-center pb-5"
       >
         <div
-          class="mb-4 flex justify-center items-center text-center md:text-left sm:text-lg text-disco-blue"
+          class="mb-4 flex justify-center items-center text-center md:text-left sm:text-lg text-disco-blue dark:text-disco-light-cyan"
         >
           <span v-if="multiple"
             >Number of selected files:

--- a/webapp/src/components/home/Home.vue
+++ b/webapp/src/components/home/Home.vue
@@ -19,7 +19,7 @@
       <div class="md:max-w-md lg:max-w-lg">
         <DiscoGIF class="bg-slate-100 rounded-lg pb-16 px-4"/>
       </div>
-      <span class="text-lg md:text-2xl lg:text-3xl text-center text-slate-300">
+      <span class="text-lg md:text-2xl lg:text-3xl text-center text-slate-600 dark:text-slate-300">
         <span class="font-disco text-disco-cyan font-semibold">DIS</span
         >tributed
         <span class="font-disco text-disco-blue font-semibold">CO</span

--- a/webapp/src/components/home/Home.vue
+++ b/webapp/src/components/home/Home.vue
@@ -17,7 +17,7 @@
     <!-- Disco logo -->
     <div class="flex flex-col justify-center items-center mb-8 space-y-4">
       <div class="md:max-w-md lg:max-w-lg">
-        <DiscoGIF class="bg-slate-100 rounded-lg pb-16 px-4"/>
+        <DiscoGIF class="bg-slate-100 rounded-lg pb-8 px-4"/>
       </div>
       <span class="text-lg md:text-2xl lg:text-3xl text-center text-slate-300">
         <span class="font-disco text-disco-cyan font-semibold">DIS</span

--- a/webapp/src/components/home/Home.vue
+++ b/webapp/src/components/home/Home.vue
@@ -17,7 +17,7 @@
     <!-- Disco logo -->
     <div class="flex flex-col justify-center items-center mb-8 space-y-4">
       <div class="md:max-w-md lg:max-w-lg">
-        <DiscoGIF/>
+        <DiscoGIF class="bg-slate-100 rounded-lg pb-16 px-4"/>
       </div>
       <span class="text-lg md:text-2xl lg:text-3xl text-center text-slate-300">
         <span class="font-disco text-disco-cyan font-semibold">DIS</span

--- a/webapp/src/components/home/Home.vue
+++ b/webapp/src/components/home/Home.vue
@@ -9,7 +9,7 @@
         href="https://framaforms.org/disco-feedback-form-1718716636"
         >
         <div class="flex flex-row flex-wrap shrink-0 items-center gap-x-2 justify-end">
-            <p class="text-disco-blue font-bold text-xs hover:underline hover:text-disco-cyan text-end">Give us some feedback</p>
+            <p class="text-disco-blue font-bold text-xs hover:underline hover:text-disco-cyan text-end dark:text-disco-dark-cyan">Give us some feedback</p>
           <FeedbackIcon custom-class="min-w-8 min-h-8 w-8 h-8"/>
         </div>
       </a>

--- a/webapp/src/components/home/Home.vue
+++ b/webapp/src/components/home/Home.vue
@@ -19,7 +19,7 @@
       <div class="md:max-w-md lg:max-w-lg">
         <DiscoGIF/>
       </div>
-      <span class="text-lg md:text-2xl lg:text-3xl text-center text-slate-600">
+      <span class="text-lg md:text-2xl lg:text-3xl text-center text-slate-300">
         <span class="font-disco text-disco-cyan font-semibold">DIS</span
         >tributed
         <span class="font-disco text-disco-blue font-semibold">CO</span

--- a/webapp/src/components/information/Information.vue
+++ b/webapp/src/components/information/Information.vue
@@ -39,7 +39,7 @@
           >
             Decentralized Learning
           </h6>
-          <DecentralizedGIF class="my-md bg-slate-100 rounded-lg border-slate-300 border-4" />
+          <DecentralizedGIF class="bg-slate-100 rounded-lg border-slate-300 border-4" />
           <p class="text-sm py-6 text-center">
             Local model aggregation is coordinated between peers without any server.
             <br/> No data is shared.

--- a/webapp/src/components/information/Information.vue
+++ b/webapp/src/components/information/Information.vue
@@ -20,7 +20,7 @@
           >
             Federated Learning
           </h6>
-          <FederatedGIF class="my-md bg-slate-100 rounded-lg border-slate-300 border-4" />
+          <FederatedGIF class="bg-slate-100 rounded-lg border-slate-300 border-4" />
           <p class="text-sm py-6 text-center">
             The server puts in common local model updates and sends back an aggregated global model. <br/>No data is shared.
           </p>

--- a/webapp/src/components/information/Information.vue
+++ b/webapp/src/components/information/Information.vue
@@ -1,8 +1,8 @@
 <template>
     <!-- Page Content -->
     <Card class="flex flex-col place-content-center p-4 space-y-6 rounded-xl ">
-      <p class="flex flex-wrap justify-center text-2xl text-slate-400 mt-2">
-        <span><span class="font-disco text-disco-cyan uppercase">dis</span><span>tributed</span>&nbsp;</span>
+      <p class="flex flex-wrap justify-center text-2xl text-slate-400 dark:text-slate-600 mt-2">
+        <span><span class="font-disco text-disco-cyan dark:text-disco-light-cyan uppercase">dis</span><span>tributed</span>&nbsp;</span>
         <span><span class="font-disco text-disco-blue uppercase">co</span><span>llaborative learning platform</span></span>
       </p>
       <div class="grid gap-8 p-4 sm:grid-cols-2 text-slate-500 border-t">

--- a/webapp/src/components/information/Information.vue
+++ b/webapp/src/components/information/Information.vue
@@ -1,11 +1,11 @@
 <template>
     <!-- Page Content -->
     <Card class="flex flex-col place-content-center p-4 space-y-6 rounded-xl ">
-      <p class="flex flex-wrap justify-center text-2xl text-slate-400 dark:text-slate-600 mt-2">
+      <p class="flex flex-wrap justify-center text-2xl text-slate-400 dark:text-slate-300 mt-2">
         <span><span class="font-disco text-disco-cyan dark:text-disco-light-cyan uppercase">dis</span><span>tributed</span>&nbsp;</span>
         <span><span class="font-disco text-disco-blue uppercase">co</span><span>llaborative learning platform</span></span>
       </p>
-      <div class="grid gap-8 p-4 sm:grid-cols-2 text-slate-500 border-t">
+      <div class="grid gap-8 p-4 sm:grid-cols-2 text-slate-400 border-t">
         <!-- Federated insight -->
         <div class="flex flex-col items-center">
           <h6

--- a/webapp/src/components/information/Information.vue
+++ b/webapp/src/components/information/Information.vue
@@ -20,7 +20,7 @@
           >
             Federated Learning
           </h6>
-          <FederatedGIF class="my-md" />
+          <FederatedGIF class="my-md bg-slate-100 rounded-lg border-slate-300 border-4" />
           <p class="text-sm py-6 text-center">
             The server puts in common local model updates and sends back an aggregated global model. <br/>No data is shared.
           </p>
@@ -39,7 +39,7 @@
           >
             Decentralized Learning
           </h6>
-          <DecentralizedGIF class="my-md" />
+          <DecentralizedGIF class="my-md bg-slate-100 rounded-lg border-slate-300 border-4" />
           <p class="text-sm py-6 text-center">
             Local model aggregation is coordinated between peers without any server.
             <br/> No data is shared.

--- a/webapp/src/components/progress_bars/InformationBar.vue
+++ b/webapp/src/components/progress_bars/InformationBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mb-4 space-y-4">
-    <div class="flex flex-wrap text-3xl text-slate-600 dark:text-slate-100 justify-center">
+    <div class="flex flex-wrap text-3xl justify-center">
       <DISCO />
     </div>
     <div class="hidden md:inline-block w-full">

--- a/webapp/src/components/progress_bars/InformationBar.vue
+++ b/webapp/src/components/progress_bars/InformationBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mb-4 space-y-4">
-    <div class="flex flex-wrap text-3xl text-slate-600 justify-center">
+    <div class="flex flex-wrap text-3xl text-slate-600 dark:text-slate-100 justify-center">
       <DISCO />
     </div>
     <div class="hidden md:inline-block w-full">

--- a/webapp/src/components/progress_bars/ProgressIcon.vue
+++ b/webapp/src/components/progress_bars/ProgressIcon.vue
@@ -15,7 +15,7 @@
       </div>
       <div
         class="transition duration-400 w-10 h-10 mx-auto rounded-full text-lg text-white flex items-center hover:scale-105 hover:cursor-pointer"
-        :class="(props.active ? 'bg-disco-blue dark:bg-disco-light-blue border-4 border-slate-200 dark:border-slate-600' : 'bg-white dark:bg-slate-800 border-4 border-slate-200 dark:border-slate-600') + (isCurrentStep ? ' bg-orange-300' : '') "
+        :class="(props.active ? 'bg-disco-blue dark:bg-disco-light-blue border-4 border-slate-200 dark:border-slate-600' : 'bg-white dark:bg-slate-800 border-4 border-slate-200 dark:border-slate-600') + (isCurrentStep ? ' bg-orange-300 dark:bg-orange-400' : '') "
       >
         <span
           class="text-center w-full"
@@ -26,7 +26,7 @@
       </div>
     </div>
     <!-- Text -->
-    <div class="text-xs text-center md:text-base text-slate-700">
+    <div class="text-xs text-center md:text-base text-slate-700 dark:text-slate-400">
       <slot name="text" />
     </div>
   </div>

--- a/webapp/src/components/progress_bars/ProgressIcon.vue
+++ b/webapp/src/components/progress_bars/ProgressIcon.vue
@@ -8,18 +8,18 @@
       >
         <div
           class="w-full rounded items-center align-middle align-center flex-1  transition duration-400"
-          :class="props.active ? 'bg-disco-blue' : 'bg-slate-200'" 
+          :class="props.active ? 'bg-disco-blue dark:bg-disco-light-blue' : 'bg-slate-200 dark:bg-slate-600'" 
         >
           <div class="py-1" />
         </div>
       </div>
       <div
         class="transition duration-400 w-10 h-10 mx-auto rounded-full text-lg text-white flex items-center hover:scale-105 hover:cursor-pointer"
-        :class="(props.active ? 'bg-disco-blue border-4 border-slate-200' : 'bg-white border-4 border-slate-200') + (isCurrentStep ? ' bg-orange-300' : '') "
+        :class="(props.active ? 'bg-disco-blue dark:bg-disco-light-blue border-4 border-slate-200 dark:border-slate-600' : 'bg-white dark:bg-slate-800 border-4 border-slate-200 dark:border-slate-600') + (isCurrentStep ? ' bg-orange-300' : '') "
       >
         <span
           class="text-center w-full"
-          :class="props.active ? 'text-white' : 'text-slate-500'"
+          :class="props.active ? 'text-white dark:text-white' : 'text-slate-500 dark:text-slate-200'"
         >
           <slot name="icon" />
         </span>

--- a/webapp/src/components/progress_bars/TrainingBar.vue
+++ b/webapp/src/components/progress_bars/TrainingBar.vue
@@ -4,7 +4,7 @@
       v-if="taskTitle !== undefined && displayTitle"
       class="flex flex-wrap font-disco text-3xl justify-center"
     >
-      <span class="text-disco-blue">{{ taskTitle }}</span>
+      <span class="text-disco-blue dark:text-disco-light-cyan">{{ taskTitle }}</span>
     </div>
     <div
       v-else

--- a/webapp/src/components/progress_bars/TrainingBar.vue
+++ b/webapp/src/components/progress_bars/TrainingBar.vue
@@ -8,7 +8,7 @@
     </div>
     <div
       v-else
-      class="flex flex-wrap text-3xl text-slate-600 justify-center"
+      class="flex flex-wrap text-3xl text-slate-600 dark:text-slate-300 justify-center"
     >
       <DISCOllaboratives />
     </div>

--- a/webapp/src/components/sidebar/SideBar.vue
+++ b/webapp/src/components/sidebar/SideBar.vue
@@ -31,11 +31,22 @@
         <SidebarButton to="/information" text="More on DISCO">
           <InfoIcon />
         </SidebarButton>
+
+        <SidebarButton 
+          to="" 
+          :text="currentTheme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode'" 
+          @click="toggleDarkMode"
+        >
+          
+          <MoonIcon v-if="currentTheme === 'light'"/>
+          <SunIcon v-else/>
+        </SidebarButton>
       </div>
     </nav>
   </div>
 </template>
 <script setup lang="ts">
+import { ref, onMounted } from 'vue';
 import { RouterLink } from "vue-router";
 
 import HomeIcon from "@/assets/svg/HomeIcon.vue";
@@ -46,4 +57,24 @@ import InfoIcon from "@/assets/svg/InfoIcon.vue";
 import DISCO from "@/components/simple/DISCO.vue";
 
 import SidebarButton from "./SidebarButton.vue";
+import MoonIcon from "@/assets/svg/MoonIcon.vue";
+import SunIcon from "@/assets/svg/SunIcon.vue";
+
+const currentTheme = ref(localStorage.getItem('theme') || 'light');
+
+// Apply the initial theme on mount
+onMounted(() => {
+  if (currentTheme.value === 'dark') {
+    document.documentElement.classList.add('dark');
+  }
+});
+// Function to toggle the dark mode
+const toggleDarkMode = () => {
+  const newTheme = currentTheme.value === 'light' ? 'dark' : 'light';
+  document.documentElement.classList.toggle('dark', newTheme === 'dark');
+  localStorage.setItem('theme', newTheme);
+  currentTheme.value = newTheme;
+};
+
+
 </script>

--- a/webapp/src/components/sidebar/SideBar.vue
+++ b/webapp/src/components/sidebar/SideBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- Mini Sidebar (LHS) -->
-    <nav class="flex flex-col flex-shrink-0 h-full sm:px-4 px-2 py-4 border-r">
+    <nav class="flex flex-col flex-shrink-0 h-full sm:px-4 px-2 py-4 border-r dark:border-black">
       <!-- Brand -->
       <div class="hidden sm:flex flex-shrink-0">
         <RouterLink
@@ -37,7 +37,6 @@
           :text="currentTheme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode'" 
           @click="toggleDarkMode"
         >
-          
           <MoonIcon v-if="currentTheme === 'light'"/>
           <SunIcon v-else/>
         </SidebarButton>

--- a/webapp/src/components/sidebar/SidebarButton.vue
+++ b/webapp/src/components/sidebar/SidebarButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-2 text-slate-500">
+  <div class="p-2 text-slate-500 dark:text-slate-200">
     <span class="sr-only"> {{ text }} </span>
     <RouterLink
       :to="to"

--- a/webapp/src/components/simple/CustomButton.vue
+++ b/webapp/src/components/simple/CustomButton.vue
@@ -6,7 +6,7 @@
     text-lg uppercase text-white
     bg-disco-cyan
     rounded duration-200
-    hover:bg-white hover:outline hover:outline-disco-cyan hover:outline-2 hover:text-disco-cyan"
+    hover:bg-white dark:hover:bg-black hover:outline hover:outline-disco-cyan dark:hover:outline-disco-light-cyan hover:outline-2 hover:text-disco-cyan dark:hover:text-disco-light-cyan"
   >
     <slot />
     <!-- Optional description slot -->

--- a/webapp/src/components/task_creation_form/TaskCreationForm.vue
+++ b/webapp/src/components/task_creation_form/TaskCreationForm.vue
@@ -8,7 +8,7 @@
     </div>
 
     <IconCard>
-      <template #title> Create your own <DISCOllaborative/> </template>
+      <template #title><span>Create your own <DISCOllaborative /></span></template>
 
       <div>
         Fill in the fields below to create your own <DISCOllaborative />, and bring a new (arbitrary) ML task into Disco.

--- a/webapp/src/components/task_creation_form/TaskForm.vue
+++ b/webapp/src/components/task_creation_form/TaskForm.vue
@@ -35,6 +35,7 @@
                   class="
                     inline
                     text-slate-600
+                    dark:text-slate-200
                     font-bold
                     md:text-right
                     mb-1

--- a/webapp/src/components/task_creation_form/containers/ArrayContainer.vue
+++ b/webapp/src/components/task_creation_form/containers/ArrayContainer.vue
@@ -25,14 +25,18 @@
             class="
               inline
               bg-gray-100
+              dark:bg-slate-700
               appearance-none
               border-0 border-gray-200
               rounded
               py-2
               px-4
               text-gray-700
+              dark:text-gray-200
               leading-tight
-              focus:outline-none focus:bg-white
+              focus:outline-none
+              focus:bg-white
+              dark:focus:bg-slate-900
             "
           />
           <ErrorMessage
@@ -56,6 +60,7 @@
               rounded
               focus:shadow-outline
               hover:bg-red-100
+              dark:hover:bg-red-900
             "
             @click="remove(idx as unknown as number)"
           >
@@ -98,6 +103,7 @@
         rounded
         focus:shadow-outline
         hover:bg-gray-100
+        dark:hover:bg-gray-800
       "
       @click="push('')"
     >

--- a/webapp/src/components/task_creation_form/containers/ObjectArrayContainer.vue
+++ b/webapp/src/components/task_creation_form/containers/ObjectArrayContainer.vue
@@ -34,16 +34,20 @@
                 class="
                   inline
                   bg-gray-100
+                  dark:bg-slate-700
                   appearance-none
                   border-0 border-gray-200
                   rounded
                   py-2
                   px-4
                   text-gray-700
+                  dark:text-gray-200
                   leading-tight
                   focus:outline-none
                   focus:bg-white
+                  dark:focus:bg-slate-900
                   focus:border-gray-500
+                  dark:focus:border-slate-500
                 "
               />
               <ErrorMessage
@@ -79,6 +83,7 @@
                 rounded
                 focus:shadow-outline
                 hover:bg-red-100
+                dark:hover:bg-red-900
               "
               @click="remove(idx as unknown as any)"
             >
@@ -121,6 +126,7 @@
           rounded
           focus:shadow-outline
           hover:bg-gray-100
+          dark:hover:bg-gray-800
         "
         @click="
           push(

--- a/webapp/src/components/task_creation_form/containers/SelectContainer.vue
+++ b/webapp/src/components/task_creation_form/containers/SelectContainer.vue
@@ -8,8 +8,10 @@
     :multiple="props.field.type === 'select-multiple'"
     class="
       bg-gray-100 rounded-md border p-2 mt-1
+      dark:bg-slate-700 dark:border-slate-400
       block w-full
       text-gray-700
+      dark:text-gray-200
       focus:outline-none focus:border-disco-cyan
     "
   >

--- a/webapp/src/components/task_creation_form/simple/CustomField.vue
+++ b/webapp/src/components/task_creation_form/simple/CustomField.vue
@@ -4,8 +4,10 @@
     :name="props.field.id"
     class="
     bg-gray-100 rounded-md border px-3 py-2 mt-1
+    dark:bg-slate-700 dark:border-slate-400
       block w-full
     text-gray-700
+    dark:text-gray-200
       focus:outline-none focus:border-disco-cyan
     "
     :class="{ 'hover:cursor-not-allowed': !available }"

--- a/webapp/src/components/testing/PredictSteps.vue
+++ b/webapp/src/components/testing/PredictSteps.vue
@@ -54,13 +54,13 @@
       </div>
     </IconCard>
 
-    <div class="p-4 mx-auto lg:w-1/2 h-full bg-white rounded-md">
+    <div class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
       <!-- header -->
-      <h4 class="p-4 border-b text-lg font-semibold text-slate-500">
+      <h4 class="p-4 border-b text-lg font-semibold text-slate-500 dark:text-slate-300">
         Inference metrics
       </h4>
       <!-- stats -->
-      <div class="flex justify-center p-4 font-medium text-slate-500">
+      <div class="flex justify-center p-4 font-medium text-slate-500 dark:text-slate-400">
         <div class="text-center">
           <span class="text-2xl">
             {{ predictions?.results.size ?? 0 }}
@@ -90,7 +90,7 @@
 
       <div
         v-else-if="predictions.type === 'tabular'"
-        class="mx-auto lg:w-3/4 h-full bg-white rounded-md max-h-128 overflow-x-scroll overflow-y-hidden"
+        class="mx-auto lg:w-3/4 h-full bg-white dark:bg-slate-950 rounded-md max-h-128 overflow-x-scroll overflow-y-hidden"
       >
         <TableLayout
           :columns="predictions.labels.input.concat(predictions.labels.output)"

--- a/webapp/src/components/testing/PredictSteps.vue
+++ b/webapp/src/components/testing/PredictSteps.vue
@@ -6,7 +6,7 @@
   >
     <div class="flex justify-center items-center mb-4">
       <span
-        class="shrink-0 py-4 px-4 bg-purple-100 rounded-md flex flex-row gap-x-4 items-center"
+        class="shrink-0 py-4 px-4 bg-purple-100 dark:text-disco-dark-blue rounded-md flex flex-row gap-x-4 items-center"
       >
         <InfoIcon custom-class="min-w-6 min-h-6 w-6 h-6 text-slate-600" />
 

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -50,13 +50,13 @@
     </IconCard>
 
     <!-- display the evaluation metrics -->
-    <div class="p-4 mx-auto lg:w-1/2 h-full bg-white rounded-md">
+    <div class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
       <!-- header -->
-      <h4 class="p-4 border-b text-lg font-semibold text-slate-500">
+      <h4 class="p-4 border-b text-lg font-semibold text-slate-500 dark:text-slate-300">
         Test Accuracy
       </h4>
       <!-- stats -->
-      <div class="grid grid-cols-2 p-4 font-medium text-slate-500">
+      <div class="grid grid-cols-2 p-4 font-medium text-slate-500 dark:text-slate-400">
         <div class="text-center">
           <span class="text-2xl">{{ currentAccuracy }}</span>
           <span class="text-sm">% of test accuracy</span>

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -93,7 +93,7 @@
 
       <div
         v-else-if="tested.type === 'tabular'"
-        class="mx-auto lg:w-3/4 h-full bg-white rounded-md max-h-128 overflow-x-scroll overflow-y-hidden"
+        class="mx-auto lg:w-3/4 h-full bg-white dark:text-slate-950 rounded-md max-h-128 overflow-x-scroll overflow-y-hidden"
       >
         <TableLayout
           :columns="
@@ -110,7 +110,7 @@
       </div>
       <div
         v-else-if="tested.type === 'text'"
-        class="mx-auto lg:w-3/4 h-full bg-white rounded-md max-h-128 overflow-x-scroll overflow-y-hidden"
+        class="mx-auto lg:w-3/4 h-full bg-white dark:text-slate-950 rounded-md max-h-128 overflow-x-scroll overflow-y-hidden"
       >
         <!-- Display nothing for now -->
       </div>

--- a/webapp/src/components/testing/Testing.vue
+++ b/webapp/src/components/testing/Testing.vue
@@ -72,8 +72,9 @@
       <div>
         <IconCard title-placement="center">
           <template #title>
-            <DISCO />
-            Model Repository — <span class="italic">Download and Test</span>
+            <span><DISCO /> Model Repository — <span class="italic">Download and Test</span></span>
+            
+            
           </template>
 
           <div

--- a/webapp/src/components/training/Description.vue
+++ b/webapp/src/components/training/Description.vue
@@ -28,7 +28,7 @@
         :key="section.id"
         class="py-4 first:py-0 last:py-0"
       >
-        <span class="text-slate-600 font-bold text-left">
+        <span class="text-slate-600 dark:text-slate-200 font-bold text-left">
           {{ section.title }}
         </span>
         <div

--- a/webapp/src/components/training/TrainingInformation.vue
+++ b/webapp/src/components/training/TrainingInformation.vue
@@ -258,7 +258,7 @@ const lossSeries = computed(() =>
       },
     ),
 );
-const darkMode = ref(localStorage.getItem("theme") === "dark");
+const darkMode = localStorage.getItem("theme") === "dark";
 console.log(darkMode);
 const commonChartsOptions = {
   chart: {

--- a/webapp/src/components/training/TrainingInformation.vue
+++ b/webapp/src/components/training/TrainingInformation.vue
@@ -60,10 +60,10 @@
       <IconCard>
         <template #title> Training Loss of the Model </template>
 
-        <span class="text-2xl font-medium text-slate-500">
+        <span class="text-2xl font-medium text-slate-500 dark:text-slate-300">
           {{ (lastEpoch?.training.loss ?? 0).toFixed(2) }}
         </span>
-        <span class="text-sm font-medium text-slate-500">
+        <span class="text-sm font-medium text-slate-500 dark:text-slate-400">
           training loss
         </span>
 
@@ -80,10 +80,10 @@
       <IconCard v-if="hasValidationData">
         <template #title> Validation Loss of the Model </template>
 
-        <span class="text-2xl font-medium text-slate-500">
+        <span class="text-2xl font-medium text-slate-500 dark:text-slate-300">
           {{ (lastEpoch?.validation?.loss ?? 0).toFixed(2) }}
         </span>
-        <span class="text-sm font-medium text-slate-500">
+        <span class="text-sm font-medium text-slate-500 dark:text-slate-400">
           validation loss
         </span>
 
@@ -106,10 +106,10 @@
       <IconCard>
         <template #title> Training Accuracy of the Model </template>
 
-        <span class="text-2xl font-medium text-slate-500">
+        <span class="text-2xl font-medium text-slate-500 dark:text-slate-300">
           {{ percent(lastEpoch?.training.accuracy ?? 0) }}
         </span>
-        <span class="text-sm font-medium text-slate-500">
+        <span class="text-sm font-medium text-slate-500 dark:text-slate-400">
           % of training accuracy
         </span>
 
@@ -128,10 +128,10 @@
       <IconCard v-if="hasValidationData">
         <template #title> Validation Accuracy of the Model </template>
 
-        <span class="text-2xl font-medium text-slate-500">
+        <span class="text-2xl font-medium text-slate-500 dark:text-slate-300">
           {{ percent(lastEpoch?.validation?.accuracy ?? 0) }}
         </span>
-        <span class="text-sm font-medium text-slate-500">
+        <span class="text-sm font-medium text-slate-500 dark:text-slate-400">
           % of validation accuracy
         </span>
 
@@ -161,7 +161,7 @@
           >
             <span
               style="white-space: pre-line"
-              class="text-sm text-slate-500"
+              class="text-sm text-slate-500 dark:text-slate-400"
             >
               {{ message }}
             </span>
@@ -174,7 +174,7 @@
 
 <script setup lang="ts">
 import { List } from "immutable";
-import { computed } from "vue";
+import { ref, computed } from "vue";
 import ApexChart from "vue3-apexcharts";
 
 import type { BatchLogs, EpochLogs, RoundLogs } from "@epfml/discojs";
@@ -258,14 +258,15 @@ const lossSeries = computed(() =>
       },
     ),
 );
-
+const darkMode = ref(localStorage.getItem("theme") === "dark");
+console.log(darkMode);
 const commonChartsOptions = {
   chart: {
     toolbar: { show: false },
     zoom: { enabled: false },
   },
   dataLabels: { enabled: false },
-  colors: ["#6096BA"],
+  colors: [ darkMode ? "#cbd5e1" : "#6096BA"],
   fill: {
     colors: ["#E2E8F0"],
     type: "solid",

--- a/webapp/src/components/training/TrainingInformation.vue
+++ b/webapp/src/components/training/TrainingInformation.vue
@@ -259,7 +259,6 @@ const lossSeries = computed(() =>
     ),
 );
 const darkMode = localStorage.getItem("theme") === "dark";
-console.log(darkMode);
 const commonChartsOptions = {
   chart: {
     toolbar: { show: false },

--- a/webapp/src/components/training/TrainingInformation.vue
+++ b/webapp/src/components/training/TrainingInformation.vue
@@ -174,7 +174,7 @@
 
 <script setup lang="ts">
 import { List } from "immutable";
-import { ref, computed } from "vue";
+import { computed } from "vue";
 import ApexChart from "vue3-apexcharts";
 
 import type { BatchLogs, EpochLogs, RoundLogs } from "@epfml/discojs";

--- a/webapp/src/components/training/TrainingInformation.vue
+++ b/webapp/src/components/training/TrainingInformation.vue
@@ -265,24 +265,72 @@ const commonChartsOptions = {
     zoom: { enabled: false },
   },
   dataLabels: { enabled: false },
-  colors: [ darkMode ? "#cbd5e1" : "#6096BA"],
+  colors: [darkMode ? "#cbd5e1" : "#6096BA"],
   fill: {
-    colors: ["#E2E8F0"],
+    colors: [darkMode ? "#1A3A4F" : "#E2E8F0"],
     type: "solid",
     opacity: 0.6,
   },
   stroke: { curve: "smooth" },
   grid: { show: false },
-  xaxis: { labels: { show: false } },
-  legend: { show: false },
+  xaxis: {
+    labels: {
+      show: true,
+      style: {
+        colors: darkMode ? "#ffffff" : "#000000",
+      },
+    },
+    axisBorder: {
+      show: true,
+      colors: darkMode ? "#ffffff" : "#000000",
+    },
+    axisTicks: {
+      show: true,
+      color: darkMode ? "#ffffff" : "#000000",
+    },
+  },
+  yaxis: {
+    labels: {
+      show: true,
+      style: {
+        colors: darkMode ? "#ffffff" : "#000000",
+      },
+    },
+    axisBorder: {
+      show: true,
+      color: darkMode ? "#ffffff" : "#000000",
+    },
+    axisTicks: {
+      show: true,
+      color: darkMode ? "#ffffff" : "#000000",
+    },
+  },
+  legend: {
+    show: true,
+    labels: {
+      colors: darkMode ? "#ffffff" : "#000000",
+    },
+  },
+  tooltip: {
+    theme: darkMode ? 'dark' : 'light',
+    style: {
+      fontSize: '12px',
+      fontFamily: undefined,
+      colors: darkMode ? '#ffffff' : '#000000',
+    },
+  }
 };
 
 const accuracyChartsOptions = {
   ...commonChartsOptions,
   yaxis: {
+    ...commonChartsOptions.yaxis,
     max: 100,
     min: 0,
-    labels: { formatter: (value: number) => value.toFixed(0) },
+    labels: { 
+      ...commonChartsOptions.yaxis.labels,
+      formatter: (value: number) => value.toFixed(0) 
+    },
   },
 };
 
@@ -297,9 +345,13 @@ const lossChartsOptions = computed(() => {
   return {
     ...commonChartsOptions,
     yaxis: {
+      ...commonChartsOptions.yaxis,
       max: yAxisMax,
       min: 0,
-      labels: { formatter: (n: number) => n.toFixed(2) },
+      labels: { 
+        ...commonChartsOptions.yaxis.labels,
+        formatter: (n: number) => n.toFixed(2) 
+      },
     },
   };
 });

--- a/webapp/tailwind.config.ts
+++ b/webapp/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   content: ["./index.html", "./src/**/*.{vue,js,ts,jsx,tsx}"],
+  darkMode: 'class', // Enable dark mode based on a CSS class
   theme: {
     fontFamily: {
       sans: ["cairo", "sans-serif"],
@@ -12,6 +13,8 @@ const config: Config = {
         disco: {
           cyan: "#6096BA",
           blue: "#274C78",
+          'dark-cyan': "#000000",
+          'dark-blue': "#12263A", // you just have to do dark: and then put the class you want to have in dark mode
         },
       },
       spacing: {

--- a/webapp/tailwind.config.ts
+++ b/webapp/tailwind.config.ts
@@ -13,8 +13,10 @@ const config: Config = {
         disco: {
           cyan: "#6096BA",
           blue: "#274C78",
-          'dark-cyan': "#000000",
+          'dark-cyan': "#1F3A4F",
           'dark-blue': "#12263A", // you just have to do dark: and then put the class you want to have in dark mode
+          'light-cyan': "#8AB9D3",
+          'light-blue': "#4A7CA1",
         },
       },
       spacing: {


### PR DESCRIPTION
I added a dark mode feature, adding a dynamic button on the sidebar, and using tailwind dark mode class system.

Here are the previews : 
![image](https://github.com/user-attachments/assets/92fcdd56-ad5a-4dec-b4c2-9cdbc0f8a28e)
![image](https://github.com/user-attachments/assets/c60f2081-d1e0-40c4-b6cf-8e9fbf8bdf24)
![image](https://github.com/user-attachments/assets/5a98a0a5-3e18-4541-a6b1-2aef56eaddc2)
![image](https://github.com/user-attachments/assets/000be123-eabb-44b0-8f99-0b48832e2a6a)
![image](https://github.com/user-attachments/assets/3ead8a3f-80a0-42ec-9073-453b745dd8cd)
![image](https://github.com/user-attachments/assets/d7426dbe-f987-4680-8692-c4a0f4303bbc)
![image](https://github.com/user-attachments/assets/64ace47b-77ff-43fa-808e-cf49f71ca105)

Edit : also added dark theme in the testing, did'nt know they were custom components
![image](https://github.com/user-attachments/assets/f89d4f06-173e-4f78-aeee-efbccc8c1f5f)


What needs to be done to perfect : 
- Polish the colors. I made some decisions about the colors, to keep the blue spirit, and for the moment I am satisfied with the result. However, there are some colors that I didn't change (for example the orange one).
- Rework the gifs and images to not have the white border, which is really ugly in dark mode (that is the number 1 priority)
- Rework the Light logo to have a transparent background

Otherwise I am satisfied about how it turned, it may not be perfect, but it is better than nothing.

I also integrated a new sunIcon, taken from https://tablericons.com/, a really cool website with a lot of open source icons.

this pull request directly respond to the issue #387 