### PR TITLE
datasets: add missing -z tar option

### DIFF
--- a/datasets/.gitignore
+++ b/datasets/.gitignore
@@ -9,6 +9,8 @@
 /simple_face-example.png
 /titanic_test.csv
 /titanic_train.csv
+/titanic_train_with_nan.csv
+/titanic_test_with_nan.csv
 /titanic_wrong_number_columns.csv
 /titanic_wrong_passengerID.csv
 

--- a/datasets/populate
+++ b/datasets/populate
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 
 # base
 curl 'https://storage.googleapis.com/deai-313515.appspot.com/example_training_data.tar.gz' |
-	tar --extract --strip-components=1
+	tar -z --extract --strip-components=1
 
 # lungs ultrasound
 mkdir -p lus_covid


### PR DESCRIPTION
Update `datasets` .gitignore with new titanic files with NaN values and add -z option to the populate script to decompress when reading from pipe