### PR TITLE
Fix README.md display error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The latest version is always running on the following link, for web and mobile:
 <p align="center">
   <b> :man_dancing: https://discolab.ai/ :man_dancing:</b>
 </p>
+
 ___
 :magic_wand: **DEVELOPERS:** DISCO is written fully in JavaScript/TypeScript. Have a look at our [developer guide](DEV.md).
 ___


### PR DESCRIPTION
The markdown separator isn't displayed due to a missing empty line:

![Screenshot 2025-02-11 at 14 22 22](https://github.com/user-attachments/assets/e1f11ac6-0b8c-47df-8253-caa2a405edd1)
