### PR TITLE
Make mnist use mean aggregation rather than secure

### DIFF
--- a/discojs/src/default_tasks/mnist.ts
+++ b/discojs/src/default_tasks/mnist.ts
@@ -30,7 +30,7 @@ export const mnist: TaskProvider<'image'> = {
         IMAGE_W: 28,
         LABEL_LIST: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
         scheme: 'decentralized',
-        aggregationStrategy: 'secure',
+        aggregationStrategy: 'mean',
         minNbOfParticipants: 3,
         maxShareValue: 100,
         tensorBackend: 'tfjs'


### PR DESCRIPTION
@rabbanitw noticed that training on mnist locally was failing.
Indeed the console shows: `webapp Error: secure aggregation is currently supported for decentralized only`

Reverting the aggregation strategy to `mean` until we support `secure` aggregation with federated learning.