### PR TITLE
Update publish-deploy.yml

### DIFF
--- a/.github/workflows/publish-deploy.yml
+++ b/.github/workflows/publish-deploy.yml
@@ -24,6 +24,7 @@ jobs:
             ~/.npm
             ~/.cache/Cypress
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm --workspace=discojs{,-node,-web} version prerelease --preid=p`date +%Y%m%d%H%M%S`
         if: github.ref_type == 'branch'


### PR DESCRIPTION
Current npm publishing fails with 404 package not found: 
```
npm error 404 Not Found - PUT https://registry.npmjs.org/@epfml%2fdiscojs - Not found
npm error 404
npm error 404  '@epfml/discojs@3.0.1-p20260617131258.0' is not in this registry.
```
I suspect the issue to be that the npm cli is not recent enough, as mentioned here: https://github.com/orgs/community/discussions/173102

It should be v11.5.1 at least.