### PR TITLE
Security: Potential path traversal when saving models to disk

### DIFF
--- a/discojs-node/src/model_loader.ts
+++ b/discojs-node/src/model_loader.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 
 import type { models, DataType } from "@epfml/discojs";
 import { serialization } from "@epfml/discojs";
@@ -10,8 +11,20 @@ export async function saveModelToDisk(
 ): Promise<void> {
   const encoded = await serialization.model.encode(model);
 
+  if (
+    path.isAbsolute(modelFileName) ||
+    modelFileName.includes("/") ||
+    modelFileName.includes("\\") ||
+    modelFileName === "." ||
+    modelFileName === ".."
+  ) {
+    throw new Error("Invalid model file name");
+  }
+
+  const modelPath = path.join(modelFolder, modelFileName);
+
   await fs.mkdir(modelFolder, { recursive: true });
-  await fs.writeFile(`${modelFolder}/${modelFileName}`, encoded);
+  await fs.writeFile(modelPath, encoded);
 }
 
 export async function loadModelFromDisk(


### PR DESCRIPTION
## Problem

`saveModelToDisk` builds the output path via string interpolation (`${modelFolder}/${modelFileName}`) without sanitizing `modelFileName`. If user-controlled, attackers can inject `../` sequences or absolute paths to overwrite unintended files.

**Severity**: `high`
**File**: `discojs-node/src/model_loader.ts`

## Solution

Use `path.resolve`/`path.join` and validate that the resolved path stays inside an allowed base directory. Reject path separators in `modelFileName` or enforce a safe filename regex.

## Changes

- `discojs-node/src/model_loader.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
