### PR TITLE
docker: freeze node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN npm --workspace=discojs --workspace=discojs-node run build
 COPY server/ server/
 RUN cd server/ && npm run build
 
-FROM node:slim AS runner
+# TODO freeze to 22 until tfjs#8425 is merged
+FROM node:22-slim AS runner
 
 WORKDIR /disco
 


### PR DESCRIPTION
node 23 is out and is used as a base image in our server. it removed (after deprecation) some functions used in tfjs. I made [a PR fixing that upstream](https://github.com/tensorflow/tfjs/pull/8425) but in the meantime, let's freeze the node version to 22.