### PR TITLE
Security: Weak NodeID validation allows arbitrary identifier values

### DIFF
--- a/discojs/src/client/types.ts
+++ b/discojs/src/client/types.ts
@@ -1,6 +1,5 @@
 export type NodeID = string
 
-// TODO @s314cy: regexp test just like server-side
 export function isNodeID (raw: unknown): raw is NodeID {
-  return typeof raw === 'string'
+  return typeof raw === 'string' && /^[a-zA-Z0-9_-]{1,64}$/.test(raw)
 }


### PR DESCRIPTION
## Problem

The `isNodeID` type guard accepts any string as a valid node identifier. In distributed/federated protocols, permissive identifiers can enable impersonation, collision attacks, log/message confusion, or protocol abuse (e.g., empty strings, extremely long IDs, crafted control characters).

**Severity**: `medium`
**File**: `discojs/src/client/types.ts`

## Solution

Enforce a strict NodeID format (length bounds + regex whitelist, e.g. `^[a-zA-Z0-9_-]{1,64}$`), and reject invalid IDs at all trust boundaries (both client and server). Consider canonicalization and uniqueness checks server-side.

## Changes

- `discojs/src/client/types.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
