### PR TITLE
Emmanuel confusion matrix

### DIFF
--- a/discojs/src/processing/index.ts
+++ b/discojs/src/processing/index.ts
@@ -108,40 +108,36 @@ export async function preprocessWithoutLabel<D extends DataType>(
 }
 
 export async function postprocess<D extends DataType>(
-  task: Task<D>,
-  dataset: Dataset<DataFormat.ModelEncoded[D][1]>,
-): Promise<Dataset<DataFormat.Inferred[D]>> {
-  switch (task.trainingInformation.dataType) {
-    case "image": {
-      // cast as typescript doesn't reduce generic type
-      const d = dataset as Dataset<DataFormat.ModelEncoded["image"][1]>;
-      const { LABEL_LIST } =
-        task.trainingInformation as TrainingInformation<"image">;
-      const labels = List(LABEL_LIST);
+	task: Task<D>,
+	encoded: DataFormat.ModelEncoded[D][1],
+): Promise<DataFormat.Inferred[D]> {
+	switch (task.trainingInformation.dataType) {
+		case "image": {
+			// cast as typescript doesn't reduce generic type
+			const index = encoded as DataFormat.ModelEncoded["image"][1];
+			const { LABEL_LIST } =
+				task.trainingInformation as TrainingInformation<"image">;
+			const labels = List(LABEL_LIST);
 
-      return d.map((index) => {
-        const v = labels.get(index);
-        if (v === undefined) throw new Error("index not found in labels");
-        return v;
-      }) as Dataset<DataFormat.Inferred[D]>;
-    }
-    case "tabular": {
-      // cast as typescript doesn't reduce generic type
-      const d = dataset as Dataset<DataFormat.ModelEncoded["tabular"][1]>;
+			const v = labels.get(index);
+			if (v === undefined) throw new Error("index not found in labels");
+			return v as DataFormat.Inferred[D];
+		}
+		case "tabular": {
+			// cast as typescript doesn't reduce generic type
+			const v = encoded as DataFormat.ModelEncoded["tabular"][1];
 
-      return d as Dataset<DataFormat.Inferred[D]>;
-    }
-    case "text": {
-      // cast as typescript doesn't reduce generic type
-      const d = dataset as Dataset<DataFormat.ModelEncoded["text"][1]>;
-      const t = task as Task<"text">;
-      const tokenizer = await models.getTaskTokenizer(t);
+			return v as DataFormat.Inferred[D];
+		}
+		case "text": {
+			// cast as typescript doesn't reduce generic type
+			const token = encoded as DataFormat.ModelEncoded["text"][1];
+			const t = task as Task<"text">;
+			const tokenizer = await models.getTaskTokenizer(t);
 
-      return d.map((token) => tokenizer.decode([token])) as Dataset<
-        DataFormat.Inferred[D]
-      >;
-    }
-  }
+			return tokenizer.decode([token]) as DataFormat.Inferred[D];
+		}
+	}
 }
 
 function extractToNumbers(columns: Iterable<string>, row: Tabular) {

--- a/discojs/src/validator.ts
+++ b/discojs/src/validator.ts
@@ -15,21 +15,23 @@ export class Validator<D extends DataType> {
   async *test(
     dataset: Dataset<DataFormat.Raw[D]>,
   ): AsyncGenerator<{ result: boolean; predicted: DataFormat.Inferred[D]; truth : number }, void> {
-    const results = (await processing.preprocess(this.task, dataset))
-      .batch(this.task.trainingInformation.batchSize)
+    const preprocessed = await processing.preprocess(this.task, dataset);
+    const batched = preprocessed.batch(this.task.trainingInformation.batchSize);
+
+    const initialResults = batched
       .map(async (batch) =>
         (await this.#model.predict(batch.map(([inputs, _]) => inputs)))
-      .zip(batch.map(([_, outputs]) => outputs))
-      .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred, truth : truth })),
-    )
-    .flatten();
+          .zip(batch.map(([_, outputs]) => outputs))
+          .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred, truth })),
+      )
+      .flatten();
 
     const predictions = await processing.postprocess(
       this.task,
-      results.map(({ predicted }) => predicted),
+      initialResults.map(({ predicted }) => predicted),
     );
 
-    const finalResults = results.zip(predictions).map(([result, predicted]) => ({
+    const finalResults = initialResults.zip(predictions).map(([result, predicted]) => ({
       ...result,
       predicted,
     }));

--- a/discojs/src/validator.ts
+++ b/discojs/src/validator.ts
@@ -14,13 +14,13 @@ export class Validator<D extends DataType> {
   /** infer every line of the dataset and check that it is as labelled */
   async *test(
     dataset: Dataset<DataFormat.Raw[D]>,
-  ): AsyncGenerator<boolean, void> {
+  ): AsyncGenerator<{ result: boolean; predicted: DataFormat.ModelEncoded[D][1] }, void> {
     const results = (await processing.preprocess(this.task, dataset))
       .batch(this.task.trainingInformation.batchSize)
       .map(async (batch) =>
         (await this.#model.predict(batch.map(([inputs, _]) => inputs)))
           .zip(batch.map(([_, outputs]) => outputs))
-          .map(([inferred, truth]) => inferred === truth),
+          .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred })),
       )
       .flatten();
 

--- a/discojs/src/validator.ts
+++ b/discojs/src/validator.ts
@@ -14,17 +14,27 @@ export class Validator<D extends DataType> {
   /** infer every line of the dataset and check that it is as labelled */
   async *test(
     dataset: Dataset<DataFormat.Raw[D]>,
-  ): AsyncGenerator<{ result: boolean; predicted: DataFormat.ModelEncoded[D][1]; truth : DataFormat.ModelEncoded[D][1] }, void> {
+  ): AsyncGenerator<{ result: boolean; predicted: DataFormat.Inferred[D]; truth : number }, void> {
     const results = (await processing.preprocess(this.task, dataset))
       .batch(this.task.trainingInformation.batchSize)
       .map(async (batch) =>
         (await this.#model.predict(batch.map(([inputs, _]) => inputs)))
-          .zip(batch.map(([_, outputs]) => outputs))
-          .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred, truth : truth })),
-      )
-      .flatten();
+      .zip(batch.map(([_, outputs]) => outputs))
+      .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred, truth : truth })),
+    )
+    .flatten();
 
-    for await (const e of results) yield e;
+    const predictions = await processing.postprocess(
+      this.task,
+      results.map(({ predicted }) => predicted),
+    );
+
+    const finalResults = results.zip(predictions).map(([result, predicted]) => ({
+      ...result,
+      predicted,
+    }));
+
+    for await (const e of finalResults) yield e;
   }
 
   /** use the model to predict every line of the dataset */

