### PR TITLE
Remove workarounds for solved eslint-plugin-vue bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@vue/eslint-config-typescript": "14.9.0",
     "eslint": "10.0.3",
     "eslint-plugin-cypress": "6.2.0",
-    "eslint-plugin-vue": "10.8.0",
+    "eslint-plugin-vue": "10.9.2",
     "knip": "6.17.1",
     "prettier": "3.6.2",
     "supports-color": "8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 10.2.0(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.6.2)
       '@vue/eslint-config-typescript':
         specifier: 14.9.0
-        version: 14.9.0(eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+        version: 14.9.0(eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint:
         specifier: 10.0.3
         version: 10.0.3(jiti@2.7.0)(supports-color@8.1.1)
@@ -257,8 +257,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-vue:
-        specifier: 10.8.0
-        version: 10.8.0(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
+        specifier: 10.9.2
+        version: 10.9.2(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
       knip:
         specifier: 6.17.1
         version: 6.17.1
@@ -2835,14 +2835,14 @@ packages:
       eslint-config-prettier:
         optional: true
 
-  eslint-plugin-vue@10.8.0:
-    resolution: {integrity: sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==}
+  eslint-plugin-vue@10.9.2:
+    resolution: {integrity: sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@stylistic/eslint-plugin': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       '@typescript-eslint/parser': ^7.0.0 || ^8.0.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      vue-eslint-parser: ^10.0.0
+      vue-eslint-parser: ^10.3.0
     peerDependenciesMeta:
       '@stylistic/eslint-plugin':
         optional: true
@@ -6132,11 +6132,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/eslint'
 
-  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/utils': 8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 10.0.3(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-plugin-vue: 10.8.0(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
+      eslint-plugin-vue: 10.9.2(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
       fast-glob: 3.3.3
       typescript-eslint: 8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       vue-eslint-parser: 10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
@@ -6975,7 +6975,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))
 
-  eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)):
+  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.62.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.7.0)(supports-color@8.1.1))
       eslint: 10.0.3(jiti@2.7.0)(supports-color@8.1.1)

--- a/webapp/src/components/dataset_input/FileSelection.vue
+++ b/webapp/src/components/dataset_input/FileSelection.vue
@@ -123,16 +123,20 @@ const inputFileElement = ref<HTMLInputElement | null>(null);
 const hideConnectField = computed(() => files.value !== undefined);
 
 const fileType = computed(() => {
-  switch (props.type) {
-    case "image":
-      return `image${props.multiple ? "s" : ""}`;
-    case "json":
-      return `JSON file${props.multiple ? "s" : ""}`;
-    case "tabular":
-      return `CSV${props.multiple ? "s" : ""}`;
-    case "text":
-      return `text file${props.multiple ? "s" : ""}`;
-  }
+  const name = (() => {
+    switch (props.type) {
+      case "image":
+        return "image";
+      case "json":
+        return "JSON file";
+      case "tabular":
+        return "CSV";
+      case "text":
+        return "text file";
+    }
+  })();
+
+  return `${name}${props.multiple ? "s" : ""}`;
 });
 
 const acceptFilter = computed(() => {

--- a/webapp/src/components/dataset_input/FileSelection.vue
+++ b/webapp/src/components/dataset_input/FileSelection.vue
@@ -123,22 +123,18 @@ const inputFileElement = ref<HTMLInputElement | null>(null);
 const hideConnectField = computed(() => files.value !== undefined);
 
 const fileType = computed(() => {
-  const name = (() => {
-    // need function wrap vuejs/eslint-plugin-vue#2142
-    switch (props.type) {
-      case "image":
-        return "image";
-      case "json":
-        return "JSON file";
-      case "tabular":
-        return "CSV";
-      case "text":
-        return "text file";
-    }
-  })();
-
-  return `${name}${props.multiple ? "s" : ""}`;
+  switch (props.type) {
+    case "image":
+      return `image${props.multiple ? "s" : ""}`;
+    case "json":
+      return `JSON file${props.multiple ? "s" : ""}`;
+    case "tabular":
+      return `CSV${props.multiple ? "s" : ""}`;
+    case "text":
+      return `text file${props.multiple ? "s" : ""}`;
+  }
 });
+
 const acceptFilter = computed(() => {
   switch (props.type) {
     case "image":
@@ -150,10 +146,6 @@ const acceptFilter = computed(() => {
     case "text":
       return "text/plain";
   }
-
-  // vuejs/eslint-plugin-vue#2142
-  props.type satisfies never;
-  throw new TypeError("invalid value");
 });
 
 // we use an event counter to test whether the user is dragging a file over the field


### PR DESCRIPTION
Code contained 2 workarounds to prevent lint errors where typescript inference should have been enough
Latest version of eslint-plugin-vue fixed the bugs, so the workarounds can be removed