### PR TITLE
Fix and rework GPT-TF.js

### DIFF
--- a/.github/workflows/record-cypress.yml
+++ b/.github/workflows/record-cypress.yml
@@ -1,0 +1,76 @@
+name: record-cypress
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  download-datasets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: true
+      - uses: actions/cache@v4
+        with:
+          path: datasets
+          key: datasets-${{ hashFiles('datasets/**') }}
+      - run: datasets/populate
+
+  build-lib:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm --workspace=discojs run build
+
+  build-lib-web:
+    needs: build-lib
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run --workspace=discojs build
+      - run: npm run --workspace=discojs-web build
+
+  record-test-webapp:
+    needs: [build-lib, build-lib-web, download-datasets]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: true
+      - uses: actions/cache@v4
+        with:
+          path: datasets
+          key: datasets-${{ hashFiles('datasets/**') }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm --workspace={discojs,discojs-web} run build
+      - run: npm --workspace=webapp run test:unit
+      - uses: cypress-io/github-action@v6
+        with:
+          working-directory: webapp
+          install: false
+          start: npm start
+          wait-on: 'http://localhost:8081' # Waits for above
+          # Records to Cypress Cloud
+          # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
+          record: true
+        env:
+          VITE_SERVER_URL: http://server
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,7 @@
     "watch": "nodemon --ext ts --ignore dist --watch ../discojs-node/dist --watch ../server/dist --watch . --exec npm run",
     "start": "npm run build && node dist/cli.js",
     "benchmark_gpt": "npm run build && node dist/benchmark_gpt.js",
+    "train_gpt": "npm run build && node dist/train_gpt.js",
     "build": "tsc",
     "lint": "npx eslint .",
     "test": ": nothing"

--- a/cli/src/benchmark_gpt.ts
+++ b/cli/src/benchmark_gpt.ts
@@ -79,7 +79,7 @@ async function main(args: Required<CLIArguments>): Promise<void> {
     task.trainingInformation.maxSequenceLength = contextLength
     const dataset = loadText('../datasets/wikitext/wiki.train.tokens')
       .map(text => processing.tokenize(tokenizer, text))
-      .unbatch()
+      .flatten()
       .batch(config.blockSize + 1, 1)
 
     const preprocessedDataset = dataset

--- a/cli/src/benchmark_gpt.ts
+++ b/cli/src/benchmark_gpt.ts
@@ -107,9 +107,9 @@ async function main(args: Required<CLIArguments>): Promise<void> {
     
     // Benchmark parameters
     const prompt = 'The game began development in 2010 , carrying over a large portion, The game began development in 2010 , carrying over a large portion, The game began development in 2010 , carrying over a large portion,'
-    const nbNewTokens = 200
+    const maxNewTokens = 200
     const iterations = 10
-    console.log("Generating", nbNewTokens, "new tokens")
+    console.log("Generating", maxNewTokens, "new tokens")
 
     let tokens = List(
       (tokenizer(prompt, { return_tensor: false }) as { input_ids: number[] })
@@ -119,13 +119,13 @@ async function main(args: Required<CLIArguments>): Promise<void> {
     let inferenceTime = 0
     for (let i = 0; i < iterations; i++) {
       const timeStart = performance.now()
-      for (let n = 0; n < nbNewTokens; n++) {
+      for (let n = 0; n < maxNewTokens; n++) {
         const next: number = (await model.predict(List.of(tokens))).first();
-	tokens = tokens.push(next)
+        tokens = tokens.push(next)
       }
       inferenceTime += performance.now() - timeStart
     }
-    console.log(`Inference time: ${(inferenceTime/ nbNewTokens / iterations).toFixed(2)} ms/token`)
+    console.log(`Inference time: ${(inferenceTime/ maxNewTokens / iterations).toFixed(2)} ms/token`)
   }
   await new Promise((resolve, reject) => {
     server.once('close', resolve)

--- a/cli/src/benchmark_gpt.ts
+++ b/cli/src/benchmark_gpt.ts
@@ -69,18 +69,18 @@ async function main(args: Required<CLIArguments>): Promise<void> {
     const config: models.GPTConfig = {
       modelType: modelType as models.GPTConfig['modelType'],
       maxIter: iterationsPerEpoch,
-      blockSize: contextLength,
       lr: 0.0001,
+      contextLength,
     }
 
     // Load the dataset after setting the Task batch size and max sequence length
     // to make sure the dataset is batched and tokenized correctly
     task.trainingInformation.batchSize = batchSize
-    task.trainingInformation.maxSequenceLength = contextLength
+    task.trainingInformation.contextLength = contextLength
     const dataset = loadText('../datasets/wikitext/wiki.train.tokens')
       .map(text => processing.tokenize(tokenizer, text))
       .flatten()
-      .batch(config.blockSize + 1, 1)
+      .batch(config.contextLength + 1, 1)
 
     const preprocessedDataset = dataset
       .map((tokens) => [tokens.pop(), tokens.last()] as [List<number>, number])

--- a/cli/src/benchmark_gpt.ts
+++ b/cli/src/benchmark_gpt.ts
@@ -70,7 +70,6 @@ async function main(args: Required<CLIArguments>): Promise<void> {
       maxIter: iterationsPerEpoch,
       blockSize: contextLength,
       lr: 0.0001,
-      vocabSize: 50258 // default wikitext task uses the gpt2 tokenizer with vocabSize 50258
     }
 
     // Load the dataset after setting the Task batch size and max sequence length

--- a/cli/src/train_gpt.ts
+++ b/cli/src/train_gpt.ts
@@ -1,0 +1,40 @@
+import * as tf from "@tensorflow/tfjs-node"
+import { AutoTokenizer } from "@xenova/transformers";
+import { models, processing } from "@epfml/discojs";
+
+async function main(): Promise<void> { 
+  const data = "Lorem ipsum dolor sit amet, consectetur adipis"
+  const datasetSource = new tf.data.FileDataSource(Buffer.from(data))
+  const textDataset = new tf.data.TextLineDataset(datasetSource)
+
+  const config: models.GPTConfig = {
+    modelType: 'gpt-nano',
+    lr: 0.01,
+    maxIter: 50,
+    evaluateEvery:50,
+    maxEvalBatches: 10,
+    blockSize: 16,
+    vocabSize: 50257,
+    debug: false
+  }
+
+  const tokenizer = await AutoTokenizer.from_pretrained('Xenova/gpt2')
+  const tokenDataset = textDataset.map((text: string) => {
+    const tokens = processing.tokenizeAndLeftPad(text, tokenizer, config.blockSize + 1)
+    const ys = tf.oneHot(tokens.slice(1), tokenizer.model.vocab.length)
+    const xs = tf.tensor(tokens.slice(0, config.blockSize), undefined, 'int32')
+    return {xs, ys}
+  }).repeat().batch(16) as tf.data.Dataset<{ xs: tf.Tensor2D, ys: tf.Tensor3D }>
+  
+  const model = new models.GPT(config)
+  
+  for await (const logs of model.train(tokenDataset, undefined)) {
+    console.log(logs)
+  }
+
+  const generation = await model.generate("Lorem", tokenizer, { maxNewTokens: 10, doSample: false, topk: 5, temperature:0.1 })
+  console.log(generation)
+}
+
+// You can run this example with "npm run run_gpt" from this folder
+main().catch(console.error)

--- a/cli/src/train_gpt.ts
+++ b/cli/src/train_gpt.ts
@@ -13,7 +13,7 @@ async function main(): Promise<void> {
     maxIter: 50,
     evaluateEvery:50,
     maxEvalBatches: 10,
-    blockSize: 16,
+    contextLength: 16,
     seed
   }
 
@@ -22,7 +22,7 @@ async function main(): Promise<void> {
   const tokenDataset = new Dataset([data])
     .map((text: string) => processing.tokenize(tokenizer, text))
     .flatten()
-    .batch(config.blockSize + 1, 1)
+    .batch(config.contextLength + 1, 1)
     .map((tokens) => [tokens.pop(), tokens.last()] as [List<number>, number])
     .repeat()
     .batch(8);

--- a/cli/src/train_gpt.ts
+++ b/cli/src/train_gpt.ts
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
 
   const tokenDataset = new Dataset([data])
     .map((text: string) => processing.tokenize(tokenizer, text))
-    .unbatch()
+    .flatten()
     .batch(config.blockSize + 1, 1)
     .map((tokens) => [tokens.pop(), tokens.last()] as [List<number>, number])
     .repeat()

--- a/discojs-node/src/loaders.spec.ts
+++ b/discojs-node/src/loaders.spec.ts
@@ -51,12 +51,13 @@ describe("image directory parser", () => {
 
 describe("text parser", () => {
   it("parses basic file", async () => {
+    const text = ["a", "b", "c"].join("\n")
     await withFile(async ({ path }) => {
-      await fs.writeFile(path, ["a", "b", "c"].join("\n"));
-
-      const parsed = loadText(path);
-
-      expect(await parsed.size()).to.equal(3);
+      await fs.writeFile(path, text);
+      
+      const sequences = await arrayFromAsync(loadText(path))
+      expect(sequences.length).to.equal(1);
+      expect(sequences[0]).to.equal(text);
     });
   });
 });

--- a/discojs-web/src/loaders.spec.ts
+++ b/discojs-web/src/loaders.spec.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-
 import { loadCSV, loadText } from "./loaders/index.js";
 
 async function arrayFromAsync<T>(iter: AsyncIterable<T>): Promise<T[]> {
@@ -22,22 +21,16 @@ describe("csv parser", () => {
 });
 
 describe("text parser", () => {
-  it("loads", async () => {
+  it("loads a simple sequence", async () => {
+    const text = ["first", "second", "third"].join("\n")
+    
     // jsdom doesn't implement .text on File/Blob
     // trick from https://github.com/jsdom/jsdom/issues/2555
-    const text = await (
-      await fetch(
-        // data URL content need to be url-encoded
-        ["data:,first", "second", "third"].join("%0A"),
-      )
+    const file = await (
+      await fetch( "data:," + encodeURIComponent(text))
     ).blob();
-
-    const parsed = loadText(text);
-
-    expect(await arrayFromAsync(parsed)).to.have.ordered.members([
-      "first",
-      "second",
-      "third",
-    ]);
+    const parsed = loadText(file)
+    expect(await parsed.size()).to.equal(1);
+    expect((await arrayFromAsync(parsed))[0]).to.equal(text);
   });
 });

--- a/discojs-web/src/loaders/text.ts
+++ b/discojs-web/src/loaders/text.ts
@@ -1,35 +1,10 @@
 import { Dataset, Text } from "@epfml/discojs";
 
-class LineStream extends TransformStream<string, string> {
-  constructor() {
-    let current_line = "";
-
-    super({
-      transform: (chunk, controller) => {
-        const [head, ...lines] = chunk.split(/\r\n|\r|\n/);
-        const first_line = current_line + head;
-
-        if (lines.length === 0) {
-          current_line = first_line;
-          return;
-        }
-
-        controller.enqueue(first_line);
-        for (const line of lines.slice(0, -1)) controller.enqueue(line);
-
-        current_line = lines[lines.length - 1];
-      },
-      flush: (controller) => controller.enqueue(current_line),
-    });
-  }
-}
-
 export function load(file: Blob): Dataset<Text> {
   return new Dataset(async function* () {
     const reader = file
       .stream()
       .pipeThrough(new TextDecoderStream())
-      .pipeThrough(new LineStream())
       .getReader();
 
     while (true) {

--- a/discojs/src/dataset/dataset.spec.ts
+++ b/discojs/src/dataset/dataset.spec.ts
@@ -62,7 +62,7 @@ describe("dataset", () => {
     expect(await arrayFromAsync(right)).to.have.length(1);
   });
 
-  it("batches in samed sized chunks", async () => {
+  it("batches in same sized chunks", async () => {
     const dataset = new Dataset([1, 2, 3, 4]);
 
     const batched = dataset.batch(2);
@@ -155,7 +155,7 @@ describe("dataset", () => {
     const blockSize = 4
 
     const parsed = new Dataset([expectedTokens])
-      .unbatch()
+      .flatten()
       .batch(blockSize + 1, 1)
       
     // -1 because the last sequence is dropped as there is no next token label

--- a/discojs/src/dataset/dataset.spec.ts
+++ b/discojs/src/dataset/dataset.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { Dataset } from "./dataset.js";
-import { Range } from "immutable";
+import { List, Range } from "immutable";
 
 // Array.fromAsync not yet widely used (2024)
 async function arrayFromAsync<T>(iter: AsyncIterable<T>): Promise<T[]> {
@@ -138,5 +138,59 @@ describe("dataset", () => {
       [2, 1],
       [3, 2],
     ]);
+  });
+
+  it("batches with overlap", async () => {
+    const dataset = new Dataset([1, 2, 3]);
+
+    const batched = dataset.batch(2, 1);
+
+    expect(
+      (await arrayFromAsync(batched)).map((l) => l.toArray()),
+    ).to.have.deep.ordered.members([[1, 2], [2, 3]]);
+  });
+
+  it("batch with overlap yields correct batches", async () => {
+    const expectedTokens = Range(0, 53).toList()
+    const blockSize = 4
+
+    const parsed = new Dataset([expectedTokens])
+      .unbatch()
+      .batch(blockSize + 1, 1)
+      
+    // -1 because the last sequence is dropped as there is no next token label
+    const expectedLength = Math.ceil(expectedTokens.size / blockSize) - 1
+    expect(await parsed.size()).to.equal(expectedLength);
+      
+    // exclude the last sequence because it has been padded
+    let sequences = List(await arrayFromAsync(parsed))
+    // we expect the last sequence to have blockSize + 1 tokens via padding
+    expect(sequences.last()?.size).to.equal(blockSize + 1)
+    sequences = sequences.pop()
+    let i = 0
+    for await (const tokens of sequences) {
+      // each sequence has length blockSize + 1 (for the label)
+      expect(tokens.toArray()).to.deep.equal(
+        expectedTokens.slice(i, i + blockSize + 1).toArray()
+      );
+      // but the window should move by blockSize only
+      i += blockSize
+    }
+  })
+
+  it("repeats content infinitely", async () => {
+    const dataset = new Dataset([0, 1, 2]).repeat();
+    const iter = dataset[Symbol.asyncIterator]()
+
+    for (const i of Range(0, 10)) {
+      const e = await iter.next()
+      expect(e.done).to.be.false
+      expect(e.value).to.equal(i % 3)
+    }
+  });
+
+  it("repeats content a fixed number of times", async () => {
+    const dataset = new Dataset([0, 1]).repeat(3);
+    expect([0,1,0,1,0,1]).to.deep.equal(await arrayFromAsync(dataset))
   });
 });

--- a/discojs/src/dataset/dataset.spec.ts
+++ b/discojs/src/dataset/dataset.spec.ts
@@ -152,29 +152,29 @@ describe("dataset", () => {
 
   it("batch with overlap yields correct batches", async () => {
     const expectedTokens = Range(0, 53).toList()
-    const blockSize = 4
+    const contextLength = 4
 
     const parsed = new Dataset([expectedTokens])
       .flatten()
-      .batch(blockSize + 1, 1)
+      .batch(contextLength + 1, 1)
       
     // -1 because the last sequence is dropped as there is no next token label
-    const expectedLength = Math.ceil(expectedTokens.size / blockSize) - 1
+    const expectedLength = Math.ceil(expectedTokens.size / contextLength) - 1
     expect(await parsed.size()).to.equal(expectedLength);
       
     // exclude the last sequence because it has been padded
     let sequences = List(await arrayFromAsync(parsed))
-    // we expect the last sequence to have blockSize + 1 tokens via padding
-    expect(sequences.last()?.size).to.equal(blockSize + 1)
+    // we expect the last sequence to have contextLength + 1 tokens via padding
+    expect(sequences.last()?.size).to.equal(contextLength + 1)
     sequences = sequences.pop()
     let i = 0
     for await (const tokens of sequences) {
-      // each sequence has length blockSize + 1 (for the label)
+      // each sequence has length contextLength + 1 (for the label)
       expect(tokens.toArray()).to.deep.equal(
-        expectedTokens.slice(i, i + blockSize + 1).toArray()
+        expectedTokens.slice(i, i + contextLength + 1).toArray()
       );
-      // but the window should move by blockSize only
-      i += blockSize
+      // but the window should move by contextLength only
+      i += contextLength
     }
   })
 

--- a/discojs/src/dataset/dataset.ts
+++ b/discojs/src/dataset/dataset.ts
@@ -112,22 +112,36 @@ export class Dataset<T> implements AsyncIterable<T> {
     ];
   }
 
-  /** Slice into chunks
-   *
-   * Last slice is smaller if dataset isn't perfectly divisible
+  /** Create batches of `size` elements with potential overlap.
+   * Last batch is smaller if dataset isn't perfectly divisible
+   * 
+   * If overlap is set to a positive integer, the last `overlap` elements of a batch 
+   * are the first `overlap` elements of the next batch.
+   * 
+   * This method is tailored to create text sequences where each token's label is the following token. 
+   * In order to have a label for the last token of the input sequence, we include the first token
+   * of the next sequence (i.e. with an overlap of 1).
    *
    * @param size count of element per chunk
+   * @param overlap number of elements overlapping between two consecutive batches
    */
-  batch(size: number): Dataset<Batched<T>> {
-    if (size <= 0 || !Number.isInteger(size)) throw new Error("invalid size");
+  batch(size: number, overlap = 0): Dataset<Batched<T>> {
+    if (size <= 0 || !Number.isInteger(size))
+      throw new Error("invalid size");
+    if (overlap >= size || !Number.isInteger(overlap))
+      throw new Error("invalid overlap");
 
     return new Dataset(
       async function* (this: Dataset<T>) {
         const iter = this[Symbol.asyncIterator]();
 
+        let overlapped = List<T>();
         for (;;) {
           const batch = List(
-            await Promise.all(Range(0, size).map(() => iter.next())),
+            // get the first elements of the next batch
+            await Promise.all(
+              Range(overlapped.size, size).map(() => iter.next())
+            )
           ).flatMap((res) => {
             if (res.done) return [];
             else return [res.value];
@@ -135,10 +149,12 @@ export class Dataset<T> implements AsyncIterable<T> {
 
           if (batch.isEmpty()) break;
 
-          yield batch;
+          // yield the current batch with the first elements of the next batch
+          yield overlapped.concat(batch);
+          overlapped = batch.takeLast(overlap);
 
           // iterator couldn't generate more
-          if (batch.size < size) break;
+          if (batch.size < size - overlap) break;
         }
       }.bind(this),
     );
@@ -172,6 +188,26 @@ export class Dataset<T> implements AsyncIterable<T> {
           if (l.done || r.done) return;
           yield [l.value, r.value] as [T, U];
         }
+      }.bind(this),
+    );
+  }
+
+  /**
+   * Repeat the dataset `times` times
+   * @param times number of times to repeat the dataset, if undefined, the dataset is repeated indefinitely
+   * @returns a dataset repeated `times` times
+   */
+  repeat(times?: number): Dataset<T> {
+    if (times !== undefined && (!Number.isInteger(times) || times < 1))
+      throw new Error("times needs to be a positive integer or undefined");
+
+    return new Dataset(
+      async function* (this: Dataset<T>) {
+        let loop = 0;
+        do {
+          yield* this;
+          loop++
+        } while (times === undefined || loop < times)
       }.bind(this),
     );
   }

--- a/discojs/src/dataset/types.ts
+++ b/discojs/src/dataset/types.ts
@@ -7,3 +7,4 @@ export type Batched<T> = List<T>;
 export { Image };
 export type Tabular = Partial<Record<string, string>>;
 export type Text = string;
+export type TokenizedText = List<number>;

--- a/discojs/src/default_tasks/wikitext.ts
+++ b/discojs/src/default_tasks/wikitext.ts
@@ -41,7 +41,9 @@ export const wikitext: TaskProvider<'text'> = {
     }
   },
 
-  getModel (): Promise<Model<'text'>> {
-    return Promise.resolve(new models.GPT())
+  getModel(): Promise<Model<'text'>> {
+    return Promise.resolve(new models.GPT({
+      blockSize: this.getTask().trainingInformation.maxSequenceLength,
+    }))
   }
 }

--- a/discojs/src/default_tasks/wikitext.ts
+++ b/discojs/src/default_tasks/wikitext.ts
@@ -33,9 +33,9 @@ export const wikitext: TaskProvider<'text'> = {
         // But if set to 0 then the webapp doesn't display the validation metrics
         validationSplit: 0.1, 
         roundDuration: 2,
-        batchSize: 1, // If set too high (e.g. 16) firefox raises a WebGL error
+        batchSize: 8, // If set too high firefox raises a WebGL error
         tokenizer: 'Xenova/gpt2',
-        maxSequenceLength: 128,
+        maxSequenceLength: 64,
         tensorBackend: 'gpt'
       }
     }

--- a/discojs/src/default_tasks/wikitext.ts
+++ b/discojs/src/default_tasks/wikitext.ts
@@ -35,7 +35,7 @@ export const wikitext: TaskProvider<'text'> = {
         roundDuration: 2,
         batchSize: 8, // If set too high firefox raises a WebGL error
         tokenizer: 'Xenova/gpt2',
-        maxSequenceLength: 64,
+        contextLength: 64,
         tensorBackend: 'gpt'
       }
     }
@@ -43,7 +43,7 @@ export const wikitext: TaskProvider<'text'> = {
 
   getModel(): Promise<Model<'text'>> {
     return Promise.resolve(new models.GPT({
-      blockSize: this.getTask().trainingInformation.maxSequenceLength,
+      contextLength: this.getTask().trainingInformation.contextLength,
     }))
   }
 }

--- a/discojs/src/models/gpt/config.ts
+++ b/discojs/src/models/gpt/config.ts
@@ -19,20 +19,17 @@ export interface GPTConfig {
   maxIter?: number
   weightDecay?: number
   verbose?: 0 | 1
-  bias?: boolean
   debug?: boolean
   dropout?: number
   residDrop?: number
   embdDrop?: number
-  tokEmb?: boolean
-  lmHead?: boolean
   nLayer?: number
   nHead?: number
   nEmbd?: number
 }
 // for a benchmark of performance, see https://github.com/epfml/disco/pull/659
 export const DEFAULT_CONFIG: Required<GPTConfig> = {
-  name: 'transformer',
+  name: 'transformer', // prefix for the model layer names
   lr: 0.001,
   weightDecay: 0,
   maxIter: 10,
@@ -43,13 +40,10 @@ export const DEFAULT_CONFIG: Required<GPTConfig> = {
   evaluateEvery: 100,
   blockSize: 128,
   vocabSize: 50257,
-  bias: true,
   debug: false,
   dropout: 0.2,
   residDrop: 0.2,
   embdDrop: 0.2,
-  tokEmb: true,
-  lmHead: true,
   nLayer: 3,
   nHead: 3,
   nEmbd: 48,

--- a/discojs/src/models/gpt/config.ts
+++ b/discojs/src/models/gpt/config.ts
@@ -26,6 +26,7 @@ export interface GPTConfig {
   nLayer?: number
   nHead?: number
   nEmbd?: number
+  seed?: number,
 }
 // for a benchmark of performance, see https://github.com/epfml/disco/pull/659
 export const DefaultGPTConfig: Required<GPTConfig> = {
@@ -47,6 +48,7 @@ export const DefaultGPTConfig: Required<GPTConfig> = {
   nLayer: 3,
   nHead: 3,
   nEmbd: 48,
+  seed: Math.random(),
 }
 
 export type ModelSize = {
@@ -91,6 +93,6 @@ export interface GenerationConfig {
 export const DefaultGenerationConfig: Required<GenerationConfig> = {
   temperature: 1.0,
   doSample: false,
-  seed: 42,
+  seed: Math.random(),
   topk: 50
 }

--- a/discojs/src/models/gpt/config.ts
+++ b/discojs/src/models/gpt/config.ts
@@ -9,7 +9,7 @@ type GPTModelType =
 
 export interface GPTConfig {
   lr: number
-  blockSize: number
+  contextLength: number
   vocabSize?: number
   modelType: GPTModelType
   name?: string,
@@ -39,7 +39,7 @@ export const DefaultGPTConfig: Required<GPTConfig> = {
   evaluate: true,
   maxEvalBatches: 12,
   evaluateEvery: 100,
-  blockSize: 128,
+  contextLength: 128,
   vocabSize: 50257,
   debug: false,
   dropout: 0.2,

--- a/discojs/src/models/gpt/config.ts
+++ b/discojs/src/models/gpt/config.ts
@@ -28,7 +28,7 @@ export interface GPTConfig {
   nEmbd?: number
 }
 // for a benchmark of performance, see https://github.com/epfml/disco/pull/659
-export const DEFAULT_CONFIG: Required<GPTConfig> = {
+export const DefaultGPTConfig: Required<GPTConfig> = {
   name: 'transformer', // prefix for the model layer names
   lr: 0.001,
   weightDecay: 0,
@@ -72,4 +72,25 @@ export function getModelSizes (modelType: GPTModelType): Required<ModelSize> {
     case 'gpt-nano':
       return { nLayer: 3, nHead: 3, nEmbd: 48 }
   }
+}
+
+export interface GenerationConfig {
+  // take random token weighted by its probability
+  // If false, predict the token with the highest probability.
+  doSample: boolean
+  // the generation temperature (higher means more randomness).
+  // Set to 0 for greedy decoding.
+  temperature: number
+  // only consider the topk most likely tokens for sampling. 
+  // used if doSample is true.
+  topk: number
+  // random seed for sampling.
+  seed: number
+}
+
+export const DefaultGenerationConfig: Required<GenerationConfig> = {
+  temperature: 1.0,
+  doSample: false,
+  seed: 42,
+  topk: 50
 }

--- a/discojs/src/models/gpt/config.ts
+++ b/discojs/src/models/gpt/config.ts
@@ -10,7 +10,7 @@ type GPTModelType =
 export interface GPTConfig {
   lr: number
   blockSize: number
-  vocabSize: number
+  vocabSize?: number
   modelType: GPTModelType
   name?: string,
   evaluate?: boolean
@@ -42,7 +42,7 @@ export const DEFAULT_CONFIG: Required<GPTConfig> = {
   maxEvalBatches: 12,
   evaluateEvery: 100,
   blockSize: 128,
-  vocabSize: 50258,
+  vocabSize: 50257,
   bias: true,
   debug: false,
   dropout: 0.2,

--- a/discojs/src/models/gpt/gpt.spec.ts
+++ b/discojs/src/models/gpt/gpt.spec.ts
@@ -28,7 +28,6 @@ describe("gpt-tfjs", function () {
       evaluateEvery: 10,
       maxEvalBatches: 10,
       blockSize: 8,
-      vocabSize: 50258,
     });
     for (let i = 0; i < 5; i++)
       for await (const _ of model.train(dataset, undefined));

--- a/discojs/src/models/gpt/gpt.spec.ts
+++ b/discojs/src/models/gpt/gpt.spec.ts
@@ -25,7 +25,7 @@ describe("gpt-tfjs", function () {
       maxIter: 10,
       evaluateEvery: 50,
       maxEvalBatches: 10,
-      blockSize: 8,
+      contextLength: 8,
       seed
     });
     for (let i = 0; i < 5; i++)

--- a/discojs/src/models/gpt/gpt.spec.ts
+++ b/discojs/src/models/gpt/gpt.spec.ts
@@ -2,43 +2,40 @@ import { expect } from "chai";
 import "@tensorflow/tfjs-node"; // speed up
 import { AutoTokenizer } from "@xenova/transformers";
 
-import { Dataset, DataFormat } from "../../index.js";
+import { Dataset, DataFormat, processing } from "../../index.js";
 
 import { GPT } from "./index.js";
-import { List, Repeat } from "immutable";
+import { List } from "immutable";
 
 describe("gpt-tfjs", function () {
   it("can overfit one sentence", async function () {
-    this.timeout("2m");
+    this.timeout("1m");
     const tokenizer = await AutoTokenizer.from_pretrained("Xenova/gpt2");
 
     const data = "Lorem ipsum dolor sit";
-    const dataTokens = List(
-      (tokenizer(data, { return_tensor: false }) as { input_ids: number[] })
-        .input_ids,
-    );
+    const dataTokens = processing.tokenize(tokenizer, data);
+    const seed = 42
     const dataset = new Dataset<DataFormat.ModelEncoded["text"]>(
-      Repeat([dataTokens.pop(), dataTokens.last()]),
-    ).batch(64);
+      [[dataTokens.pop(), dataTokens.last()]]
+    ).repeat().batch(8);
 
     const model = new GPT({
       modelType: "gpt-nano",
       lr: 0.01,
       maxIter: 10,
-      evaluateEvery: 10,
+      evaluateEvery: 50,
       maxEvalBatches: 10,
       blockSize: 8,
+      seed
     });
     for (let i = 0; i < 5; i++)
       for await (const _ of model.train(dataset, undefined));
 
     const input = "Lorem ipsum dolor";
-    const inputTokens = List(
-      (tokenizer(input, { return_tensor: false }) as { input_ids: number[] })
-        .input_ids,
-    );
+    const inputTokens = processing.tokenize(tokenizer, data);
+    
     const outputToken: number = (
-      await model.predict(List.of(inputTokens))
+      await model.predict(List.of(inputTokens), { seed })
     ).first();
     const output = tokenizer.decode([outputToken]);
 

--- a/discojs/src/models/gpt/index.ts
+++ b/discojs/src/models/gpt/index.ts
@@ -27,7 +27,7 @@ export type GPTSerialization = {
 export class GPT extends Model<"text"> {
   private readonly model: GPTModel;
 
-  readonly #blockSize: number;
+  readonly #contextLength: number;
   readonly #maxBatchCount: number;
   readonly #vocabSize: number;
 
@@ -38,7 +38,7 @@ export class GPT extends Model<"text"> {
     model.compile();
     this.model = model;
 
-    this.#blockSize = partialConfig?.blockSize ?? DefaultGPTConfig.blockSize;
+    this.#contextLength = partialConfig?.contextLength ?? DefaultGPTConfig.contextLength;
     this.#maxBatchCount = partialConfig?.maxIter ?? DefaultGPTConfig.maxIter;
     this.#vocabSize = partialConfig?.vocabSize ?? DefaultGPTConfig.vocabSize;
   }
@@ -157,7 +157,7 @@ export class GPT extends Model<"text"> {
    * Generate the next token after the input sequence.
    * In other words, takes an input tensor of shape (prompt length T) and returns a tensor of shape (T+1)
    * 
-   * @param token input tokens of shape (T,). T is truncated to the model's block size
+   * @param token input tokens of shape (T,). T is truncated to the model's context length
    * @param config generation config: temperature, doSample, topk
    * @returns the next token predicted by the model
    */
@@ -166,7 +166,7 @@ export class GPT extends Model<"text"> {
     config: GenerationConfig,
   ): Promise<DataFormat.ModelEncoded["text"][1]> {
     // slice input tokens if longer than context length
-    tokens = tokens.slice(-this.#blockSize);
+    tokens = tokens.slice(-this.#contextLength);
 
     const input = tf.tidy(() =>
       tf.tensor1d(tokens.toArray(), "int32").expandDims<tf.Tensor2D>(0),

--- a/discojs/src/models/gpt/index.ts
+++ b/discojs/src/models/gpt/index.ts
@@ -35,7 +35,7 @@ export class GPT extends Model<"text"> {
   readonly #maxBatchCount: number;
   readonly #vocabSize: number;
 
-  constructor(partialConfig?: GPTConfig, layersModel?: tf.LayersModel) {
+  constructor(partialConfig?: Partial<GPTConfig>, layersModel?: tf.LayersModel) {
     super();
 
     const model = new GPTModel(partialConfig, layersModel);

--- a/discojs/src/models/gpt/index.ts
+++ b/discojs/src/models/gpt/index.ts
@@ -1,5 +1,6 @@
 /**
- * this code is taken from gpt-tfjs with modifications from @peacefulotter and @lukemovement
+ * Source: https://github.com/zemlyansky/gpt-tfjs and https://github.com/karpathy/build-nanogpt
+ * With modifications from @peacefulotter, @lukemovement and the Disco team
  **/
 
 import createDebug from "debug";

--- a/discojs/src/models/gpt/layers.ts
+++ b/discojs/src/models/gpt/layers.ts
@@ -67,13 +67,14 @@ tf.serialization.registerClass(LogLayer)
 
 type CausalSelfAttentionConfig =
     ConstructorParameters<typeof tf.layers.Layer>[0]
-    & Record<'blockSize' | 'nHead' | 'nEmbd' | 'dropout', number>
+    & Record<'blockSize' | 'nHead' | 'nEmbd' | 'dropout' | 'nLayer', number>
 
 class CausalSelfAttention extends tf.layers.Layer {
   static readonly className = 'CausalSelfAttention'
 
   private readonly nHead: number
   private readonly nEmbd: number
+  private readonly nLayer: number
   private readonly dropout: number
   private readonly mask: tf.Tensor2D
   cAttnKernel?: tf.LayerVariable
@@ -88,6 +89,7 @@ class CausalSelfAttention extends tf.layers.Layer {
 
     this.nEmbd = config.nEmbd
     this.nHead = config.nHead
+    this.nLayer = config.nLayer
     this.dropout = config.dropout
 
     // mask is a lower triangular matrix filled with 1
@@ -102,7 +104,7 @@ class CausalSelfAttention extends tf.layers.Layer {
       'c_attn.weight',
       [this.nEmbd, 3 * this.nEmbd],
       'float32',
-      tf.initializers.glorotNormal({})
+      tf.initializers.randomNormal({ mean:0, stddev:0.02 }) // use same init as GPT2
     )
     this.cAttnBias = this.addWeight(
       'c_attn.bias',
@@ -115,7 +117,12 @@ class CausalSelfAttention extends tf.layers.Layer {
       'c_proj.kernel',
       [this.nEmbd, this.nEmbd],
       'float32',
-      tf.initializers.glorotNormal({})
+      // the input keeps accumulating through the residual stream so we
+      // scale the initialization with the nb of layers to keep a unit std
+      // Sources:
+      // https://github.com/karpathy/build-nanogpt/blob/6104ab1b53920f6e2159749676073ff7d815c1fa/train_gpt2.py#L103
+      // https://youtu.be/l8pRSuU81PU?si=5GcKfi_kPgLgvtg2&t=4640
+      tf.initializers.randomNormal({ mean:0, stddev: 0.02 * Math.sqrt(2 * this.nLayer) })
     )
     this.cProjBias = this.addWeight(
       'c_proj.bias',
@@ -255,7 +262,7 @@ class GELU extends tf.layers.Layer {
 tf.serialization.registerClass(GELU)
 
 type MLPConfig = ConstructorParameters<typeof tf.layers.Layer>[0] &
-  Required<ModelSize> & Record<'blockSize' | 'residDrop', number>
+  Required<ModelSize> & Record<'blockSize' | 'residDrop' | 'nLayer', number>
 
 function MLP(config: MLPConfig): tf.LayersModel {
   return tf.sequential({ layers: [
@@ -263,19 +270,23 @@ function MLP(config: MLPConfig): tf.LayersModel {
       name: config.name + `.mlp.c_fc`,
       units: 4 * config.nEmbd,
       inputDim: config.nEmbd,
-      inputShape: [config.blockSize, config.nEmbd]
+      inputShape: [config.blockSize, config.nEmbd],
+      kernelInitializer: tf.initializers.randomNormal({ mean: 0, stddev: 0.02 }),
     }),
     new GELU(),
     tf.layers.dense({
-        name: config.name + '.mlp.c_proj',
-        units: config.nEmbd,
-        inputDim: 4 * config.nEmbd,
-      inputShape: [config.blockSize, 4 * config.nEmbd]
+      name: config.name + '.mlp.c_proj',
+      units: config.nEmbd,
+      inputDim: 4 * config.nEmbd,
+      inputShape: [config.blockSize, 4 * config.nEmbd],
+      kernelInitializer: tf.initializers.randomNormal({
+        mean: 0, stddev: 0.02 * Math.sqrt(2 * config.nLayer)
       }),
-      tf.layers.dropout({
-        name: config.name + '.mlp.drop',
-        rate: config.residDrop
-      }),
+    }),
+    tf.layers.dropout({
+      name: config.name + '.mlp.drop',
+      rate: config.residDrop
+    }),
   ]})
 }
 
@@ -362,7 +373,7 @@ class LMEmbedding extends tf.layers.Layer {
       'wte', //use same name as GPT2
       [this.vocabSize, this.nEmbd],
       'float32',
-      tf.initializers.randomNormal({})
+      tf.initializers.randomNormal({ mean:0, stddev:0.02 })
     )
   }
 
@@ -452,7 +463,7 @@ export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
     name: config.name + '.wpe',
     inputDim: config.blockSize,
     outputDim: config.nEmbd,
-    embeddingsInitializer: 'zeros'
+    embeddingsInitializer: tf.initializers.randomNormal({ mean: 0, stddev: 0.02 }),
   }).apply(range) as tf.SymbolicTensor
   
   if (config.debug) {
@@ -474,7 +485,12 @@ export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
     ).apply(x)
   }
   // Normalization
-  x = tf.layers.layerNormalization({ name: config.name + '.ln_f', epsilon: 1e-5 })
+  x = tf.layers.layerNormalization({
+    name: config.name + '.ln_f',
+    epsilon: 1e-5,
+    gammaInitializer: 'ones',
+    betaInitializer: 'zeros',
+  })
     .apply(x)
   if (config.debug) {
     x = new LogLayer({ name: 'ln_f_log' }).apply(x)

--- a/discojs/src/models/gpt/layers.ts
+++ b/discojs/src/models/gpt/layers.ts
@@ -1,6 +1,9 @@
+import createDebug from "debug";
 import * as tf from '@tensorflow/tfjs'
 import type { GPTConfig } from './config.js'
 import type { ModelSize } from './config.js'
+
+const debug = createDebug("discojs:models:gpt:layers");
 
 /**
  * Defines a range, from 0 to T, that is used to create positional embeddings
@@ -14,11 +17,9 @@ class Range extends tf.layers.Layer {
 
   override call (input: tf.Tensor | tf.Tensor[], kwargs: Record<string, unknown>): tf.Tensor | tf.Tensor[] {
     return tf.tidy(() => {
-      if (Array.isArray(input)) {
-        // TODO support multitensor
-        input = input[0]
-      }
+      if (Array.isArray(input)) input = input[0]
       this.invokeCallHook(input, kwargs)
+
       const T = input.shape[1]
       if (T === undefined) throw new Error('unexpected shape')
       return tf.reshape(tf.range(0, T, 1, 'int32'), [1, T])
@@ -27,6 +28,11 @@ class Range extends tf.layers.Layer {
 }
 tf.serialization.registerClass(Range)
 
+/**
+ * LogLayer is a layer that allows debugging the input that is fed to this layer
+ * This layer allows to inspect the input tensor at a specific point 
+ * in the model by adding a log layer in the model definition
+ */
 class LogLayer extends tf.layers.Layer {
   static readonly className = 'LogLayer'
 
@@ -36,10 +42,17 @@ class LogLayer extends tf.layers.Layer {
 
   override call (input: tf.Tensor | tf.Tensor[], kwargs: Record<string, unknown>): tf.Tensor | tf.Tensor[] {
     return tf.tidy(() => {
-      if (Array.isArray(input)) {
-        input = input[0]
-      }
+      if (Array.isArray(input)) input = input[0]
       this.invokeCallHook(input, kwargs)
+
+      const logs = {
+        'shape': input.shape,
+        'is_only_zero': !!input.equal(tf.tensor(0)).all().dataSync()[0],
+        'has_some_NaN': !!input.isNaN().any().dataSync()[0],
+        'min': +input.min().dataSync()[0].toPrecision(3),
+        'max': +input.max().dataSync()[0].toPrecision(3),
+      }
+      debug("%s logged: %o", this.name, logs)
       return input
     })
   }
@@ -64,6 +77,9 @@ class CausalSelfAttention extends tf.layers.Layer {
 
   constructor (private readonly config: CausalSelfAttentionConfig) {
     super(config)
+    if (config.nEmbd % config.nHead !== 0)
+      throw new Error('The embedding dimension `nEmbd` must be divisible by the number of attention heads `nHead`')
+
     this.nEmbd = config.nEmbd
     this.nHead = config.nHead
     this.dropout = config.dropout
@@ -75,26 +91,28 @@ class CausalSelfAttention extends tf.layers.Layer {
   }
 
   override build (): void {
+    // key, query, value projections for all heads, but in a batch
     this.cAttnKernel = this.addWeight(
-      'c_attn/kernel',
+      'c_attn.weight',
       [this.nEmbd, 3 * this.nEmbd],
       'float32',
       tf.initializers.glorotNormal({})
     )
     this.cAttnBias = this.addWeight(
-      'c_attn/bias',
+      'c_attn.bias',
       [3 * this.nEmbd],
       'float32',
       tf.initializers.zeros()
     )
+    // output projection
     this.cProjKernel = this.addWeight(
-      'c_proj/kernel',
+      'c_proj.kernel',
       [this.nEmbd, this.nEmbd],
       'float32',
       tf.initializers.glorotNormal({})
     )
     this.cProjBias = this.addWeight(
-      'c_proj/bias',
+      'c_proj.bias',
       [this.nEmbd],
       'float32',
       tf.initializers.zeros()
@@ -118,55 +136,54 @@ class CausalSelfAttention extends tf.layers.Layer {
         this.cProjBias === undefined
       ) { throw new Error('not built') }
 
-      if (Array.isArray(input)) {
-        input = input[0]
-      }
+      if (Array.isArray(input)) input = input[0]
       this.invokeCallHook(input, kwargs)
 
       const dense = (x: tf.Tensor, kernel: tf.LayerVariable, bias: tf.LayerVariable): tf.Tensor => {
+        // TODO: use broadcasting when tfjs will support backpropagating through broadcasting
         const k = kernel.read().expandDims(0).tile([x.shape[0], 1, 1])
         const m = x.matMul(k)
         return tf.add(m, bias.read())
       }
       // Apply attention weights to inputs as one big matrix which is then split into the
       // query, key and value submatrices
+      // nHead is "number of heads", hs is "head size", and C (number of channels) = n_embd = nHead * hs
+      // e.g. in GPT-2 (124M), nHead = 12, hs = 64, so nHead * hs = C = 768 channels in the Transformer
       const cAttn = dense(input, this.cAttnKernel, this.cAttnBias)
-
       let [q, k, v] = tf.split(cAttn, 3, -1) as [tf.Tensor, tf.Tensor, tf.Tensor]
-      const [B, T, C] = k.shape
+      // Follow naming conventions in https://github.com/karpathy/build-nanogpt/
+      const [B, T, C] = k.shape // batch size, sequence length, embedding dimensionality (number of channels)
 
       const splitHeads = (x: tf.Tensor): tf.Tensor =>
         tf.transpose(
-          tf.reshape(x, [B, T, this.nHead, C / this.nHead]),
-          [0, 2, 1, 3]
+          tf.reshape(x, [B, T, this.nHead, C / this.nHead]), // (B, T, nHead, head size)
+          [0, 2, 1, 3] // (B, nHead, T, hs)
         )
 
-      q = splitHeads(q)
-      k = splitHeads(k)
-      v = splitHeads(v)
+      q = splitHeads(q) // (B, nHead, T, hs)
+      k = splitHeads(k) // (B, nHead, T, hs)
+      v = splitHeads(v) // (B, nHead, T, hs)
 
-      // Scaled self attention: query @ key / sqrt(n_heads)
+      // Scaled self attention: query @ key / sqrt(hs)
+      // Matrix representing the token-to-token attention (B, nHead, T, T)
       let att = tf.mul(
-        tf.matMul(q, k, false, true),
-        tf.div(
-          1,
-          tf.sqrt(tf.cast(k.shape[k.shape.length - 1], 'float32'))
-        )
+        tf.matMul(q, k, false, true), // (B, nHead, T, hs) x (B, nHead, hs, T) -> (B, nHead, T, T)
+        tf.div(1, tf.sqrt(tf.cast(k.shape[k.shape.length - 1], 'float32'))) // 1 / sqrt(hs)
       )
-
-      // The next operations apply attention to the past tokens, which is
-      // essentially a weighted average of the past tokens with complicated weights,
-      // and makes sure to not pay any attention to future tokens
-
+      /**
+       * The next operations apply attention only on the past tokens, which is
+       * essentially a weighted average of the past tokens with complicated weights,
+       * it relies on a mask to not "pay any attention" to future tokens
+       */ 
       // mask is lower triangular matrix filled with 1
-      const mask = this.mask.slice([0, 0], [T, T])
+      const mask = this.mask.slice([0, 0], [T, T]) // (T, T)
       // 1 - mask                   => upper triangular matrix filled with 1
       // (1 - mask) * -10^9         => upper triangular matrix filled with -inf
       // att + ((1 - mask) * -10^9) => lower triangular part is the same as the `att` matrix
       //                               upper triangular part is -inf
-      att = tf.add(att, tf.mul(tf.sub(1, mask), -1e9))
-      // applying softmax zeros out the upper triangular part 
-      //(which are the attention weights of future tokens)
+      att = tf.add(att, tf.mul(tf.sub(1, mask), -1e9)) // (B, nHead, T, T)
+      // applying softmax zeroes out the upper triangular part (softmax(-inf) = 0)
+      // i.e., zeroes out future tokens's attention weights
       // and creates a probability distribution for the lower triangular
       // (attention weights of past tokens). The probability distribution ensures
       // that the attention weights of past tokens for a particular token sum to one
@@ -174,10 +191,10 @@ class CausalSelfAttention extends tf.layers.Layer {
       att = kwargs.training === true ? tf.dropout(att, this.dropout) : att
 
       // This is where the (attention-)weighted sum of past values is performed
-      let y = tf.matMul(att, v)
-      y = tf.transpose(y, [0, 2, 1, 3])
-      y = tf.reshape(y, [B, T, C])
-      y = dense(y, this.cProjKernel, this.cProjBias)
+      let y = tf.matMul(att, v) // (B, nHead, T, T) x (B, nHead, T, hs) -> (B, nHead, T, hs)
+      y = tf.transpose(y, [0, 2, 1, 3]) // (B, T, nHead, hs)
+      y = tf.reshape(y, [B, T, C]) // (B, T, C = nHead * hs)
+      y = dense(y, this.cProjKernel, this.cProjBias) // output projection (B, T, C)
       y = kwargs.training === true ? tf.dropout(y, this.dropout) : y
       return y
     })
@@ -185,6 +202,12 @@ class CausalSelfAttention extends tf.layers.Layer {
 }
 tf.serialization.registerClass(CausalSelfAttention)
 
+/**
+ * GELU with tanh approximate
+ * GELU(x) = x * 0.5 * (1 + Tanh[sqrt(2/π) * (x + 0.044715 * x^3)])
+ * 
+ * https://pytorch.org/docs/stable/generated/torch.nn.GELU.html
+ */
 class GELU extends tf.layers.Layer {
   static readonly className = 'GELU'
 
@@ -203,19 +226,19 @@ class GELU extends tf.layers.Layer {
         input = input[0]
       }
       this.invokeCallHook(input, kwargs)
-      const cdf = tf.mul(
-        0.5,
+      const cdf = tf.mul( // 0.5 * (1 + Tanh[sqrt(2/π) * (x + 0.044715 * x^3)])
+        0.5, 
         tf.add(
           1,
-          tf.tanh(
+          tf.tanh( // Tanh[sqrt(2/π) * (x + 0.044715 * x^3)]
             tf.mul(
-              tf.sqrt(tf.div(2, Math.PI)),
-              tf.add(input, tf.mul(0.044715, tf.pow(input, 3)))
+              tf.sqrt(tf.div(2, Math.PI)), // (sqrt(2/π)
+              tf.add(input, tf.mul(0.044715, tf.pow(input, 3))) // (x + 0.044715 * x^3)
             )
           )
         )
       )
-      return tf.mul(input, cdf)
+      return tf.mul(input, cdf) // x * 0.5 * (1 + Tanh[sqrt(2/π) * (x + 0.044715 * x^3)])
     })
   }
 }
@@ -227,52 +250,82 @@ type MLPConfig = ConstructorParameters<typeof tf.layers.Layer>[0] &
 function MLP(config: MLPConfig): tf.LayersModel {
   return tf.sequential({ layers: [
     tf.layers.dense({
-      name: config.name + `/mlp/c_fc`,
+      name: config.name + `.mlp.c_fc`,
       units: 4 * config.nEmbd,
       inputDim: config.nEmbd,
       inputShape: [config.blockSize, config.nEmbd]
     }),
     new GELU(),
-  tf.layers.dense({
-      name: config.name + '/mlp/c_proj',
-      units: config.nEmbd,
-      inputDim: 4 * config.nEmbd,
+    tf.layers.dense({
+        name: config.name + '.mlp.c_proj',
+        units: config.nEmbd,
+        inputDim: 4 * config.nEmbd,
       inputShape: [config.blockSize, 4 * config.nEmbd]
-    }),
-    tf.layers.dropout({
-      name: config.name + '/mlp/drop',
-      rate: config.residDrop
-    }),
+      }),
+      tf.layers.dropout({
+        name: config.name + '.mlp.drop',
+        rate: config.residDrop
+      }),
   ]})
 }
 
 type BlockConfig = CausalSelfAttentionConfig & MLPConfig & { debug: boolean }
 
+/**
+ * Performs the following operations:
+ * x1 = input + mlp(layernorm_1(input))
+ * output = x1 + mlp(layernorm_2(x1))
+ */
 function TransformerBlock (conf: BlockConfig): tf.LayersModel {
-  const config = Object.assign({ name: 'h' }, conf)
+  const config = Object.assign({ name: '.h' }, conf)
   const inputs = tf.input({ shape: [config.blockSize, config.nEmbd] })
   let x1, x2
   // input normalization
-  x1 = tf.layers.layerNormalization({ name: config.name + '/ln_1', epsilon: 1e-5 })
-    .apply(inputs)
+  x1 = tf.layers.layerNormalization({
+    name: config.name + '.ln_1',
+    epsilon: 1e-5,
+    gammaInitializer: 'ones', // already the default but make it explicit
+    betaInitializer: 'zeros',
+  }).apply(inputs)
+
   if (config.debug) {
-    x1 = new LogLayer({ name: config.name + '/ln_1_log' }).apply(x1)
+    x1 = new LogLayer({ name: config.name + '.ln_1_log' }).apply(x1)
   }
   // self attention layer
   x1 = new CausalSelfAttention(
-    Object.assign({}, config, { name: config.name + '/attn' }),
+    Object.assign({}, config, { name: config.name + '.attn' }),
   ).apply(x1)
+
+  if (config.debug) {
+    x1 = new LogLayer({ name: config.name + '.attn_log' }).apply(x1)
+  }
+
   // Residual connection
   x1 = tf.layers.add().apply([inputs, x1 as tf.SymbolicTensor])
+  if (config.debug) {
+    x1 = new LogLayer({ name: config.name + '.residual_log' }).apply(x1)
+  }
   // normalization 
-  x2 = tf.layers
-    .layerNormalization({ name: config.name + '/ln_2', epsilon: 1e-5 })
-    .apply(x1)
+  x2 = tf.layers.layerNormalization({
+      name: config.name + '.ln_2',
+      epsilon: 1e-5,
+      gammaInitializer: 'ones',
+      betaInitializer: 'zeros',
+  }).apply(x1)
+  if (config.debug) {
+    x2 = new LogLayer({ name: config.name + '.ln_2_log' }).apply(x2)
+  }
   
   // MLP 
-  x2 = MLP(Object.assign({}, config, { name: config.name })).apply(x2)
+  x2 = MLP(Object.assign({}, config, { name: config.name + '.mlp' })).apply(x2)
+  if (config.debug) {
+    x2 = new LogLayer({ name: config.name + '.mlp_log' }).apply(x2)
+  }
   // add attention output to mlp output
   x2 = tf.layers.add().apply([x1 as tf.SymbolicTensor, x2 as tf.SymbolicTensor])
+  if (config.debug) {
+    x2 = new LogLayer({ name: config.name + '.add_log' }).apply(x2)
+  }
 
   return tf.model({ name: config.name, inputs, outputs: x2 as tf.SymbolicTensor })
 }
@@ -289,27 +342,30 @@ function TransformerBlock (conf: BlockConfig): tf.LayersModel {
 export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
   const inputs = tf.input({ shape: [null] })
 
-  //Token embedding
-  const tokEmb = tf.layers.embedding({
-      name: config.name + '/wte',
+  // token embedding
+  let tokEmb = tf.layers.embedding({
+      name: config.name + '.wte',
       inputDim: config.vocabSize,
       outputDim: config.nEmbd,
       embeddingsInitializer: 'zeros',
       embeddingsRegularizer: undefined,
       activityRegularizer: undefined
-    }).apply(inputs) as tf.SymbolicTensor
-
+  }).apply(inputs) as tf.SymbolicTensor
+  
+  if (config.debug) {
+    tokEmb = new LogLayer({ name: 'tokEmb_log' }).apply(tokEmb) as tf.SymbolicTensor
+  }
   // Positional embedding
   const range = new Range({}).apply(inputs)
   let posEmb = tf.layers.embedding({
-    name: config.name + '/wpe',
+    name: config.name + '.wpe',
     inputDim: config.blockSize,
     outputDim: config.nEmbd,
     embeddingsInitializer: 'zeros'
   }).apply(range) as tf.SymbolicTensor
   
   if (config.debug) {
-    posEmb = new LogLayer({ name: 'posEmb' }).apply(posEmb) as tf.SymbolicTensor
+    posEmb = new LogLayer({ name: 'posEmb_log' }).apply(posEmb) as tf.SymbolicTensor
   }
 
   // token and positional embeddings are added together
@@ -317,20 +373,20 @@ export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
   // dropout
   x = tf.layers.dropout({name: 'drop', rate: config.embdDrop}).apply(x)
   if (config.debug) {
-    x = new LogLayer({ name: 'dropadd' }).apply(x)
+    x = new LogLayer({ name: 'drop_log' }).apply(x)
   }
 
-  //Apply successively transformer blocks, attention and dense layers
+  // apply successively transformer blocks, attention and dense layers
   for (let i = 0; i < config.nLayer; i++) {
     x = TransformerBlock(
-      Object.assign({}, config, { name: config.name + '/h/' + i }),
+      Object.assign({}, config, { name: config.name + '.h' + i }),
     ).apply(x)
   }
   // Normalization
-  x = tf.layers.layerNormalization({ name: config.name + '/ln_f', epsilon: 1e-5 })
+  x = tf.layers.layerNormalization({ name: config.name + '.ln_f', epsilon: 1e-5 })
     .apply(x)
   if (config.debug) {
-    x = new LogLayer({ name: 'fin/ln' }).apply(x)
+    x = new LogLayer({ name: 'ln_f_log' }).apply(x)
   }
 
   // Append a language modeling head
@@ -341,6 +397,10 @@ export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
     inputShape: [config.blockSize, config.nEmbd],
     useBias: false
   }).apply(x)
+  
+  if (config.debug) {
+    x = new LogLayer({ name: 'lm_head_log' }).apply(x)
+  }
 
   return tf.model({ inputs, outputs: x as tf.SymbolicTensor })
 }

--- a/discojs/src/models/gpt/layers.ts
+++ b/discojs/src/models/gpt/layers.ts
@@ -67,7 +67,7 @@ tf.serialization.registerClass(LogLayer)
 
 type CausalSelfAttentionConfig =
     ConstructorParameters<typeof tf.layers.Layer>[0]
-    & Record<'blockSize' | 'nHead' | 'nEmbd' | 'dropout' | 'nLayer', number>
+    & Record<'blockSize' | 'nHead' | 'nEmbd' | 'dropout' | 'nLayer' | 'seed', number>
 
 class CausalSelfAttention extends tf.layers.Layer {
   static readonly className = 'CausalSelfAttention'
@@ -76,6 +76,7 @@ class CausalSelfAttention extends tf.layers.Layer {
   private readonly nEmbd: number
   private readonly nLayer: number
   private readonly dropout: number
+  private readonly seed: number
   private readonly mask: tf.Tensor2D
   cAttnKernel?: tf.LayerVariable
   cAttnBias?: tf.LayerVariable
@@ -91,6 +92,7 @@ class CausalSelfAttention extends tf.layers.Layer {
     this.nHead = config.nHead
     this.nLayer = config.nLayer
     this.dropout = config.dropout
+    this.seed = config.seed
 
     // mask is a lower triangular matrix filled with 1
     // calling bandPart zero out the upper triangular part of the all-ones matrix
@@ -104,7 +106,7 @@ class CausalSelfAttention extends tf.layers.Layer {
       'c_attn.weight',
       [this.nEmbd, 3 * this.nEmbd],
       'float32',
-      tf.initializers.randomNormal({ mean:0, stddev:0.02 }) // use same init as GPT2
+      tf.initializers.randomNormal({ mean:0, stddev:0.02, seed: this.seed }) // use same init as GPT2
     )
     this.cAttnBias = this.addWeight(
       'c_attn.bias',
@@ -122,7 +124,9 @@ class CausalSelfAttention extends tf.layers.Layer {
       // Sources:
       // https://github.com/karpathy/build-nanogpt/blob/6104ab1b53920f6e2159749676073ff7d815c1fa/train_gpt2.py#L103
       // https://youtu.be/l8pRSuU81PU?si=5GcKfi_kPgLgvtg2&t=4640
-      tf.initializers.randomNormal({ mean:0, stddev: 0.02 * Math.sqrt(2 * this.nLayer) })
+      tf.initializers.randomNormal({
+        mean: 0, stddev: 0.02 * Math.sqrt(2 * this.nLayer), seed: this.seed
+      })
     )
     this.cProjBias = this.addWeight(
       'c_proj.bias',
@@ -204,14 +208,14 @@ class CausalSelfAttention extends tf.layers.Layer {
       // (attention weights of past tokens). The probability distribution ensures
       // that the attention weights of past tokens for a particular token sum to one
       att = tf.softmax(att, -1)
-      att = kwargs.training === true ? tf.dropout(att, this.dropout) : att
+      att = kwargs.training === true ? tf.dropout(att, this.dropout, undefined, this.seed) : att
 
       // This is where the (attention-)weighted sum of past values is performed
       let y = tf.matMul(att, v) // (B, nHead, T, T) x (B, nHead, T, hs) -> (B, nHead, T, hs)
       y = tf.transpose(y, [0, 2, 1, 3]) // (B, T, nHead, hs)
       y = tf.reshape(y, [B, T, C]) // (B, T, C = nHead * hs)
       y = dense(y, this.cProjKernel, this.cProjBias) // output projection (B, T, C)
-      y = kwargs.training === true ? tf.dropout(y, this.dropout) : y
+      y = kwargs.training === true ? tf.dropout(y, this.dropout, undefined, this.seed) : y
       return y
     })
   }
@@ -262,7 +266,7 @@ class GELU extends tf.layers.Layer {
 tf.serialization.registerClass(GELU)
 
 type MLPConfig = ConstructorParameters<typeof tf.layers.Layer>[0] &
-  Required<ModelSize> & Record<'blockSize' | 'residDrop' | 'nLayer', number>
+  Required<ModelSize> & Record<'blockSize' | 'residDrop' | 'nLayer' | 'seed', number>
 
 function MLP(config: MLPConfig): tf.LayersModel {
   return tf.sequential({ layers: [
@@ -271,7 +275,9 @@ function MLP(config: MLPConfig): tf.LayersModel {
       units: 4 * config.nEmbd,
       inputDim: config.nEmbd,
       inputShape: [config.blockSize, config.nEmbd],
-      kernelInitializer: tf.initializers.randomNormal({ mean: 0, stddev: 0.02 }),
+      kernelInitializer: tf.initializers.randomNormal({
+        mean: 0, stddev: 0.02, seed: config.seed
+      }),
     }),
     new GELU(),
     tf.layers.dense({
@@ -280,12 +286,13 @@ function MLP(config: MLPConfig): tf.LayersModel {
       inputDim: 4 * config.nEmbd,
       inputShape: [config.blockSize, 4 * config.nEmbd],
       kernelInitializer: tf.initializers.randomNormal({
-        mean: 0, stddev: 0.02 * Math.sqrt(2 * config.nLayer)
+        mean: 0, stddev: 0.02 * Math.sqrt(2 * config.nLayer), seed: config.seed
       }),
     }),
     tf.layers.dropout({
       name: config.name + '.mlp.drop',
-      rate: config.residDrop
+      rate: config.residDrop,
+      seed: config.seed
     }),
   ]})
 }
@@ -365,7 +372,8 @@ class LMEmbedding extends tf.layers.Layer {
   static readonly className = 'LMEmbedding'
   embeddings?: tf.LayerVariable
 
-  constructor(private readonly vocabSize: number, private readonly nEmbd: number) {
+  constructor(private readonly vocabSize: number,
+    private readonly nEmbd: number, private readonly seed: number) {
     super({})
   }
   override build(): void {
@@ -373,7 +381,7 @@ class LMEmbedding extends tf.layers.Layer {
       'wte', //use same name as GPT2
       [this.vocabSize, this.nEmbd],
       'float32',
-      tf.initializers.randomNormal({ mean:0, stddev:0.02 })
+      tf.initializers.randomNormal({ mean:0, stddev:0.02, seed: this.seed })
     )
   }
 
@@ -451,7 +459,7 @@ export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
   const inputs = tf.input({ shape: [null] })
 
   // token embedding
-  const wte = new LMEmbedding(config.vocabSize, config.nEmbd)
+  const wte = new LMEmbedding(config.vocabSize, config.nEmbd, config.seed)
   let tokEmb = wte.apply(inputs) as tf.SymbolicTensor // (batch_size, input length T, nEmbd)
   
   if (config.debug) {
@@ -463,7 +471,9 @@ export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
     name: config.name + '.wpe',
     inputDim: config.blockSize,
     outputDim: config.nEmbd,
-    embeddingsInitializer: tf.initializers.randomNormal({ mean: 0, stddev: 0.02 }),
+    embeddingsInitializer: tf.initializers.randomNormal({
+      mean: 0, stddev: 0.02, seed: config.seed
+    }),
   }).apply(range) as tf.SymbolicTensor
   
   if (config.debug) {
@@ -473,7 +483,9 @@ export function GPTArchitecture(config: Required<GPTConfig>): tf.LayersModel {
   // token and positional embeddings are added together
   let x = tf.layers.add().apply([tokEmb, posEmb])
   // dropout
-  x = tf.layers.dropout({name: 'drop', rate: config.embdDrop}).apply(x)
+  x = tf.layers.dropout({
+    name: 'drop', rate: config.embdDrop, seed: config.seed
+  }).apply(x)
   if (config.debug) {
     x = new LogLayer({ name: 'drop_log' }).apply(x)
   }

--- a/discojs/src/models/gpt/model.ts
+++ b/discojs/src/models/gpt/model.ts
@@ -28,7 +28,7 @@ export declare abstract class Dataset<T> {
 export class GPTModel extends tf.LayersModel {
   protected readonly config: Required<GPTConfig>
 
-  constructor(partialConfig?: GPTConfig, layersModel?: tf.LayersModel) {
+  constructor(partialConfig?: Partial<GPTConfig>, layersModel?: tf.LayersModel) {
     // Fill missing config parameters with default values
     let completeConfig: Required<GPTConfig> = { ...DEFAULT_CONFIG, ...partialConfig }
     // Add layer sizes depending on which model has been specified

--- a/discojs/src/models/gpt/model.ts
+++ b/discojs/src/models/gpt/model.ts
@@ -59,7 +59,7 @@ export class GPTModel extends tf.LayersModel {
     const callbacks = trainingArgs.callbacks as tf.CustomCallbackArgs
     const evalDataset = trainingArgs.validationData as tf.data.Dataset<{ xs: tf.Tensor2D, ys: tf.Tensor3D }>
     await callbacks.onTrainBegin?.()
-    
+
     for (let epoch = 1; epoch <= trainingArgs.epochs; epoch++) {
       let accuracyFraction: [number, number] = [0, 0];
       let averageLoss = 0
@@ -75,7 +75,7 @@ export class GPTModel extends tf.LayersModel {
         let preprocessingTime = performance.now()
         await Promise.all([xs.data(), ys.data()])
         preprocessingTime = performance.now() - preprocessingTime
-
+        
         // TODO include as a tensor inside the model
         const accTensor = tf.tidy(() => {
           const logits = this.apply(xs)
@@ -92,7 +92,7 @@ export class GPTModel extends tf.LayersModel {
         if (typeof accSum !== 'number')
           throw new Error('got multiple accuracy sum')
         accuracyFraction = [accuracyFraction[0] + accSum, accuracyFraction[1] + accSize];
-	tf.dispose([accTensor])
+        tf.dispose([accTensor])
 
         const lossTensor = tf.tidy(() => {
           const { grads, value: lossTensor } = this.optimizer.computeGradients(() => {
@@ -141,7 +141,7 @@ export class GPTModel extends tf.LayersModel {
         tf.dispose([xs, ys])
       }
       let logs: tf.Logs = {
-        'loss': averageLoss / iteration,
+        'loss': averageLoss / (iteration - 1), // -1 because iteration got incremented at the end of the loop
         'acc': accuracyFraction[0] / accuracyFraction[1],
       }
       if (evalDataset !== undefined) {

--- a/discojs/src/models/gpt/model.ts
+++ b/discojs/src/models/gpt/model.ts
@@ -2,12 +2,12 @@ import createDebug from "debug";
 import * as tf from '@tensorflow/tfjs'
 
 import type { GPTConfig } from './config.js'
-import { getModelSizes, DEFAULT_CONFIG } from './config.js'
+import { getModelSizes, DefaultGPTConfig } from './config.js'
 import { getCustomAdam, clipByGlobalNormObj } from './optimizers.js'
 import evaluate from './evaluate.js'
 import { GPTArchitecture } from './layers.js'
 
-const debug = createDebug("discojs:models:gpt");
+const debug = createDebug("discojs:models:gpt:model");
 
 /**
  * tfjs does not export LazyIterator and Dataset...
@@ -30,7 +30,7 @@ export class GPTModel extends tf.LayersModel {
 
   constructor(partialConfig?: Partial<GPTConfig>, layersModel?: tf.LayersModel) {
     // Fill missing config parameters with default values
-    let completeConfig: Required<GPTConfig> = { ...DEFAULT_CONFIG, ...partialConfig }
+    let completeConfig: Required<GPTConfig> = { ...DefaultGPTConfig, ...partialConfig }
     // Add layer sizes depending on which model has been specified
     completeConfig = { ...completeConfig, ...getModelSizes(completeConfig.modelType) }
 

--- a/discojs/src/processing/index.ts
+++ b/discojs/src/processing/index.ts
@@ -60,7 +60,7 @@ export async function preprocess<D extends DataType>(
 
       const tokenizer = await models.getTaskTokenizer(t);
       return d.map(text => processing.tokenize(tokenizer, text))
-        .unbatch()
+        .flatten()
         .batch(blockSize + 1, 1)
         .map((tokens) => [tokens.pop(), tokens.last()]) as
           Dataset<DataFormat.ModelEncoded[D]>;
@@ -101,7 +101,7 @@ export async function preprocessWithoutLabel<D extends DataType>(
       const tokenizer = await models.getTaskTokenizer(t);
 
       return d.map(text => processing.tokenize(tokenizer, text))
-        .unbatch()
+        .flatten()
         .batch(blockSize)
     }
   }

--- a/discojs/src/processing/index.ts
+++ b/discojs/src/processing/index.ts
@@ -56,19 +56,14 @@ export async function preprocess<D extends DataType>(
       // cast as typescript doesn't reduce generic type
       const d = dataset as Dataset<DataFormat.Raw["text"]>;
       const t = task as Task<"text">;
+      const blockSize = task.trainingInformation.maxSequenceLength
 
       const tokenizer = await models.getTaskTokenizer(t);
-      const totalTokenCount =
-        task.trainingInformation.maxSequenceLength ??
-        (tokenizer.model_max_length as number);
-
-      return d
-        .map((line) =>
-          processing.tokenizeAndLeftPad(line, tokenizer, totalTokenCount),
-        )
-        .map((tokens) => [tokens.pop(), tokens.last()]) as Dataset<
-        DataFormat.ModelEncoded[D]
-      >;
+      return d.map(text => processing.tokenize(tokenizer, text))
+        .unbatch()
+        .batch(blockSize + 1, 1)
+        .map((tokens) => [tokens.pop(), tokens.last()]) as
+          Dataset<DataFormat.ModelEncoded[D]>;
     }
   }
 }
@@ -102,17 +97,12 @@ export async function preprocessWithoutLabel<D extends DataType>(
       // cast as typescript doesn't reduce generic type
       const d = dataset as Dataset<DataFormat.Raw["text"]>;
       const t = task as Task<"text">;
-
+      const blockSize = task.trainingInformation.maxSequenceLength
       const tokenizer = await models.getTaskTokenizer(t);
-      const totalTokenCount =
-        t.trainingInformation.maxSequenceLength ??
-        (tokenizer.model_max_length as number);
 
-      return d
-        .map((line) =>
-          processing.tokenizeAndLeftPad(line, tokenizer, totalTokenCount),
-        )
-        .map((tokens) => tokens.pop());
+      return d.map(text => processing.tokenize(tokenizer, text))
+        .unbatch()
+        .batch(blockSize)
     }
   }
 }

--- a/discojs/src/processing/index.ts
+++ b/discojs/src/processing/index.ts
@@ -56,12 +56,12 @@ export async function preprocess<D extends DataType>(
       // cast as typescript doesn't reduce generic type
       const d = dataset as Dataset<DataFormat.Raw["text"]>;
       const t = task as Task<"text">;
-      const blockSize = task.trainingInformation.maxSequenceLength
+      const contextLength = task.trainingInformation.contextLength
 
       const tokenizer = await models.getTaskTokenizer(t);
       return d.map(text => processing.tokenize(tokenizer, text))
         .flatten()
-        .batch(blockSize + 1, 1)
+        .batch(contextLength + 1, 1)
         .map((tokens) => [tokens.pop(), tokens.last()]) as
           Dataset<DataFormat.ModelEncoded[D]>;
     }
@@ -97,12 +97,12 @@ export async function preprocessWithoutLabel<D extends DataType>(
       // cast as typescript doesn't reduce generic type
       const d = dataset as Dataset<DataFormat.Raw["text"]>;
       const t = task as Task<"text">;
-      const blockSize = task.trainingInformation.maxSequenceLength
+      const contextLength = task.trainingInformation.contextLength
       const tokenizer = await models.getTaskTokenizer(t);
 
       return d.map(text => processing.tokenize(tokenizer, text))
         .flatten()
-        .batch(blockSize)
+        .batch(contextLength)
     }
   }
 }

--- a/discojs/src/processing/text.spec.ts
+++ b/discojs/src/processing/text.spec.ts
@@ -1,12 +1,17 @@
 import { expect } from "chai";
 
-import { tokenizeAndLeftPad } from "./text.js";
+import { tokenize } from "./text.js";
 import { AutoTokenizer } from "@xenova/transformers";
 import { Repeat } from "immutable";
 
 describe("text processing", () => {
-  const text =
-    "Hello world, a bc 1 2345, '? 976. Wikipedia is a free content online encyclopedia written and maintained by a community \n of volunteers, known as Wikipedians. Founded by Jimmy Wales and Larry Sanger on January 15, 2001, Wikipedia is hosted by the Wikimedia Foundation, an American nonprofit organization that employs a staff of over 700 people.[7]";
+  const text = [
+    "Hello world, a bc 1 2345, '? 976. Wikipedia is a free content online encyclopedia",
+    "written and maintained by a community \n of volunteers, known as Wikipedians.",
+    "Founded by Jimmy Wales and Larry Sanger on January 15, 2001, Wikipedia is hosted by the",
+    "Wikimedia Foundation, an American nonprofit organization that employs a staff of over 700 people.[7]"
+  ].join(" ");
+
   const expectedTokens = [
     15496, 995, 11, 257, 47125, 352, 2242, 2231, 11, 705, 30, 860, 4304, 13,
     15312, 318, 257, 1479, 2695, 2691, 45352, 3194, 290, 9456, 416, 257, 2055,
@@ -16,29 +21,64 @@ describe("text processing", () => {
     257, 3085, 286, 625, 13037, 661, 3693, 22, 60,
   ];
 
-  it("tokenizes text", async () => {
-    const tokenizer = await AutoTokenizer.from_pretrained("Xenova/gpt2");
+  const shortText = 'import { AutoTokenizer } from "@xenova/transformers";' 
+  // with GPT 2 tokenizer
+  const shortExpectedTokens = [
+    11748, 1391, 11160, 30642, 7509, 1782, 422,
+    44212, 87, 268, 10071, 14, 35636, 364, 8172
+  ]
 
-    const tokens = tokenizeAndLeftPad(text, tokenizer, expectedTokens.length);
-
+  it("can tokenize text with the Llama 3 tokenizer", async () => {
+    const tokenizer = await AutoTokenizer.from_pretrained("Xenova/llama-3-tokenizer");
+    // Tokenizer playgrounds aren't consistent: https://github.com/huggingface/transformers.js/issues/1019
+    // Tokenization with python:
+    // from transformers import AutoTokenizer
+    // tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B")
+    // tokenizer.encode(text, add_special_tokens=False)
+    const expectedTokens = [
+      9906, 1917, 11, 264, 18399, 220, 16, 220, 11727, 20, 11, 32167,
+      220, 25208, 13, 27685, 374, 264, 1949, 2262, 2930, 83708, 5439, 323, 18908,
+      555, 264, 4029, 720, 315, 23872, 11, 3967, 439, 119234, 291, 5493, 13, 78811,
+      555, 28933, 23782, 323, 30390, 328, 4091, 389, 6186, 220, 868, 11, 220, 1049,
+      16, 11, 27685, 374, 21685, 555, 279, 90940, 5114, 11, 459, 3778, 33184, 7471,
+      430, 51242, 264, 5687, 315, 927, 220, 7007, 1274, 8032, 22, 60
+    ]
+    const tokens = tokenize(tokenizer, text);
     expect(tokens.toArray()).to.be.deep.equal(expectedTokens);
   });
 
-  it("tokenizes until wanted size", async () => {
+  it("can tokenize text with the GPT2 tokenizer", async () => {
     const tokenizer = await AutoTokenizer.from_pretrained("Xenova/gpt2");
 
-    const tokens = tokenizeAndLeftPad(text, tokenizer, 10);
+    const tokens = tokenize(tokenizer, text);
+    expect(tokens.toArray()).to.be.deep.equal(expectedTokens);
+  });
 
+  it("truncates until expected length", async () => {
+    const tokenizer = await AutoTokenizer.from_pretrained("Xenova/gpt2");
+
+    const tokens = tokenize(tokenizer, text, {truncation: true, max_length: 10});
     expect(tokens.toArray()).to.be.deep.equal(expectedTokens.slice(0, 10));
   });
 
-  it("pads until enough token are generated", async () => {
+  it("pads sequence until enough token are generated", async () => {
     const tokenizer = await AutoTokenizer.from_pretrained("Xenova/gpt2");
+    const max_length = 20
 
-    const tokens = tokenizeAndLeftPad("", tokenizer, 10);
-
-    expect(tokens.toArray()).to.be.deep.equal(
-      Repeat(tokenizer.pad_token_id, 10).toArray(),
+    const tokens = tokenize(tokenizer, shortText, {padding: true, max_length});
+    const paddedSequence = Repeat(tokenizer.pad_token_id, max_length - shortExpectedTokens.length)
+      .concat(shortExpectedTokens).toArray();
+    expect(tokens.toArray()).to.be.deep.equal(paddedSequence);
+  });
+    
+  it("can pad on right side", async () => {
+    const tokenizer = await AutoTokenizer.from_pretrained("Xenova/gpt2");
+    const max_length = 20
+    
+    const tokens = tokenize(tokenizer, shortText, {padding: true, padding_side: 'right', max_length});
+    const paddedSequence = shortExpectedTokens.concat(
+      Repeat(tokenizer.pad_token_id, max_length - shortExpectedTokens.length).toArray()
     );
+    expect(tokens.toArray()).to.be.deep.equal(paddedSequence);
   });
 });

--- a/discojs/src/serialization/model.spec.ts
+++ b/discojs/src/serialization/model.spec.ts
@@ -51,7 +51,7 @@ describe('serialization', () => {
       maxIter: 10,
       evaluateEvery:10,
       maxEvalBatches: 10,
-      blockSize: 8,
+      contextLength: 8,
     }
     const model = new models.GPT(config)
 

--- a/discojs/src/serialization/model.spec.ts
+++ b/discojs/src/serialization/model.spec.ts
@@ -52,7 +52,6 @@ describe('serialization', () => {
       evaluateEvery:10,
       maxEvalBatches: 10,
       blockSize: 8,
-      vocabSize: 50258
     }
     const model = new models.GPT(config)
 

--- a/discojs/src/task/training_information.ts
+++ b/discojs/src/task/training_information.ts
@@ -67,7 +67,7 @@ interface DataTypeToTrainingInformation {
 
     // maxSequenceLength: the maximum length of a input string used as input to a GPT model. It is used during preprocessing to
     // truncate strings to a maximum length. The default value is tokenizer.model_max_length
-    maxSequenceLength?: number;
+    maxSequenceLength: number;
   };
 }
 
@@ -234,8 +234,7 @@ export function isTrainingInformation(
       if (
         (typeof tokenizer !== "string" &&
           !(tokenizer instanceof PreTrainedTokenizer)) ||
-        (maxSequenceLength !== undefined &&
-          typeof maxSequenceLength !== "number")
+        (typeof maxSequenceLength !== "number")
       )
         return false;
 

--- a/discojs/src/task/training_information.ts
+++ b/discojs/src/task/training_information.ts
@@ -65,9 +65,9 @@ interface DataTypeToTrainingInformation {
     // When the tokenizer is first called, the actual object will be initialized and loaded into this field for the subsequent tokenizations.
     tokenizer: string | PreTrainedTokenizer;
 
-    // maxSequenceLength: the maximum length of a input string used as input to a GPT model. It is used during preprocessing to
+    // contextLength: the maximum length of a input string used as input to a GPT model. It is used during preprocessing to
     // truncate strings to a maximum length. The default value is tokenizer.model_max_length
-    maxSequenceLength: number;
+    contextLength: number;
   };
 }
 
@@ -224,7 +224,7 @@ export function isTrainingInformation(
     }
     case "text": {
       const {
-        maxSequenceLength,
+        contextLength,
         tokenizer,
       }: Partial<
         Omit<TrainingInformation<"text">,
@@ -234,14 +234,14 @@ export function isTrainingInformation(
       if (
         (typeof tokenizer !== "string" &&
           !(tokenizer instanceof PreTrainedTokenizer)) ||
-        (typeof maxSequenceLength !== "number")
+        (typeof contextLength !== "number")
       )
         return false;
 
       const _: TrainingInformation<"text"> = {
         ...repack,
         dataType,
-        maxSequenceLength,
+        contextLength,
         tokenizer,
       } satisfies Record<keyof TrainingInformation<"text">, unknown>;
 

--- a/discojs/src/types/data_format.ts
+++ b/discojs/src/types/data_format.ts
@@ -1,6 +1,6 @@
 import { List } from "immutable";
 
-import type { Image, processing, Tabular, Text } from "../index.js";
+import type { Image, processing, Tabular, Text, TokenizedText } from "../index.js";
 
 /**
  * The data & label format goes through various stages.
@@ -33,7 +33,7 @@ type Token = number;
 export interface ModelEncoded {
   image: [image: processing.NormalizedImage<3>, label: number];
   tabular: [row: List<number>, number];
-  text: [line: List<Token>, next: Token];
+  text: [line: TokenizedText, next: Token];
 }
 
 /** what gets outputted by the Validator, for humans */

--- a/discojs/src/validator.ts
+++ b/discojs/src/validator.ts
@@ -22,7 +22,7 @@ export class Validator<D extends DataType> {
           .zip(batch.map(([_, outputs]) => outputs))
           .map(([inferred, truth]) => inferred === truth),
       )
-      .unbatch();
+      .flatten();
 
     for await (const e of results) yield e;
   }
@@ -36,7 +36,7 @@ export class Validator<D extends DataType> {
     )
       .batch(this.task.trainingInformation.batchSize)
       .map((batch) => this.#model.predict(batch))
-      .unbatch();
+      .flatten();
 
     const predictions = await processing.postprocess(
       this.task,

--- a/webapp/cypress.config.ts
+++ b/webapp/cypress.config.ts
@@ -5,6 +5,7 @@ import * as fs from "node:fs/promises";
 export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:8081/",
+    projectId: "aps8et", // to get recordings on Cypress Cloud
     setupNodeEvents(on) {
       on("task", {
         readdir: async (p: string) =>

--- a/webapp/src/components/testing/__tests__/Testing.spec.ts
+++ b/webapp/src/components/testing/__tests__/Testing.spec.ts
@@ -28,6 +28,7 @@ const TASK: Task<"text"> = {
     batchSize: 1,
     roundDuration: 1,
     validationSplit: 0,
+    maxSequenceLength: 64,
   },
 };
 

--- a/webapp/src/components/testing/__tests__/Testing.spec.ts
+++ b/webapp/src/components/testing/__tests__/Testing.spec.ts
@@ -28,7 +28,7 @@ const TASK: Task<"text"> = {
     batchSize: 1,
     roundDuration: 1,
     validationSplit: 0,
-    maxSequenceLength: 64,
+    contextLength: 64,
   },
 };
 


### PR DESCRIPTION
Closes #654 

* Fix weight initialization from zero to random uniform -> Fixes GPT2 NaN loss
* Implement weight sharing between token embeddings and the language modeling head -> -20% memory footprint
* Improve generation with top k sampling option
* Add seed for deterministic runs
* Implement text loaders by byte chunk rather than by line which doesn't require to pad each line to the context length
* Waiting on Transformers.js [#984](https://github.com/huggingface/transformers.js/issues/984) and [#1019](https://github.com/huggingface/transformers.js/issues/1019#issuecomment-2465803843) to migrate to @huggingface/transformers v3.