--- a/discojs/src/validator.ts
+++ b/discojs/src/validator.ts
@@ -1,4 +1,4 @@
-import type { Dataset, DataFormat, DataType, Model, Task } from "./index.js";
+import { Dataset, DataFormat, DataType, Model, Task } from "./index.js";
 import { processing } from "./index.js";
 
 export class Validator<D extends DataType> {
@@ -12,32 +12,25 @@ export class Validator<D extends DataType> {
   }
 
   /** infer every line of the dataset and check that it is as labelled */
-  async *test(
-    dataset: Dataset<DataFormat.Raw[D]>,
-  ): AsyncGenerator<{ result: boolean; predicted: DataFormat.Inferred[D]; truth : number }, void> {
-    const preprocessed = await processing.preprocess(this.task, dataset);
-    const batched = preprocessed.batch(this.task.trainingInformation.batchSize);
+	async test(
+		dataset: Dataset<DataFormat.Raw[D]>,
+	): Promise<Dataset<Record<"predicted" | "truth", DataFormat.Inferred[D]>>> {
+		const preprocessed = await processing.preprocess(this.task, dataset);
+		const batched = preprocessed.batch(this.task.trainingInformation.batchSize);
 
-    const initialResults = batched
-      .map(async (batch) =>
-        (await this.#model.predict(batch.map(([inputs, _]) => inputs)))
-          .zip(batch.map(([_, outputs]) => outputs))
-          .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred, truth })),
-      )
-      .flatten();
+		const predictionWithTruth = batched
+			.map(async (batch) =>
+				(await this.#model.predict(batch.map(([inputs, _]) => inputs))).zip(
+					batch.map(([_, outputs]) => outputs),
+				),
+			)
+			.flatten();
 
-    const predictions = await processing.postprocess(
-      this.task,
-      initialResults.map(({ predicted }) => predicted),
-    );
-
-    const finalResults = initialResults.zip(predictions).map(([result, predicted]) => ({
-      ...result,
-      predicted,
-    }));
-
-    for await (const e of finalResults) yield e;
-  }
+		return predictionWithTruth.map(async ([predicted, truth]) => ({
+			predicted: await processing.postprocess(this.task, predicted),
+			truth: await processing.postprocess(this.task, truth),
+		}));
+	}
 
   /** use the model to predict every line of the dataset */
   async *infer(
@@ -50,10 +43,9 @@ export class Validator<D extends DataType> {
       .map((batch) => this.#model.predict(batch))
       .flatten();
 
-    const predictions = await processing.postprocess(
-      this.task,
-      modelPredictions,
-    );
+		const predictions = modelPredictions.map((prediction) =>
+			processing.postprocess(this.task, prediction),
+		);
 
     for await (const e of predictions) yield e;
   }

--- a/discojs/src/validator.ts
+++ b/discojs/src/validator.ts
@@ -14,13 +14,13 @@ export class Validator<D extends DataType> {
   /** infer every line of the dataset and check that it is as labelled */
   async *test(
     dataset: Dataset<DataFormat.Raw[D]>,
-  ): AsyncGenerator<{ result: boolean; predicted: DataFormat.ModelEncoded[D][1] }, void> {
+  ): AsyncGenerator<{ result: boolean; predicted: DataFormat.ModelEncoded[D][1]; truth : DataFormat.ModelEncoded[D][1] }, void> {
     const results = (await processing.preprocess(this.task, dataset))
       .batch(this.task.trainingInformation.batchSize)
       .map(async (batch) =>
         (await this.#model.predict(batch.map(([inputs, _]) => inputs)))
           .zip(batch.map(([_, outputs]) => outputs))
-          .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred })),
+          .map(([inferred, truth]) => ({ result: inferred === truth, predicted: inferred, truth : truth })),
       )
       .flatten();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.5.tgz",
-      "integrity": "sha512-v+XHd9XmWbufxF1/bTaVm2yhbxY+TB4YtWRqF2zaXBlDNMkls34KiATz0AVDLavL3iB6bQk9/7n3oY1EoLSWGA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.7.tgz",
+      "integrity": "sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -209,14 +209,29 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.13.0",
+        "qs": "6.13.1",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "^4.1.3",
+        "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/qs": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@cypress/request/node_modules/uuid": {
@@ -4648,9 +4663,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
       "funding": [
         {
           "type": "github",
@@ -5237,13 +5252,13 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "13.15.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.15.1.tgz",
-      "integrity": "sha512-DwUFiKXo4lef9kA0M4iEhixFqoqp2hw8igr0lTqafRb9qtU3X0XGxKbkSYsUFdkrAkphc7MPDxoNPhk5pj9PVg==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.4",
+        "@cypress/request": "^3.0.6",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -5254,6 +5269,7 @@
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
+        "ci-info": "^4.0.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
         "commander": "^6.2.1",
@@ -5268,7 +5284,6 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -7913,18 +7928,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
     "node_modules/is-core-module": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
@@ -8373,19 +8376,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/jsdom/node_modules/tough-cookie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
-      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/jsdom/node_modules/webidl-conversions": {
@@ -10591,12 +10581,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "license": "MIT"
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -10640,6 +10624,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10668,12 +10653,6 @@
       "engines": {
         "node": ">=0.4.x"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -10945,12 +10924,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
       "license": "ISC"
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -12401,7 +12374,6 @@
       "version": "6.1.55",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.55.tgz",
       "integrity": "sha512-HxQR/9roQ07Pwc8RyyrJMAxRz5/ssoF3qIPPUiIo3zUt6yMdmYZjM2OZIFMiZ3jHyz9jrGHEHuQZrUhoc1LkDw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.55"
@@ -12414,7 +12386,6 @@
       "version": "6.1.55",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.55.tgz",
       "integrity": "sha512-BL+BuKHHaOpntE5BGI6naXjULU6aRlgaYdfDHR3T/hdbNTWkWUZ9yuc11wGnwgpvRwlyUiIK+QohYK3olaVU6Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -12492,27 +12463,15 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.0.tgz",
+      "integrity": "sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -12848,16 +12807,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url/node_modules/punycode": {

--- a/server/tests/validator.spec.ts
+++ b/server/tests/validator.spec.ts
@@ -25,7 +25,7 @@ describe("validator", () => {
 
     let hits = 0;
     let size = 0;
-    for await (const correct of validator.test(dataset)) {
+    for await (const correct of await validator.test(dataset)) {
       if (correct) hits++;
       size++;
     }
@@ -45,7 +45,7 @@ describe("validator", () => {
 
     let hits = 0;
     let size = 0;
-    for await (const correct of validator.test(dataset)) {
+    for await (const correct of await validator.test(dataset)) {
       if (correct) hits++;
       size++;
     }
@@ -73,7 +73,7 @@ describe("validator", () => {
 
     let hits = 0;
     let size = 0;
-    for await (const correct of validator.test(dataset)) {
+    for await (const correct of await validator.test(dataset)) {
       if (correct) hits++;
       size++;
     }

--- a/server/tests/validator.spec.ts
+++ b/server/tests/validator.spec.ts
@@ -31,7 +31,7 @@ describe("validator", () => {
     }
 
     expect(hits / size).to.be.greaterThan(0.3);
-  }).timeout("5s");
+  }).timeout("10s");
 
   it("can read and predict randomly on titanic", async () => {
     const provider = defaultTasks.titanic;

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -142,7 +142,7 @@ const props = defineProps<{
 interface Tested {
   image: List<{
     input: { filename: string; image: ImageData };
-    output: { truth: string; correct: boolean };
+    output: { truth: string; correct: boolean; predicted : number };
   }>;
   tabular: {
     labels: {
@@ -151,7 +151,7 @@ interface Tested {
     };
     results: List<{
       input: List<string>;
-      output: { truth: string; correct: boolean };
+      output: { truth: string; correct: boolean; predicted : number };
     }>;
   };
   // TODO what to show?
@@ -159,7 +159,7 @@ interface Tested {
 }
 
 const dataset = ref<LabeledDataset[D]>();
-const generator = ref<AsyncGenerator<boolean, void>>();
+const generator = ref<AsyncGenerator<{result : boolean, predicted : number}, void>>();
 const tested = ref<Tested[D]>();
 
 const visitedSamples = computed<number>(() => {
@@ -179,7 +179,7 @@ const visitedSamples = computed<number>(() => {
 });
 const currentAccuracy = computed<string>(() => {
   if (tested.value === undefined) return "0";
-
+  console.log(tested.value);
   let hits: number | undefined;
   switch (props.task.trainingInformation.dataType) {
     case "image":
@@ -250,7 +250,7 @@ async function startImageTest(
     generator.value = validator.test(
       dataset.map(({ image, label }) => [image, label] as [Image, string]),
     );
-    for await (const [{ filename, image, label }, correct] of dataset.zip(
+    for await (const [{ filename, image, label }, {result, predicted}] of dataset.zip(
       toRaw(generator.value),
     )) {
       results = results.push({
@@ -264,7 +264,8 @@ async function startImageTest(
         },
         output: {
           truth: label,
-          correct,
+          correct: result,
+          predicted: predicted,
         },
       });
 
@@ -295,7 +296,7 @@ async function startTabularTest(
   let results: Tested["tabular"]["results"] = List();
   try {
     generator.value = validator.test(dataset);
-    for await (const [row, correct] of dataset.zip(toRaw(generator.value))) {
+    for await (const [row, {result, predicted}] of dataset.zip(toRaw(generator.value))) {
       const truth = row[outputColumn];
       if (truth === undefined)
         throw new Error("row doesn't have expected output column");
@@ -308,8 +309,9 @@ async function startTabularTest(
           return ret;
         }),
         output: {
-          truth,
-          correct,
+          truth: truth,
+          correct: result,
+          predicted : predicted,
         },
       });
 
@@ -330,8 +332,8 @@ async function startTextTest(
 
   try {
     generator.value = validator.test(dataset);
-    for await (const correct of toRaw(generator.value)) {
-      results = results.push({ output: { correct } });
+    for await (const {result, predicted} of toRaw(generator.value)) {
+      results = results.push({ output:  {correct : result} });
       tested.value = results as Tested[D];
     }
   } finally {

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -124,7 +124,7 @@
           "
           :rows="
             (tested as Tested['tabular']).results.map(({ input, output }) =>
-              input.concat(output.truth).push(output.correct.toString()),
+              input.concat(output.label).push(output.correct.toString()),
             )
           "
         />
@@ -180,7 +180,7 @@ interface Tested {
     };
     results: List<{
       input: List<string>;
-      output: { truth: string; correct: boolean; predicted : number, label : number };
+      output: { truth: number; correct: boolean; predicted : number, label : string };
     }>;
   };
   // TODO what to show?
@@ -217,7 +217,7 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
       labels = (props.task as Task<"image">).trainingInformation.LABEL_LIST;
       break;
     case "tabular" :
-      labels = (props.task as Task<"image">).trainingInformation.LABEL_LIST;
+      labels = ["0", "1"]; // binary classification
       break;
     case "text" :
       return undefined;
@@ -240,7 +240,10 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
     //case "text":
     //  return undefined;
     case "tabular":
-        break;
+      (tested.value as Tested["tabular"]).results.map(
+        ({ output }) => matrix[output.predicted][output.truth] = matrix[output.predicted][output.truth] + 1,
+      );
+      break;
     default: {
       const _: never = props.task.trainingInformation;
       throw new Error("should never happen");
@@ -383,10 +386,10 @@ async function startTabularTest(
           return ret;
         }),
         output: {
-          truth: truth_label,
+          truth: truth,
           correct: result,
           predicted : predicted,
-          label : truth,
+          label : truth_label,
         },
       });
 
@@ -458,7 +461,7 @@ function saveCsv(): void {
             .toArray(),
           ...t.results.map((result) =>
             result.input
-              .concat(result.output.truth)
+              .concat(result.output.label)
               .push(result.output.correct.toString())
               .toArray(),
           ),

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -235,7 +235,7 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
       throw new Error("should never happen");
     }
   }
-  const size = Math.max(labels.size, Math.max(...Array.from(labels)));
+  const size = Math.max(labels.size, ...labels);
   // Initialize the confusion matrix
   const matrix = Array.from({ length: size }, () => Array(size).fill(0));
   

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -67,7 +67,7 @@
       <thead>
         <tr>
           <th class="px-0 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">
-            <span class="">Label \ Prediction</span>
+            Label \ Prediction
           </th>
           <th v-for="(label, index) in Object.keys(confusionMatrix.matrix)" :key="'header-' + index" class="text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">
             {{ label }}

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -59,7 +59,10 @@
     </div>
 
     
-    <div v-if="confusionMatrix && confusionMatrix.matrix && Object.keys(confusionMatrix.matrix).length > 0" class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
+    <div
+      v-if="confusionMatrix !== undefined"
+      class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md"
+    >
       <h4 class="p-4 text-lg font-semibold text-slate-500 dark:text-slate-300">
       Confusion Matrix
     </h4>
@@ -69,18 +72,28 @@
           <th class="px-0 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">
             Label \ Prediction
           </th>
-          <th v-for="(label, index) in Object.keys(confusionMatrix.matrix)" :key="'header-' + index" class="text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">
-            {{ label }}
-          </th>
+          <th
+              v-for="(_, label) in confusionMatrix"
+              :key="label"
+              class="text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider"
+            >
+              {{ label }}
+            </th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(rowLabel, rowIndex) in Object.keys(confusionMatrix.matrix)" :key="'row-' + rowIndex">
-          <td class="py-2 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2">
-            {{ rowLabel }}
+        <tr v-for="(_, row) in confusionMatrix" :key="row">
+          <td
+            class="py-2 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2"
+          >
+            {{ row }}
           </td>
-          <td v-for="(colLabel, colIndex) in Object.keys(confusionMatrix.matrix[rowLabel])" :key="'col-' + colIndex" class="whitespace-nowrap text-sm dark:text-gray-300 text-gray-700">
-            {{ confusionMatrix.matrix[rowLabel][colLabel] }}
+          <td
+            v-for="(_, col) in confusionMatrix[row]"
+            :key="col"
+            class="whitespace-nowrap text-sm dark:text-gray-300 text-gray-700"
+          >
+            {{ confusionMatrix[row][col] }}
           </td>
         </tr>
       </tbody>
@@ -158,7 +171,6 @@ import ImageCard from "@/components/containers/ImageCard.vue";
 import LabeledDatasetInput from "@/components/dataset_input/LabeledDatasetInput.vue";
 import TableLayout from "@/components/containers/TableLayout.vue";
 import type { LabeledDataset } from "@/components/dataset_input/types.js";
-import { Map } from 'immutable';
 
 const debug = createDebug("webapp:testing:TestSteps");
 const toaster = useToaster();
@@ -213,21 +225,21 @@ const visitedSamples = computed<number>(() => {
   }
 });
 
-const confusionMatrix = computed<{ labels: Map<number, string>; matrix: { [key: string]: { [key: string]: number } } }>(() => {
-  if (tested.value === undefined) {
-    return { labels: Map<number, string>(), matrix: {} };
-  }
-  let labels : string[] = [];
+const confusionMatrix = computed<{ [key: string]: { [key: string]: number } } | undefined>(() => {
+  if (tested.value === undefined) return undefined;
+
+  let labels: string[] = [];
   switch (props.task.trainingInformation.dataType) {
-    case "image" : 
+    case "image":
       labels = (props.task as Task<"image">).trainingInformation.LABEL_LIST;
       break;
-    case "tabular" :
+    case "tabular":
       labels = ["0", "1"]; // binary classification
       break;
-    case "text" :
-      return { labels: Map<number, string>(), matrix: {} };    default: {
-    const _: never = props.task.trainingInformation;
+    case "text":
+      return undefined;
+    default: {
+      const _: never = props.task.trainingInformation;
       throw new Error("should never happen");
     }
   }
@@ -237,9 +249,9 @@ const confusionMatrix = computed<{ labels: Map<number, string>; matrix: { [key: 
 
   // Initialize the confusion matrix
   labels.forEach((label) => {
-    matrix[label.toString()] = {};
+    matrix[label] = {};
     labels.forEach((innerLabel) => {
-      matrix[label.toString()][innerLabel.toString()] = 0;
+      matrix[label][innerLabel] = 0;
     });
   });
 
@@ -249,8 +261,6 @@ const confusionMatrix = computed<{ labels: Map<number, string>; matrix: { [key: 
           ( {output} ) => matrix[output.label][output.predicted] = matrix[output.label][output.predicted] + 1,
         );
         break;
-    //case "text":
-    //  return undefined;
     case "tabular":
       (tested.value as Tested["tabular"]).results.map(
         ({ output }) => matrix[output.truth][output.predicted] = matrix[output.truth][output.predicted] + 1,
@@ -261,8 +271,8 @@ const confusionMatrix = computed<{ labels: Map<number, string>; matrix: { [key: 
       throw new Error("should never happen");
     }
   }
-  const mapLabels = Map(labels.map((label, index) => [index, label]));
-  return {labels : mapLabels, matrix : matrix};
+
+  return matrix;
 })
 
 const currentAccuracy = computed<string>(() => {

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -24,7 +24,7 @@
     <IconCard class="mx-auto mt-10 lg:w-1/2" title-placement="left">
       <template #title> Test &amp; validate your model </template>
 
-      <div v-show="generator === undefined">
+      <div v-show="controller === undefined">
         By clicking the button below, you will be able to validate your model
         against a chosen dataset of yours. Below, once you assessed the model,
         you can compare the ground truth and the predicted values
@@ -32,7 +32,7 @@
           <CustomButton @click="startTest()"> test </CustomButton>
         </div>
       </div>
-      <div v-show="generator !== undefined">
+      <div v-show="controller !== undefined">
         <div class="flex justify-center">
           <CustomButton @click="stopTest()"> stop testing </CustomButton>
         </div>
@@ -172,7 +172,12 @@ const props = defineProps<{
 interface Tested {
   image: List<{
     input: { filename: string; image: ImageData };
-    output: { truth: number; correct: boolean; predicted : string, label : string };
+    output: {
+      truth: string;
+      correct: boolean;
+      predicted: string;
+      label: string;
+    };
   }>;
   tabular: {
     labels: {
@@ -189,7 +194,7 @@ interface Tested {
 }
 
 const dataset = ref<LabeledDataset[D]>();
-const generator = ref<AsyncGenerator<{result : boolean, predicted : string | number; truth : number}, void>>();
+const controller = ref<AbortController>();
 const tested = ref<Tested[D]>();
 
 const visitedSamples = computed<number>(() => {
@@ -330,11 +335,15 @@ async function startImageTest(
   let results: Tested["image"] = List();
   
   try {
-    generator.value = validator.test(
-      dataset.map(({ image, label }) => [image, label] as [Image, string]),
-    );
-    for await (const [{ filename, image, label }, {result, predicted, truth}] of dataset.zip(
-      toRaw(generator.value),
+    controller.value = new AbortController();
+
+    for await (const [
+      { filename, image, label },
+      { predicted, truth },
+    ] of dataset.zip(
+      await validator.test(
+        dataset.map(({ image, label }) => [image, label] as [Image, string]),
+      ),
     )) {
       results = results.push({
         input: {
@@ -346,17 +355,19 @@ async function startImageTest(
           ),
         },
         output: {
-          label: label,
-          correct: result,
-          predicted: String(predicted),
-          truth : truth,
+          label,
+          correct: predicted === truth,
+          predicted,
+          truth,
         },
       });
 
       tested.value = results as Tested[D];
+
+      if (controller.value.signal.aborted) break;
     }
   } finally {
-    generator.value = undefined;
+    controller.value = undefined;
   }
 }
 
@@ -379,8 +390,11 @@ async function startTabularTest(
 
   let results: Tested["tabular"]["results"] = List();
   try {
-    generator.value = validator.test(dataset);
-    for await (const [row, {result, predicted, truth}] of dataset.zip(toRaw(generator.value))) {
+    controller.value = new AbortController();
+
+    for await (const [row, { predicted, truth }] of dataset.zip(
+      await validator.test(dataset),
+    )) {
       const truth_label = row[outputColumn];
       if (truth_label === undefined)
         throw new Error("row doesn't have expected output column");
@@ -393,17 +407,19 @@ async function startTabularTest(
           return ret;
         }),
         output: {
-          truth: truth,
-          correct: result,
-          predicted : Number(predicted),
-          label : truth_label,
+          truth,
+          correct: truth === predicted,
+          predicted,
+          label: truth_label,
         },
       });
 
       tested.value = { labels, results } as Tested[D];
+
+      if (controller.value.signal.aborted) break;
     }
   } finally {
-    generator.value = undefined;
+    controller.value = undefined;
   }
 }
 
@@ -416,22 +432,24 @@ async function startTextTest(
   let results: Tested["text"] = List();
 
   try {
-    generator.value = validator.test(dataset);
-    for await (const {result} of toRaw(generator.value)) {
-      results = results.push({ output:  {correct : result} });
+    controller.value = new AbortController();
+
+    for await (const { predicted, truth } of await validator.test(dataset)) {
+      results = results.push({ output: { correct: predicted === truth } });
       tested.value = results as Tested[D];
+      if (controller.value.signal.aborted) break;
     }
   } finally {
-    generator.value = undefined;
+    controller.value = undefined;
   }
 }
 
 async function stopTest(): Promise<void> {
-  const g = generator.value;
-  if (g === undefined) return;
+  const c = controller.value;
+  if (c === undefined) return;
 
-  generator.value = undefined;
-  g.return();
+  controller.value = undefined;
+  c.abort();
 }
 
 function saveCsv(): void {

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -58,47 +58,51 @@
       </div>
     </div>
 
-    
-    <div
+    <IconCard
       v-if="confusionMatrix !== undefined"
       class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md"
     >
-      <h4 class="p-4 text-lg font-semibold text-slate-500 dark:text-slate-300">
-      Confusion Matrix
-    </h4>
-    <table class="min-w-full divide-y divide-slate-600 dark:divide-slate-400 text-center">
-      <thead>
-        <tr>
-          <th class="px-0 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">
-            Label \ Prediction
-          </th>
-          <th
-              v-for="(_, label) in confusionMatrix"
-              :key="label"
-              class="text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider"
-            >
-              {{ label }}
-            </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="(_, row) in confusionMatrix" :key="row">
-          <td
-            class="py-2 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2"
-          >
-            {{ row }}
-          </td>
-          <td
-            v-for="(_, col) in confusionMatrix[row]"
-            :key="col"
-            class="whitespace-nowrap text-sm dark:text-gray-300 text-gray-700"
-          >
-            {{ confusionMatrix[row][col] }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+      <template #title> Confusion Matrix </template>
+
+      <div class="flex flex-row w-full justify-center">
+        <table
+          class="divide-y-2 divide-slate-600 dark:divide-slate-400 text-center"
+        >
+          <thead>
+            <tr>
+              <th
+                class="p-2 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header"
+              >
+                Label \ Prediction
+              </th>
+              <th
+                v-for="(_, label) in confusionMatrix"
+                :key="label"
+                class="p-2 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider"
+              >
+                {{ label }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(_, row) in confusionMatrix" :key="row">
+              <td
+                class="p-2 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2"
+              >
+                {{ row }}
+              </td>
+              <td
+                v-for="(_, col) in confusionMatrix[row]"
+                :key="col"
+                class="p-2 whitespace-nowrap text-sm dark:text-gray-300 text-gray-700"
+              >
+                {{ confusionMatrix[row][col] }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </IconCard>
 
     <div v-if="tested !== undefined">
       <div class="mx-auto lg:w-1/2 text-center pb-8">

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -65,20 +65,20 @@
       <table class="min-w-full divide-y divide-slate-600 dark:divide-slate-400 text-center">
         <thead>
           <tr>
-            <th class="pl-6 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">                  
+            <th class="px-0 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">                  
               <span class="">Label \ Prediction</span>
             </th>              
-            <th v-for="(label, index) in confusionMatrix.matrix[0]" :key="'header-' + index" class="px-6 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">
+            <th v-for="(label, index) in confusionMatrix.matrix[0]" :key="'header-' + index" class="text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">
               {{ confusionMatrix.labels.get(index) }}
             </th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="(row, rowIndex) in confusionMatrix.matrix" :key="'row-' + rowIndex">
-            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2">
+            <td class="py-2 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2">
               {{ confusionMatrix.labels.get(rowIndex) }}
             </td>
-            <td v-for="(value, colIndex) in row" :key="'col-' + colIndex" class="px-6 py-4 whitespace-nowrap text-sm dark:text-gray-300 text-gray-700">
+            <td v-for="(value, colIndex) in row" :key="'col-' + colIndex" class="whitespace-nowrap text-sm dark:text-gray-300 text-gray-700">
               {{ value }}
             </td>
           </tr>

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -234,14 +234,14 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
   switch (props.task.trainingInformation.dataType) {
     case "image":
         (tested.value as Tested["image"]).map(
-          ( {output} ) => matrix[output.predicted][output.truth] = matrix[output.predicted][output.truth] + 1,
+          ( {output} ) => matrix[output.truth][output.predicted] = matrix[output.truth][output.predicted] + 1,
         );
         break;
     //case "text":
     //  return undefined;
     case "tabular":
       (tested.value as Tested["tabular"]).results.map(
-        ({ output }) => matrix[output.predicted][output.truth] = matrix[output.predicted][output.truth] + 1,
+        ({ output }) => matrix[output.truth][output.predicted] = matrix[output.truth][output.predicted] + 1,
       );
       break;
     default: {

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -209,33 +209,25 @@ const visitedSamples = computed<number>(() => {
 
 const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[][]} | undefined>(() => {
   if (tested.value === undefined) return undefined;
-  const labels = Set<number>(); // l'idéal serait de tous les avoir en one try, sinon c'est dégueulasse
-  const mapLabels = Map<number, string>();
-  
-  // get all the labels
+  // const labels = Set<number>(); // l'idéal serait de tous les avoir en one try, sinon c'est dégueulasse
+  // const mapLabels = Map<number, string>();
+  let labels : string[] = [];
   switch (props.task.trainingInformation.dataType) {
-    case "image":
-      (tested.value as Tested["image"]).forEach(({ output }) => {
-        labels.add(output.truth);
-        labels.add(output.predicted);
-        mapLabels.set(output.truth, output.label);
-      });
+    case "image" : 
+      labels = (props.task as Task<"image">).trainingInformation.LABEL_LIST;
       break;
-    case "text":
+    case "tabular" :
+      labels = (props.task as Task<"image">).trainingInformation.LABEL_LIST;
+      break;
+    case "text" :
       return undefined;
-    case "tabular":
-      (tested.value as Tested["tabular"]).results.forEach(({ output }) => {
-        labels.add(output.label);
-        labels.add(output.predicted);
-        mapLabels.set(output.label, output.truth);
-      });
-      break;
     default: {
       const _: never = props.task.trainingInformation;
       throw new Error("should never happen");
     }
   }
-  const size = Math.max(labels.size, ...labels);
+
+  const size = labels.length;
   // Initialize the confusion matrix
   const matrix = Array.from({ length: size }, () => Array(size).fill(0));
   
@@ -248,17 +240,13 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
     //case "text":
     //  return undefined;
     case "tabular":
-        (tested.value as Tested["tabular"]).results.forEach( ({output}) => {
-          labels.add(output.label);
-          labels.add(output.predicted);
-          mapLabels.set(output.label, output.truth);
-        });
         break;
     default: {
       const _: never = props.task.trainingInformation;
       throw new Error("should never happen");
     }
   }
+  const mapLabels = Map(labels.map((label, index) => [index, label]));
   return {labels : mapLabels, matrix : matrix};
 })
 
@@ -330,7 +318,7 @@ async function startImageTest(
 ): Promise<void> {
   const validator = new Validator(task, model);
   let results: Tested["image"] = List();
-
+  
   try {
     generator.value = validator.test(
       dataset.map(({ image, label }) => [image, label] as [Image, string]),

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -227,7 +227,6 @@ const confusionMatrix = computed<{ labels: Map<number, string>; matrix: { [key: 
     }
   }
 
-  const size = labels.length;
   // Initialize the confusion matrix
   const matrix: { [key: string]: { [key: string]: number } } = {};
 
@@ -258,8 +257,6 @@ const confusionMatrix = computed<{ labels: Map<number, string>; matrix: { [key: 
     }
   }
   const mapLabels = Map(labels.map((label, index) => [index, label]));
-  console.log(mapLabels)
-  console.log(matrix)
   return {labels : mapLabels, matrix : matrix};
 })
 

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -58,33 +58,34 @@
       </div>
     </div>
 
-    <div v-if="confusionMatrix && confusionMatrix.matrix.length > 0" class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
+    
+    <div v-if="confusionMatrix && confusionMatrix.matrix && Object.keys(confusionMatrix.matrix).length > 0" class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
       <h4 class="p-4 text-lg font-semibold text-slate-500 dark:text-slate-300">
-        Confusion Matrix
-      </h4>
-      <table class="min-w-full divide-y divide-slate-600 dark:divide-slate-400 text-center">
-        <thead>
-          <tr>
-            <th class="px-0 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">                  
-              <span class="">Label \ Prediction</span>
-            </th>              
-            <th v-for="(label, index) in confusionMatrix.matrix[0]" :key="'header-' + index" class="text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">
-              {{ confusionMatrix.labels.get(index) }}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(row, rowIndex) in confusionMatrix.matrix" :key="'row-' + rowIndex">
-            <td class="py-2 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2">
-              {{ confusionMatrix.labels.get(rowIndex) }}
-            </td>
-            <td v-for="(value, colIndex) in row" :key="'col-' + colIndex" class="whitespace-nowrap text-sm dark:text-gray-300 text-gray-700">
-              {{ value }}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+      Confusion Matrix
+    </h4>
+    <table class="min-w-full divide-y divide-slate-600 dark:divide-slate-400 text-center">
+      <thead>
+        <tr>
+          <th class="px-0 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">
+            <span class="">Label \ Prediction</span>
+          </th>
+          <th v-for="(label, index) in Object.keys(confusionMatrix.matrix)" :key="'header-' + index" class="text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">
+            {{ label }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(rowLabel, rowIndex) in Object.keys(confusionMatrix.matrix)" :key="'row-' + rowIndex">
+          <td class="py-2 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2">
+            {{ rowLabel }}
+          </td>
+          <td v-for="(colLabel, colIndex) in Object.keys(confusionMatrix.matrix[rowLabel])" :key="'col-' + colIndex" class="whitespace-nowrap text-sm dark:text-gray-300 text-gray-700">
+            {{ confusionMatrix.matrix[rowLabel][colLabel] }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
     <div v-if="tested !== undefined">
       <div class="mx-auto lg:w-1/2 text-center pb-8">
@@ -157,7 +158,7 @@ import ImageCard from "@/components/containers/ImageCard.vue";
 import LabeledDatasetInput from "@/components/dataset_input/LabeledDatasetInput.vue";
 import TableLayout from "@/components/containers/TableLayout.vue";
 import type { LabeledDataset } from "@/components/dataset_input/types.js";
-import { Map, Set } from 'immutable';
+import { Map } from 'immutable';
 
 const debug = createDebug("webapp:testing:TestSteps");
 const toaster = useToaster();
@@ -171,7 +172,7 @@ const props = defineProps<{
 interface Tested {
   image: List<{
     input: { filename: string; image: ImageData };
-    output: { truth: number; correct: boolean; predicted : number, label : string };
+    output: { truth: number; correct: boolean; predicted : string, label : string };
   }>;
   tabular: {
     labels: {
@@ -188,7 +189,7 @@ interface Tested {
 }
 
 const dataset = ref<LabeledDataset[D]>();
-const generator = ref<AsyncGenerator<{result : boolean, predicted : number; truth : number}, void>>();
+const generator = ref<AsyncGenerator<{result : boolean, predicted : string | number; truth : number}, void>>();
 const tested = ref<Tested[D]>();
 
 const visitedSamples = computed<number>(() => {
@@ -207,10 +208,10 @@ const visitedSamples = computed<number>(() => {
   }
 });
 
-const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[][]} | undefined>(() => {
-  if (tested.value === undefined) return undefined;
-  // const labels = Set<number>(); // l'idéal serait de tous les avoir en one try, sinon c'est dégueulasse
-  // const mapLabels = Map<number, string>();
+const confusionMatrix = computed<{ labels: Map<number, string>; matrix: { [key: string]: { [key: string]: number } } }>(() => {
+  if (tested.value === undefined) {
+    return { labels: Map<number, string>(), matrix: {} };
+  }
   let labels : string[] = [];
   switch (props.task.trainingInformation.dataType) {
     case "image" : 
@@ -220,21 +221,28 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
       labels = ["0", "1"]; // binary classification
       break;
     case "text" :
-      return undefined;
-    default: {
-      const _: never = props.task.trainingInformation;
+      return { labels: Map<number, string>(), matrix: {} };    default: {
+    const _: never = props.task.trainingInformation;
       throw new Error("should never happen");
     }
   }
 
   const size = labels.length;
   // Initialize the confusion matrix
-  const matrix = Array.from({ length: size }, () => Array(size).fill(0));
-  
+  const matrix: { [key: string]: { [key: string]: number } } = {};
+
+  // Initialize the confusion matrix
+  labels.forEach((label) => {
+    matrix[label.toString()] = {};
+    labels.forEach((innerLabel) => {
+      matrix[label.toString()][innerLabel.toString()] = 0;
+    });
+  });
+
   switch (props.task.trainingInformation.dataType) {
     case "image":
         (tested.value as Tested["image"]).map(
-          ( {output} ) => matrix[output.truth][output.predicted] = matrix[output.truth][output.predicted] + 1,
+          ( {output} ) => matrix[output.label][output.predicted] = matrix[output.label][output.predicted] + 1,
         );
         break;
     //case "text":
@@ -250,6 +258,8 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
     }
   }
   const mapLabels = Map(labels.map((label, index) => [index, label]));
+  console.log(mapLabels)
+  console.log(matrix)
   return {labels : mapLabels, matrix : matrix};
 })
 
@@ -341,7 +351,7 @@ async function startImageTest(
         output: {
           label: label,
           correct: result,
-          predicted: predicted,
+          predicted: String(predicted),
           truth : truth,
         },
       });
@@ -388,7 +398,7 @@ async function startTabularTest(
         output: {
           truth: truth,
           correct: result,
-          predicted : predicted,
+          predicted : Number(predicted),
           label : truth_label,
         },
       });

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -56,34 +56,34 @@
           <span class="text-sm">&nbsp;samples visited</span>
         </div>
       </div>
+    </div>
 
-      <div v-if="confusionMatrix && confusionMatrix.length > 0" class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
-        <h4 class="p-4 text-lg font-semibold text-slate-500 dark:text-slate-300">
-          Confusion Matrix
-        </h4>
-        <table class="min-w-full divide-y divide-slate-200 text-center">
-          <thead>
-            <tr>
-              <th class="pl-6 py-3 text-xs font-medium text-gray-200 uppercase tracking-wider text-center border-r-gray-200 border-r-2 diagonal-header">                  
-                <span class="">Label \ Prediction</span>
-              </th>              
-              <th v-for="(label, index) in confusionMatrix[0]" :key="'header-' + index" class="px-6 py-3 text-xs font-medium text-gray-200 uppercase tracking-wider">
-                {{ index }}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(row, rowIndex) in confusionMatrix" :key="'row-' + rowIndex">
-              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-200 border-r-gray-200 border-r-2">
-                {{ rowIndex }}
-              </td>
-              <td v-for="(value, colIndex) in row" :key="'col-' + colIndex" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {{ value }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+    <div v-if="confusionMatrix && confusionMatrix.matrix.length > 0" class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
+      <h4 class="p-4 text-lg font-semibold text-slate-500 dark:text-slate-300">
+        Confusion Matrix
+      </h4>
+      <table class="min-w-full divide-y divide-slate-600 dark:divide-slate-400 text-center">
+        <thead>
+          <tr>
+            <th class="pl-6 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider text-center border-r-gray-600 dark:border-r-gray-400 border-r-2 diagonal-header">                  
+              <span class="">Label \ Prediction</span>
+            </th>              
+            <th v-for="(label, index) in confusionMatrix.matrix[0]" :key="'header-' + index" class="px-6 py-3 text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">
+              {{ confusionMatrix.labels.get(index) }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, rowIndex) in confusionMatrix.matrix" :key="'row-' + rowIndex">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-800 dark:text-gray-200 border-r-gray-600 dark:border-r-gray-400 border-r-2">
+              {{ confusionMatrix.labels.get(rowIndex) }}
+            </td>
+            <td v-for="(value, colIndex) in row" :key="'col-' + colIndex" class="px-6 py-4 whitespace-nowrap text-sm dark:text-gray-300 text-gray-700">
+              {{ value }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
 
     <div v-if="tested !== undefined">
@@ -206,9 +206,10 @@ const visitedSamples = computed<number>(() => {
   }
 });
 
-const confusionMatrix = computed<number[][] | undefined>(() => {
+const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[][]} | undefined>(() => {
   if (tested.value === undefined) return undefined;
   const labels = new Set<number>();
+  const mapLabels = new Map<number, string>();
   
   // get all the labels
   switch (props.task.trainingInformation.dataType) {
@@ -216,6 +217,7 @@ const confusionMatrix = computed<number[][] | undefined>(() => {
       (tested.value as Tested["image"]).forEach(({ output }) => {
         labels.add(output.label);
         labels.add(output.predicted);
+        mapLabels.set(output.label, output.truth);
       });
       break;
     case "text":
@@ -224,6 +226,7 @@ const confusionMatrix = computed<number[][] | undefined>(() => {
       (tested.value as Tested["tabular"]).results.forEach(({ output }) => {
         labels.add(output.label);
         labels.add(output.predicted);
+        mapLabels.set(output.label, output.truth);
       });
       break;
     default: {
@@ -231,6 +234,7 @@ const confusionMatrix = computed<number[][] | undefined>(() => {
       throw new Error("should never happen");
     }
   }
+  console.log(mapLabels)
   const size = Math.max(labels.size, Math.max(...Array.from(labels)));
   // Initialize the confusion matrix
   const matrix = Array.from({ length: size }, () => Array(size).fill(0));
@@ -250,7 +254,7 @@ const confusionMatrix = computed<number[][] | undefined>(() => {
       throw new Error("should never happen");
     }
   }
-  return matrix;
+  return {labels : mapLabels, matrix : matrix};
 })
 
 const currentAccuracy = computed<string>(() => {

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -56,6 +56,34 @@
           <span class="text-sm">&nbsp;samples visited</span>
         </div>
       </div>
+
+      <div v-if="confusionMatrix && confusionMatrix.length > 0" class="p-4 mx-auto lg:w-1/2 h-full bg-white dark:bg-slate-950 rounded-md">
+        <h4 class="p-4 text-lg font-semibold text-slate-500 dark:text-slate-300">
+          Confusion Matrix
+        </h4>
+        <table class="min-w-full divide-y divide-slate-200 text-center">
+          <thead>
+            <tr>
+              <th class="pl-6 py-3 text-xs font-medium text-gray-200 uppercase tracking-wider text-center border-r-gray-200 border-r-2 diagonal-header">                  
+                <span class="">Label \ Prediction</span>
+              </th>              
+              <th v-for="(label, index) in confusionMatrix[0]" :key="'header-' + index" class="px-6 py-3 text-xs font-medium text-gray-200 uppercase tracking-wider">
+                {{ index }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(row, rowIndex) in confusionMatrix" :key="'row-' + rowIndex">
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-200 border-r-gray-200 border-r-2">
+                {{ rowIndex }}
+              </td>
+              <td v-for="(value, colIndex) in row" :key="'col-' + colIndex" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                {{ value }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
 
     <div v-if="tested !== undefined">
@@ -142,16 +170,16 @@ const props = defineProps<{
 interface Tested {
   image: List<{
     input: { filename: string; image: ImageData };
-    output: { truth: string; correct: boolean; predicted : number };
+    output: { truth: string; correct: boolean; predicted : number, label : number };
   }>;
   tabular: {
     labels: {
       input: List<string>;
-      output: { truth: string; correct: string };
+      output: { truth: string; correct: string, label : string };
     };
     results: List<{
       input: List<string>;
-      output: { truth: string; correct: boolean; predicted : number };
+      output: { truth: string; correct: boolean; predicted : number, label : number };
     }>;
   };
   // TODO what to show?
@@ -159,7 +187,7 @@ interface Tested {
 }
 
 const dataset = ref<LabeledDataset[D]>();
-const generator = ref<AsyncGenerator<{result : boolean, predicted : number}, void>>();
+const generator = ref<AsyncGenerator<{result : boolean, predicted : number; truth : number}, void>>();
 const tested = ref<Tested[D]>();
 
 const visitedSamples = computed<number>(() => {
@@ -177,9 +205,58 @@ const visitedSamples = computed<number>(() => {
     }
   }
 });
+
+const confusionMatrix = computed<number[][] | undefined>(() => {
+  if (tested.value === undefined) return undefined;
+  const labels = new Set<number>();
+  
+  // get all the labels
+  switch (props.task.trainingInformation.dataType) {
+    case "image":
+      (tested.value as Tested["image"]).forEach(({ output }) => {
+        labels.add(output.label);
+        labels.add(output.predicted);
+      });
+      break;
+    case "text":
+      return undefined;
+    case "tabular":
+      (tested.value as Tested["tabular"]).results.forEach(({ output }) => {
+        labels.add(output.label);
+        labels.add(output.predicted);
+      });
+      break;
+    default: {
+      const _: never = props.task.trainingInformation;
+      throw new Error("should never happen");
+    }
+  }
+  const size = Math.max(labels.size, Math.max(...Array.from(labels)));
+  // Initialize the confusion matrix
+  const matrix = Array.from({ length: size }, () => Array(size).fill(0));
+  
+  switch (props.task.trainingInformation.dataType) {
+    case "image":
+        (tested.value as Tested["image"]).map(
+          ( {output} ) => matrix[output.predicted][output.label] = matrix[output.predicted][output.label] + 1,
+        );
+        break;
+    //case "text":
+    //  return undefined;
+    case "tabular":
+      return undefined;
+    default: {
+      const _: never = props.task.trainingInformation;
+      throw new Error("should never happen");
+    }
+  }
+  return matrix;
+})
+
 const currentAccuracy = computed<string>(() => {
+  console.log(confusionMatrix)
+
   if (tested.value === undefined) return "0";
-  console.log(tested.value);
   let hits: number | undefined;
   switch (props.task.trainingInformation.dataType) {
     case "image":
@@ -250,7 +327,7 @@ async function startImageTest(
     generator.value = validator.test(
       dataset.map(({ image, label }) => [image, label] as [Image, string]),
     );
-    for await (const [{ filename, image, label }, {result, predicted}] of dataset.zip(
+    for await (const [{ filename, image, label }, {result, predicted, truth}] of dataset.zip(
       toRaw(generator.value),
     )) {
       results = results.push({
@@ -266,6 +343,7 @@ async function startImageTest(
           truth: label,
           correct: result,
           predicted: predicted,
+          label : truth,
         },
       });
 
@@ -296,9 +374,9 @@ async function startTabularTest(
   let results: Tested["tabular"]["results"] = List();
   try {
     generator.value = validator.test(dataset);
-    for await (const [row, {result, predicted}] of dataset.zip(toRaw(generator.value))) {
-      const truth = row[outputColumn];
-      if (truth === undefined)
+    for await (const [row, {result, predicted, truth}] of dataset.zip(toRaw(generator.value))) {
+      const truth_label = row[outputColumn];
+      if (truth_label === undefined)
         throw new Error("row doesn't have expected output column");
 
       results = results.push({
@@ -309,9 +387,10 @@ async function startTabularTest(
           return ret;
         }),
         output: {
-          truth: truth,
+          truth: truth_label,
           correct: result,
           predicted : predicted,
+          label : truth,
         },
       });
 

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -171,7 +171,7 @@ const props = defineProps<{
 interface Tested {
   image: List<{
     input: { filename: string; image: ImageData };
-    output: { truth: string; correct: boolean; predicted : number, label : number };
+    output: { truth: number; correct: boolean; predicted : number, label : string };
   }>;
   tabular: {
     labels: {
@@ -209,16 +209,16 @@ const visitedSamples = computed<number>(() => {
 
 const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[][]} | undefined>(() => {
   if (tested.value === undefined) return undefined;
-  const labels = Set<number>();
+  const labels = Set<number>(); // l'idéal serait de tous les avoir en one try, sinon c'est dégueulasse
   const mapLabels = Map<number, string>();
   
   // get all the labels
   switch (props.task.trainingInformation.dataType) {
     case "image":
       (tested.value as Tested["image"]).forEach(({ output }) => {
-        labels.add(output.label);
+        labels.add(output.truth);
         labels.add(output.predicted);
-        mapLabels.set(output.label, output.truth);
+        mapLabels.set(output.truth, output.label);
       });
       break;
     case "text":
@@ -242,7 +242,7 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
   switch (props.task.trainingInformation.dataType) {
     case "image":
         (tested.value as Tested["image"]).map(
-          ( {output} ) => matrix[output.predicted][output.label] = matrix[output.predicted][output.label] + 1,
+          ( {output} ) => matrix[output.predicted][output.truth] = matrix[output.predicted][output.truth] + 1,
         );
         break;
     //case "text":
@@ -348,10 +348,10 @@ async function startImageTest(
           ),
         },
         output: {
-          truth: label,
+          label: label,
           correct: result,
           predicted: predicted,
-          label : truth,
+          truth : truth,
         },
       });
 
@@ -457,7 +457,7 @@ function saveCsv(): void {
           ["Filename", "Truth", "Correct"],
           ...(tested as Tested["image"]).map(({ input, output }) => [
             input.filename,
-            output.truth,
+            output.label,
             output.correct.toString(),
           ]),
         ]);

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -157,6 +157,7 @@ import ImageCard from "@/components/containers/ImageCard.vue";
 import LabeledDatasetInput from "@/components/dataset_input/LabeledDatasetInput.vue";
 import TableLayout from "@/components/containers/TableLayout.vue";
 import type { LabeledDataset } from "@/components/dataset_input/types.js";
+import { Map, Set } from 'immutable';
 
 const debug = createDebug("webapp:testing:TestSteps");
 const toaster = useToaster();
@@ -208,8 +209,8 @@ const visitedSamples = computed<number>(() => {
 
 const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[][]} | undefined>(() => {
   if (tested.value === undefined) return undefined;
-  const labels = new Set<number>();
-  const mapLabels = new Map<number, string>();
+  const labels = Set<number>();
+  const mapLabels = Map<number, string>();
   
   // get all the labels
   switch (props.task.trainingInformation.dataType) {
@@ -247,7 +248,12 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
     //case "text":
     //  return undefined;
     case "tabular":
-      return undefined;
+        (tested.value as Tested["tabular"]).results.forEach( ({output}) => {
+          labels.add(output.label);
+          labels.add(output.predicted);
+          mapLabels.set(output.label, output.truth);
+        });
+        break;
     default: {
       const _: never = props.task.trainingInformation;
       throw new Error("should never happen");

--- a/webapp/src/components/testing/TestSteps.vue
+++ b/webapp/src/components/testing/TestSteps.vue
@@ -234,7 +234,6 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
       throw new Error("should never happen");
     }
   }
-  console.log(mapLabels)
   const size = Math.max(labels.size, Math.max(...Array.from(labels)));
   // Initialize the confusion matrix
   const matrix = Array.from({ length: size }, () => Array(size).fill(0));
@@ -258,7 +257,6 @@ const confusionMatrix = computed<{labels : Map<number, string>, matrix : number[
 })
 
 const currentAccuracy = computed<string>(() => {
-  console.log(confusionMatrix)
 
   if (tested.value === undefined) return "0";
   let hits: number | undefined;
@@ -415,7 +413,7 @@ async function startTextTest(
 
   try {
     generator.value = validator.test(dataset);
-    for await (const {result, predicted} of toRaw(generator.value)) {
+    for await (const {result} of toRaw(generator.value)) {
       results = results.push({ output:  {correct : result} });
       tested.value = results as Tested[D];
     }


### PR DESCRIPTION
This pull request add a confusion matrix to the testing page

![image](https://github.com/user-attachments/assets/501c0901-335f-4d09-9273-1e9cebde4869)
![image](https://github.com/user-attachments/assets/de332ec2-ef4d-4366-a557-8e2745a9c43d)

The confusion matrix has been made so that it works with multiple class classfication, and not only binary classification.

This pull request modify the Validator class in the discoJS library, in order to retrieve
- If the element was correctly predicted
- The prediction
- the original label of the element