### PR TITLE
Update publish-deploy.yml

### DIFF
--- a/.github/workflows/publish-deploy.yml
+++ b/.github/workflows/publish-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npm --workspace=discojs{,-node,-web} version prerelease --preid=p`date +%Y%m%d%H%M%S`
         if: github.ref_type == 'branch'
       - run: npm --workspace=discojs{,-node,-web} run build
-      - run: npm --workspace=discojs{,-node,-web} publish --access public
+      - run: npm --workspace=discojs{,-node,-web} publish --access public --tag latest
 
   build-webapp:
     if: github.ref_type == 'branch'


### PR DESCRIPTION
Fix error: `Run npm --workspace=discojs{,-node,-web} publish --access public npm error You must specify a tag using --tag when publishing a prerelease version.`