### PR TITLE
ci: fix broken cache behavior

### DIFF
--- a/.github/actions/download-datasets/action.yml
+++ b/.github/actions/download-datasets/action.yml
@@ -7,7 +7,7 @@ runs:
       with:
         path: datasets
         key: datasets-${{ hashFiles('datasets/populate') }} # Only invalidate cache when download script changes
-    - if: steps.cache.outputs.cache-hit != 'true'
+    - if: steps.cache.outputs.cache-hit == '' || steps.cache.outputs.cache-hit == 'false'
       run: datasets/populate
       shell: bash
     - uses: actions/upload-artifact@v7

--- a/.github/actions/download-datasets/action.yml
+++ b/.github/actions/download-datasets/action.yml
@@ -7,7 +7,7 @@ runs:
       with:
         path: datasets
         key: datasets-${{ hashFiles('datasets/populate') }} # Only invalidate cache when download script changes
-    - if: steps.cache.outputs.cache-hit == 'false'
+    - if: steps.cache.outputs.cache-hit != 'true'
       run: datasets/populate
       shell: bash
     - uses: actions/upload-artifact@v7

--- a/discojs/package.json
+++ b/discojs/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@epfml/isomorphic-wrtc": "1",
     "@jimp/core": "1",
-    "@jimp/plugin-resize": "^1.6.1",
+    "@jimp/plugin-resize": "1",
     "@msgpack/msgpack": "3",
     "@tensorflow/tfjs": "4",
     "@xenova/transformers": "2",


### PR DESCRIPTION
Turns out that there is a case `steps.cache.outputs.cache-hit == ''` we need to cover when using the Github download action ([docs](https://github.com/actions/cache#skipping-steps-based-on-cache-hit)). This should repair the CI.
Also fixes a non-major package version that I let get through in a dependabot PR

closes #1143  