### PR TITLE
Migrate npm publishing to Trusted Publisher instead of access tokens

### DIFF
--- a/.github/workflows/publish-deploy.yml
+++ b/.github/workflows/publish-deploy.yml
@@ -8,6 +8,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v6
@@ -15,6 +16,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false  # never use caching in release builds
           scope: "@epfml"
       - uses: actions/cache@v5
         with:
@@ -27,9 +29,7 @@ jobs:
         if: github.ref_type == 'branch'
       - run: npm --workspace=discojs{,-node,-web} run build
       - run: npm --workspace=discojs{,-node,-web} publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+       
   build-webapp:
     if: github.ref_type == 'branch'
     runs-on: ubuntu-latest


### PR DESCRIPTION
NPM recommends avoid access tokens to publish new packages in our CD pipeline. In addition, the max lifetime of a token is 90 days so we regularly have to renew the token manually. 
Trusted publishing directly connects our repository with the npm packages and creates short-lived tokens per publishing and also avoids any manual renewal.
[NPM documentation](https://docs.npmjs.com/trusted-publishers)